### PR TITLE
Adding Security Rule Examples

### DIFF
--- a/Examples/security_rules.ruleset
+++ b/Examples/security_rules.ruleset
@@ -57,3 +57,79 @@ AWS::ElasticLoadBalancing::LoadBalancer AccessLoggingPolicy.Enabled == true << L
 
 AWS::FSx::FileSystem KmsKeyId == /.*/ << CMKs should be used instead of AWS-provided KMS keys
 
+AWS::GuardDuty::Detector Enable == true << Detector should be enabled
+
+AWS::ImageBuilder::Component KmsKeyId == /.*/ << A KMS key should be provided for encryption
+
+AWS::ImageBuilder::InfrastructureConfiguration Logging.S3Logs == /.*/ << Logging should be enabled
+
+AWS::Kinesis::Stream StreamEncryption.EncryptionType == KMS << Stream encryption should be enabled
+
+AWS::KMS::Key EnableKeyRotation == true << Key rotation should be enabled
+
+AWS::Lambda::Function KmsKeyArn == /.*/ << KMS key should be set for encryption
+AWS::Lambda::Function VpcConfig == /.*/ << Function should be launched in a VPC
+
+AWS::MediaStore::Container AccessLoggingEnabled == true << Logging should be enabled
+
+AWS::MSK::Cluster ClientAuthentication.Tls.CertificateAuthorityArnList == /.*/ << Clusters should authenticate clients with TLS
+AWS::MSK::Cluster EncryptionInfo.EncryptionAtRest == true << Encryption at rest should be enabled
+AWS::MSK::Cluster EncryptionInfo.EncryptionInTransit == true << Encryption in transit should be enabled
+AWS::MSK::Cluster EnhancedMonitoring == PER_TOPIC_PER_BROKER << Enhanced monitoring should be enabled
+
+AWS::Neptune::DBCluster BackupRetentionPeriod == %backup_retention << Backups should be retained for set retention period
+AWS::Neptune::DBCluster EnableCloudwatchLogsExports == /.*/ << CloudWatch log exports should be enabled
+AWS::Neptune::DBCluster IamAuthEnabled == true << Cluster should use IAM authentication
+AWS::Neptune::DBCluster StorageEncrypted == true << Storage encryption should be enabled
+
+AWS::Neptune::DBInstance AllowMajorVersionUpgrade == true << Major version upgrades should be enabled to receive security updates
+AWS::Neptune::DBInstance AutoMinorVersionUpgrade == true << Minor version upgrades should be enabled to receive security updates
+
+AWS::OpsWorks::App EnableSsl == true << TLS should be enabled
+
+AWS::OpsWorksCM::Server AssociatePublicIpAddress == false << Public IPs should not be assigned by default
+AWS::OpsWorksCM::Server DisableAutomatedBackup == false << Backups should not be enabled
+
+AWS::RDS::DBCluster BackupRetentionPeriod == %backup_retention << Backups should be retained for set retention period
+AWS::RDS::DBCluster EnableCloudwatchLogsExports == /.*/ << CloudWatch log exports should be enabled
+AWS::RDS::DBCluster StorageEncrypted == true << Storage encryption should be enabled
+
+AWS::RDS::DBInstance AllowMajorVersionUpgrade == true << Major version upgrades should be enabled to receive security updates
+AWS::RDS::DBInstance AutoMinorVersionUpgrade == true << Minor version upgrades should be enabled to receive security updates
+AWS::RDS::DBInstance BackupRetentionPeriod == %backup_retention << Backups should be retained for set retention period
+AWS::RDS::DBInstance EnableCloudwatchLogsExports == /.*/ << CloudWatch log exports should be enabled
+AWS::RDS::DBInstance PubliclyAccessible == false << Databasae should not be publicly accessible
+AWS::RDS::DBInstance StorageEncrypted == true << Storage encryption should be enabled
+
+AWS::RDS::DBProxy DebugLogging == false << Debug logging should not be enabled to avoid exposing SQL queries
+AWS::RDS::DBProxy RequireTLS == true << TLS should be required for proxy connections
+
+AWS::Redshift::Cluster AllowVersionUpgrade == true << Minor version upgrades should be enabled to receive security updates
+AWS::Redshift::Cluster AutomatedSnapshotRetentionPeriod == %backup_retention << Backups should be retained for set retention period
+AWS::Redshift::Cluster Encrypted == true << Storage encryption should be enabled
+AWS::Redshift::Cluster PubliclyAccessible == false << Databasae should not be publicly accessible
+
+AWS::S3::AccessPoint PublicAccessBlockConfiguration.BlockPublicAcls == true << S3 should be set to block public ACLs
+AWS::S3::AccessPoint PublicAccessBlockConfiguration.BlockPublicPolicy == true << S3 should be set to block public policies
+AWS::S3::AccessPoint PublicAccessBlockConfiguration.IgnorePublicAcls == true << S3 should be set to ignore public ACLs
+AWS::S3::AccessPoint PublicAccessBlockConfiguration.RestrictPublicBuckets == true << S3 should be set to restrict public buckets
+
+AWS::S3::Bucket BucketEncryption.ServerSideEncryptionConfiguration == /.*/ << S3 bucket encryption should be enabled
+AWS::S3::Bucket LoggingConfiguration.DestinationBucketName == /.*/ << S3 bucket logging should be enabled
+AWS::S3::Bucket PublicAccessBlockConfiguration.BlockPublicAcls == true << S3 should be set to block public ACLs
+AWS::S3::Bucket PublicAccessBlockConfiguration.BlockPublicPolicy == true << S3 should be set to block public policies
+AWS::S3::Bucket PublicAccessBlockConfiguration.IgnorePublicAcls == true << S3 should be set to ignore public ACLs
+AWS::S3::Bucket PublicAccessBlockConfiguration.RestrictPublicBuckets == true << S3 should be set to restrict public buckets
+
+AWS::SageMaker::NotebookInstance DirectInternetAccess == Disabled << Notebooks should not have direct internet access
+AWS::SageMaker::NotebookInstance KmsKeyId == /.*/ << KMS encryption should be enabled
+AWS::SageMaker::NotebookInstance RootAccess == Disabled << Root access for users should be disabled
+
+AWS::SNS::Topic KmsMasterKeyId == /.*/ << KMS encryption should be enabled
+
+AWS::SQS::Queue KmsMasterKeyId == /.*/ << KMS encryption should be enabled
+
+AWS::StepFunctions::StateMachine LoggingConfiguration == /.*/ << Logging should be enabled
+
+AWS::WorkSpaces::Workspace RootVolumeEncryptionEnabled == true << Encryption should be enabled
+AWS::WorkSpaces::Workspace UserVolumeEncryptionEnabled == true << Encryption should be enabled

--- a/Examples/security_rules.ruleset
+++ b/Examples/security_rules.ruleset
@@ -1,0 +1,59 @@
+let backup_retention = 7
+let allowed_ports = [80, 443]
+
+AWS::AmazonMQ::Broker AutoMinorVersionUpgrade == true << Version upgrades should be enabled to receive security updates
+AWS::AmazonMQ::Broker EncryptionOptions.UseAwsOwnedKey == false << CMKs should be used instead of AWS-provided KMS keys
+AWS::AmazonMQ::Broker EngineVersion == 5.15.10 << Broker engine version should be at least 5.15.10
+AWS::AmazonMQ::Broker Logs.Audit == true << Audit logging should be enabled
+AWS::AmazonMQ::Broker Logs.General == true << General logging should be enabled
+AWS::AmazonMQ::Broker PubliclyAccessible == false << Broker should not be publicly accessible
+
+AWS::AmazonMQ::Configuration EngineVersion == 5.15.10 << Broker engine version should be at least 5.15.10
+
+AWS::ApiGateway::DomainName SecurityPolicy == TLS_1_2 << API Gateway DomainName SecurityPolicy should use TLS 1.2
+
+AWS::CloudFront::Distribution ViewerCertificate.MinimumProtocolVersion == TLSv1.2_2018 << CloudFront TLS version should be 1.2
+
+AWS::CloudTrail::Trail EnableLogFileValidation == true << CloudTrail file validation should be enabled
+AWS::CloudTrail::Trail IncludeGlobalServiceEvents == true << CloudTrail should include global service events
+AWS::CloudTrail::Trail IsLogging == true << CloudTrail logging should be enabled
+AWS::CloudTrail::Trail IsMultiRegionTrail == true << CloudTrail trails should cover all regions
+
+AWS::CodeBuild::Project EncryptionKey == /.*/ << CodeBuild should use a CMK instead of AWS-provided KMS keys
+AWS::CodeBuild::Project VpcConfig.VpcId == /.*/ << CodeBuild projects should be built in a VPC
+
+AWS::CodeBuild::SourceCredential Token == /^\{\{resolve:secretsmanager.*$/ << CodeBuild credentials should use a reference instead of plaintext
+
+AWS::CodeStar::GitHubRepository IsPrivate == true << GitHub repository should be private
+
+AWS::DAX::Cluster SSESpecification.SSEEnabled == true << DAX cluster encryption should be enabled
+
+AWS::DMS::ReplicationInstance AllowMajorVersionUpgrade == true << DMS instance upgrades should be enabled
+AWS::DMS::ReplicationInstance AutoMinorVersionUpgrade == true << DMS instance upgrades should be enabled
+AWS::DMS::ReplicationInstance KmsKeyId == /.*/ << A KMS key should be provided for encryption
+AWS::DMS::ReplicationInstance MultiAZ == true << DMS instance should be deployed in multiple AZs
+AWS::DMS::ReplicationInstance PubliclyAccessible == false << DMS instance should not be publicly accessible
+
+AWS::DocDB::DBCluster BackupRetentionPeriod == %backup_retention << Backups should be retained for set retention period
+AWS::DocDB::DBCluster StorageEncrypted == true << Storage should be encrypted
+
+AWS::DynamoDB::Table SSESpecification.SSEEnabled == true << DynamoDB tables should be encrypted with CMKs
+
+AWS::EC2::Instance SourceDestCheck != false << EC2 source destination check should be enabled unless the instance is performing NAT
+
+AWS::EC2::Volume Encrypted == true << EC2 volumes should be encrypted
+
+AWS::EFS::FileSystem Encrypted == true << EFS file system should be encrypted
+
+AWS::EKS::Cluster EncryptionConfig.Provider.KeyArn == /.*/ << EKS cluster encryption config should be set
+
+AWS::ElastiCache::CacheCluster AutoMinorVersionUpgrade == true << ElastiCache upgrades should be enabled
+AWS::ElastiCache::CacheCluster SnapshotRetentionLimit == %backup_retention << Backups should be retained for set retention period
+
+AWS::Elasticsearch::Domain EncryptionAtRestOptions.Enabled == true << Domain encryption should be enabled
+AWS::Elasticsearch::Domain NodeToNodeEncryptionOptions.Enabled == true << Node-to-node encryption should be enabled
+
+AWS::ElasticLoadBalancing::LoadBalancer AccessLoggingPolicy.Enabled == true << Load balancer logging should be enabled
+
+AWS::FSx::FileSystem KmsKeyId == /.*/ << CMKs should be used instead of AWS-provided KMS keys
+

--- a/Examples/security_template.json
+++ b/Examples/security_template.json
@@ -155,6 +155,182 @@
             "Properties" : {
                 
             }
+        },
+        "GuardDutyDetector" : {
+            "Type" : "AWS::GuardDuty::Detector",
+            "Properties" : {
+                "Enabled": true
+            }
+        },
+        "ImageBuilderComponent" : {
+            "Type" : "AWS::ImageBuilder::Component",
+            "Properties" : {
+                
+            }
+        },
+        "ImageBuilderInfrastructureConfiguration": {
+            "Type": "AWS::ImageBuilder::InfrastructureConfiguration",
+            "Properties": {
+                "Logging": {
+                    
+                }
+            }
+        },
+        "KinesisStream" : {
+            "Type" : "AWS::Kinesis::Stream",
+            "Properties" : {
+                "StreamEncryption": {
+                    "EncryptionType": "invalid"
+                }
+            }
+        },
+        "KMSKey" : {
+            "Type" : "AWS::KMS::Key",
+            "Properties" : {
+                "EnableKeyRotation": false
+            }
+        },
+        "LambdaFunction" : {
+            "Type" : "AWS::Lambda::Function",
+            "Properties" : {
+                "VpcConfig": {
+
+                }
+            }
+        },
+        "MediaStoreContainer" : {
+            "Type" : "AWS::MediaStore::Container",
+            "Properties" : {
+                "AccessLoggingEnabled": false
+            }
+        },
+        "MSKCluster" : {
+            "Type" : "AWS::MSK::Cluster",
+            "Properties" : {
+                "ClientAuthentication": {
+                    
+                },
+                "EncryptionInfo": {
+                    "EncryptionAtRest": false,
+                    "EncryptionInTransit": false
+                },
+                "EnhancedMonitoring": "PER_BROKER"
+            }
+        },
+        "NeptuneCluster" : {
+            "Type" : "AWS::Neptune::DBCluster",
+            "Properties" : {
+                "BackupRetentionPeriod": 1,
+                "IamAuthEnabled": false,
+                "StorageEncrypted": false
+            }
+        },
+        "NeptuneInstance" : {
+            "Type" : "AWS::Neptune::DBInstance",
+            "Properties" : {
+                "AllowMajorVersionUpgrade": false,
+                "AutoMinorVersionUpgrade": false
+            }
+        },
+        "OpsWorksApp" : {
+            "Type" : "AWS::OpsWorks::App",
+            "Properties" : {
+                "EnableSslx": false
+            }
+        },
+        "OpsWorksCMServer" : {
+            "Type" : "AWS::OpsWorksCM::Server",
+            "Properties" : {
+                "AssociatePublicIpAddress": true,
+                "DisableAutomatedBackup": true
+            }
+        },
+        "RDSDBCluster" : {
+            "Type" : "AWS::RDS::DBCluster",
+            "Properties" : {
+                "BackupRetentionPeriod": 1,
+                "StorageEncrypted": false
+            }
+        },
+        "RDSDBInstance" : {
+            "Type" : "AWS::RDS::DBInstance",
+            "Properties" : {
+                "AllowMajorVersionUpgrade": false,
+                "AutoMinorVersionUpgrade": false,
+                "BackupRetentionPeriod": 1,
+                "PubliclyAccessible": true,
+                "StorageEncrypted": false
+            }
+        },
+        "RDSDBProxy" : {
+            "Type" : "AWS::RDS::DBProxy",
+            "Properties" : {
+                "DebugLogging": true,
+                "RequireTLS": false
+            }
+        },
+        "RedshiftCluster" : {
+            "Type" : "AWS::Redshift::Cluster",
+            "Properties" : {
+                "AllowVersionUpgrade": false,
+                "AutomatedSnapshotRetentionPeriod": 1,
+                "Encrypted": false,
+                "PubliclyAccessible": true
+            }
+        },
+        "S3AccessPoint" : {
+            "Type" : "AWS::S3::AccessPoint",
+            "Properties" : {
+                "PublicAccessBlockConfiguration": {
+                    "BlockPublicAcls": false,
+                    "BlockPublicPolicy": false,
+                    "IgnorePublicAcls": false,
+                    "RestrictPublicBuckets": false
+                }
+            }
+        },
+        "S3Bucket" : {
+            "Type" : "AWS::S3::AccessPoint",
+            "Properties" : {
+                "PublicAccessBlockConfiguration": {
+                    "BlockPublicAcls": false,
+                    "BlockPublicPolicy": false,
+                    "IgnorePublicAcls": false,
+                    "RestrictPublicBuckets": false
+                }
+            }
+        },
+        "SageMakerNotebook" : {
+            "Type" : "AWS::SageMaker::NotebookInstance",
+            "Properties" : {
+                "DirectInternetAccess": "Enabled",
+                "RootAccess": true
+            }
+        },
+        "SNSTopic" : {
+            "Type" : "AWS::SNS::Topic",
+            "Properties" : {
+                
+            }
+        },
+        "SQSQueue" : {
+            "Type" : "AWS::SQS::Queue",
+            "Properties" : {
+                
+            }
+        },
+        "StepFunctionsStateMachine" : {
+            "Type" : "AWS::StepFunctions::StateMachine",
+            "Properties" : {
+                
+            }
+        },
+        "WorkspacesWorkspace" : {
+            "Type" : "AWS::WorkSpaces::Workspace",
+            "Properties" : {
+                "RootVolumeEncryptionEnabled": false,
+                "UserVolumeEncryptionEnabled": false
+            }
         }
     }
 }

--- a/Examples/security_template.json
+++ b/Examples/security_template.json
@@ -1,0 +1,160 @@
+{
+    "Resources": {
+        "AmazonMQBroker" : {
+            "Type" : "AWS::AmazonMQ::Broker",
+            "Properties" : {
+                "AutoMinorVersionUpgrade": false,
+                "EncryptionOptions": {
+                    "UseAwsOwnedKey": true
+                },
+                "EngineVersion": "5.15.9",
+                "Logs": {
+                    "Audit": false,
+                    "General": false
+                },
+                "PubliclyAccessible": true
+            }
+        },
+        "ApiGatewayDomain" : {
+            "Type" : "AWS::ApiGateway::DomainName",
+            "Properties" : {
+                "DomainName": "test.com",
+                "SecurityPolicy": "TLS_1_0"
+            }
+        },
+        "ApiGatewayDomainSecure" : {
+            "Type" : "AWS::ApiGateway::DomainName",
+            "Properties" : {
+                "DomainName": "test.com",
+                "SecurityPolicy": "TLS_1_2"
+            }
+        },
+        "CloudFrontDistribution" : {
+            "Type" : "AWS::CloudFront::Distribution",
+            "Properties" : {
+                "ViewerCertificate" : {
+                    "MinimumProtocolVersion" : "TLSv1"
+                }
+            }
+        },
+        "CloudTrailTrail" : {
+            "Type" : "AWS::CloudTrail::Trail",
+            "Properties" : {
+                "EnableLogFileValidation" : false,
+                "IncludeGlobalServiceEvents": false,
+                "IsLogging": false,
+                "IsMultiRegionTrail": false
+            }
+        },
+        "CodeBuildProject" : {
+            "Type" : "AWS::CodeBuild::Project",
+            "Properties" : {
+                
+            }
+        },
+        "CodeBuildCredentials" : {
+            "Type" : "AWS::CodeBuild::SourceCredential",
+            "Properties" : {
+                "Token": "{{resolve:secretsmanager}}"
+            }
+        },
+        "CodeStarRepo" : {
+            "Type" : "AWS::CodeStar::GitHubRepository",
+            "Properties" : {
+                "IsPrivate": false
+            }
+        },
+        "DMSInstance" : {
+            "Type" : "AWS::DMS::ReplicationInstance",
+            "Properties" : {
+                "AllowMajorVersionUpgrade": false,
+                "AutoMinorVersionUpgrade": false,
+                "MultiAZ": false,
+                "PubliclyAccessible": true
+            }
+        },
+        "DocDBCluster" : {
+            "Type" : "AWS::DocDB::DBCluster",
+            "Properties" : {
+                "BackupRetentionPeriod": 1,
+                "StorageEncrypted": false
+            }
+        },
+        "DynamoDBTable" : {
+            "Type" : "AWS::DynamoDB::Table",
+            "Properties" : {
+                "SSESpecification": {
+                    "SSEEnabled": false
+                }
+            }
+        },
+        "EC2Instance" : {
+            "Type" : "AWS::EC2::Instance",
+            "Properties" : {
+                "SourceDestCheck": false
+            }
+        },
+        "EC2SecurityGroup" : {
+            "Type" : "AWS::EC2::SecurityGroup",
+            "Properties" : {
+                "CidrIp": "0.0.0.0/0",
+                "FromPort": 22,
+                "ToPort": 22
+            }
+        },
+        "EC2Volume" : {
+            "Type" : "AWS::EC2::Volume",
+            "Properties" : {
+                "Encrypted": false
+            }
+        },
+        "EFSFileSystem" : {
+            "Type" : "AWS::EFS::FileSystem",
+            "Properties" : {
+                "Encrypted": false
+            }
+        },
+        "EKSCluster" : {
+            "Type" : "AWS::EKS::Cluster",
+            "Properties" : {
+                "EncryptionConfig": {
+                    "Provider": {
+                        
+                    }
+                }
+            }
+        },
+        "ElastiCacheCluster" : {
+            "Type" : "AWS::ElastiCache::CacheCluster",
+            "Properties" : {
+                "AutoMinorVersionUpgrade": false,
+                "SnapshotRetentionLimit": 1
+            }
+        },
+        "ElasticsearchDomain" : {
+            "Type" : "AWS::Elasticsearch::Domain",
+            "Properties" : {
+                "EncryptionAtRestOptions": {
+                    "Enabled": false
+                },
+                "NodeToNodeEncryptionOptions": {
+                    "Enabled": false
+                }
+            }
+        },
+        "ELB" : {
+            "Type" : "AWS::ElasticLoadBalancing::LoadBalancer",
+            "Properties" : {
+                "AccessLoggingPolicy": {
+                    "Enabled": false
+                }
+            }
+        },
+        "FsXFilesystem" : {
+            "Type" : "AWS::FSx::FileSystem",
+            "Properties" : {
+                
+            }
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -60,6 +60,18 @@ $> cfn-guard -t Examples/ebs_volume_template.json -r Examples/ebs_volume_templat
    Number of failures: 6 
 ```
 
+### Evaluating Security Policies
+
+CloudFormation Guard can be used to evaluate security best practices for infrastructure deployed via CloudFormation. A number of example rules are included:
+
+```
+$> cfn-guard -t Examples/security_template.json -r Examples/security_rules.ruleset
+   "[AmazonMQBroker] failed because [AutoMinorVersionUpgrade] is [false] and Version upgrades should be enabled to receive security updates"
+   "[AmazonMQBroker] failed because [EncryptionOptions.UseAwsOwnedKey] is [true] and CMKs should be used instead of AWS-provided KMS keys"
+   "[AmazonMQBroker] failed because [EngineVersion] is [5.15.9] and Broker engine version should be at least 5.15.10"
+   ...
+```
+
 More details on how to write rules and how the tool can work with build systems can be found [here](cfn-guard/README.md).
 
 ### Automatically Generating Rules


### PR DESCRIPTION
*Issue #, if available:* Addresses #18 

*Description of changes:* Adds examples of security checks, covering encryption, backup retention periods, minimum engine versions, TLS protocol versions, and more.

Opening this as a draft first because I intend to add (or welcome someone else to assist with adding) checks for the remaining ~60 supported CloudFormation resource types.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
