### PR TITLE
Release 0.5.1

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,35 @@
+---
+name: Bug report
+about: Create a report to help us improve CloudFormation Guard
+title: "[BUG]"
+labels: bug
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Please supply:
+
+1. An example rule set and template that results in the error
+1. The commands you used to invoke the tool
+1. The output of a `-vvv` log level if it's not related to cfn-guard-lambda, or the relevant CloudWatch log messages if it is related to the lambda
+
+**NOTE: Please be sure that the templates, rule sets and logs you provide as part of your bug report do not contain any sensitive information.**
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Operating System:**
+[eg, MacOS, Windows, Ubuntu, etc]
+
+**OS Version**
+[eg Catalina, 10, 18.04, etc]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: "[Enhancement]"
+labels: enhancement
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: rust
+
+script:
+  - cd cfn-guard && cargo build --verbose --all && cargo test --verbose --all
+script:
+  - cd cfn-guard-lambda && cargo build --verbose --all && cargo test --verbose --all
+script:
+  - cd cfn-guard-rulegen && cargo build --verbose --all && cargo test --verbose --all

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,11 @@ cfn-guard-lambda_update:
 clean:
 	if test -f cloudformation-guard.tar.gz; then rm cloudformation-guard.tar.gz; fi
 
+test:
+	cd cfn-guard; cargo test
+	cd cfn-guard-rulegen; cargo test
+	cd cfn-guard-lambda; make test
+
 release_with_binaries: clean cfn-guard cfn-guard-rulegen
 	tar czvf cloudformation-guard.tar.gz -X Exclude.txt .
 

--- a/cfn-guard-lambda/Cargo.lock
+++ b/cfn-guard-lambda/Cargo.lock
@@ -91,6 +91,7 @@ name = "cfn-guard"
 version = "0.5.0"
 dependencies = [
  "clap",
+ "lazy_static",
  "log",
  "regex",
  "serde",

--- a/cfn-guard-lambda/Cargo.lock
+++ b/cfn-guard-lambda/Cargo.lock
@@ -88,7 +88,7 @@ checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
 name = "cfn-guard"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "clap",
  "lazy_static",
@@ -102,7 +102,7 @@ dependencies = [
 
 [[package]]
 name = "cfn-guard-lambda"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "cfn-guard",
  "lambda_runtime",

--- a/cfn-guard-lambda/Cargo.toml
+++ b/cfn-guard-lambda/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cfn-guard-lambda"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2018"
 
 [dependencies]

--- a/cfn-guard-lambda/Makefile
+++ b/cfn-guard-lambda/Makefile
@@ -119,12 +119,9 @@ endif
 
 test: build
 	aws lambda update-function-code --function-name $(project_name) --zip-file fileb://./lambda.zip
-	aws lambda invoke --function-name $(project_name) --payload $(request_payload_fail) output.json
-	cat output.json | jq '.'
-	aws lambda invoke --function-name $(project_name) --payload $(request_payload_pass) output.json
-	cat output.json | jq '.'
-	aws lambda invoke --function-name $(project_name) --payload $(request_payload_err) output.json
-	cat output.json | jq '.'
+	$(MAKE) fail
+	$(MAKE) pass
+	$(MAKE) err
 
 clean:
 	@sh -c "if test -f bootstrap; then rm bootstrap; fi"
@@ -159,22 +156,25 @@ build: clean
 	chmod +x bootstrap
 	zip lambda.zip bootstrap
 
-install: build
-	aws lambda create-function --function-name $(project_name) --handler doesnt.matter --zip-file fileb://./lambda.zip --runtime provided --role $(role_arn)  --environment Variables={RUST_BACKTRACE=1}
+fail:
 	aws lambda invoke --function-name $(project_name) --payload $(request_payload_fail) output.json
 	cat output.json | jq '.'
+
+pass:
 	aws lambda invoke --function-name $(project_name) --payload $(request_payload_pass) output.json
 	cat output.json | jq '.'
+
+err:
 	aws lambda invoke --function-name $(project_name) --payload $(request_payload_err) output.json
 	cat output.json | jq '.'
 
-invoke:
-	aws lambda invoke --function-name $(project_name) --payload $(request_payload_fail) output.json
-	cat output.json | jq '.'
-	aws lambda invoke --function-name $(project_name) --payload $(request_payload_pass) output.json
-	cat output.json | jq '.'
-	aws lambda invoke --function-name $(project_name) --payload $(request_payload_err) output.json
-	cat output.json | jq '.'
+install: build
+	aws lambda create-function --function-name $(project_name) --handler doesnt.matter --zip-file fileb://./lambda.zip --runtime provided --role $(role_arn)  --environment Variables={RUST_BACKTRACE=1}
+	$(MAKE) fail
+	$(MAKE) pass
+	$(MAKE) err
+
+invoke: fail pass err
 
 uninstall:
 	aws lambda delete-function --function-name $(project_name)

--- a/cfn-guard-lambda/README.md
+++ b/cfn-guard-lambda/README.md
@@ -4,7 +4,14 @@ The Lambda version of the tool is a lightweight wrapper around the core [cfn-gua
 
 The primary interface for building and deploying the tool is the [Makefile](Makefile).  Examples for the payload it expects can be found there.
 
-## Dependencies
+## Table of Contents
+* [Installation](#installation)
+* [Build and run post-install](#to-build-and-run-post-install)
+* [Calling the Lambda Function](#calling-the-lambda-function)
+* [FAQ](#faq)
+
+## Installation
+### Dependencies
 * AWS CLI [configured](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html) with permissions to deploy and invoke Lambdas
 * An [AWS Lambda Execution Role](https://docs.aws.amazon.com/lambda/latest/dg/lambda-intro-execution-role.html) in IAM
 * A shell environment variable called `CFN_GUARD_LAMBDA_ROLE_ARN` set to the ARN of that role
@@ -12,14 +19,13 @@ The primary interface for building and deploying the tool is the [Makefile](Make
 * If building on a Mac, you'll need [Homebrew](https://brew.sh/).  
 * If building on Ubuntu, you'll need to run `sudo apt-get update; sudo apt install build-essential` if you haven't already
 
-## To install CloudFormation Guard Lambda the first time
-
-If you're on a Mac, add the following to `~/.cargo/config`:
-
-```
-[target.x86_64-unknown-linux-musl]
-linker = "x86_64-linux-musl-gcc"
-```
+### Mac/Ubuntu
+1. Install and configure the [dependencies](#dependencies).
+1. If you're on a Mac, add the following to `~/.cargo/config`:
+    ```
+    [target.x86_64-unknown-linux-musl]
+    linker = "x86_64-linux-musl-gcc"
+    ```
 1. Ensure you're in the `cfn-guard-lambda` directory
 1. Run `make pre-reqs`.
 1. Run `make install`.
@@ -112,6 +118,60 @@ cat output.json | jq '.'
   ],
   "exit_status": "ERR"
 }
+```
+## Calling the Lambda Function
+### Request Structure
+Requests to `cfn-guard-lambda` require the following 3 fields:
+* `template` - The string version of the YAML or JSON CloudFormation Template
+* `ruleSet` - The string version of the rule set file
+* `strict_checks` - A boolean indicating whether to apply [strict checks](../cfn-guard/README.md#about)
+
+#### Example
+There are example payloads in the [Makefile](Makefile).  Here's one we use to test a rule set that should not pass:
+
+``` 
+request_payload_fail = '{ "template": "{\n    \"Resources\": {\n        \"NewVolume\" : {\n            \"Type\" : \"AWS::EC2::Volume\",\n            \"Properties\" : {\n                \"Size\" : 100,\n                \"Encrypted\": true,\n                \"AvailabilityZone\" : \"us-east-1b\"\n            }\n        },\n        \"NewVolume2\" : {\n            \"Type\" : \"AWS::EC2::Volume\",\n            \"Properties\" : {\n                \"Size\" : 99,\n                \"Encrypted\": true,\n                \"AvailabilityZone\" : \"us-east-1b\"\n            }\n        } }\n}",\
+                     "ruleSet": "let require_encryption = true\nlet disallowed_azs = [us-east-1a,us-east-1b,us-east-1c]\n\nAWS::EC2::Volume AvailabilityZone NOT_IN %disallowed_azs\nAWS::EC2::Volume Encrypted != %require_encryption\nAWS::EC2::Volume Size == 101 |OR| AWS::EC2::Volume Size == 99\nAWS::IAM::Role AssumeRolePolicyDocument.Version == 2012-10-18\nAWS::EC2::Volume Lorem == true\nAWS::EC2::Volume Encrypted == %ipsum\nAWS::EC2::Volume AvailabilityZone != /us-east-.*/",\
+                      "strict_checks": true}'
+
+#======================================================================
+# Request Payload Fail:
+#======================================================================
+# Template
+#{"Resources": {
+#  "NewVolume" : {
+#    "Type" : "AWS::EC2::Volume",
+#    "Properties" : {
+#      "Size" : 100,
+#      "Encrypted": true,
+#      "AvailabilityZone" : "us-east-1b"
+#    }
+#  },
+#  "NewVolume2" : {
+#    "Type" : "AWS::EC2::Volume",
+#    "Properties" : {
+#    "Size" : 99,
+#    "Encrypted": true,
+#    "AvailabilityZone" : "us-east-1b"
+#    }
+#  }
+#}
+
+# Rule Set
+# let require_encryption = true
+# let disallowed_azs = [us-east-1a,us-east-1b,us-east-1c]
+
+# AWS::EC2::Volume AvailabilityZone NOT_IN %disallowed_azs
+# AWS::EC2::Volume Encrypted != %require_encryption
+# AWS::EC2::Volume Size == 101 |OR| AWS::EC2::Volume Size == 99
+# AWS::IAM::Role AssumeRolePolicyDocument.Version == 2012-10-18
+# AWS::EC2::Volume Lorem == true
+# AWS::EC2::Volume Encrypted == %ipsum
+# AWS::EC2::Volume AvailabilityZone != /us-east-.*/
+
+# Strict Checks
+# true
+#======================================================================
 ```
 
 ## FAQ

--- a/cfn-guard-lambda/src/main.rs
+++ b/cfn-guard-lambda/src/main.rs
@@ -1,4 +1,4 @@
-// © 2020 Amazon Web Services, Inc. or its affiliates. All Rights Reserved. This AWS Content is provided subject to the terms of the AWS Customer Agreement available at http://aws.amazon.com/agreement or other written agreement between Customer and either Amazon Web Services, Inc. or Amazon Web Services EMEA SARL or both.
+// © Amazon Web Services, Inc. or its affiliates. All Rights Reserved. This AWS Content is provided subject to the terms of the AWS Customer Agreement available at http://aws.amazon.com/agreement or other written agreement between Customer and either Amazon Web Services, Inc. or Amazon Web Services EMEA SARL or both.
 
 use std::error::Error;
 

--- a/cfn-guard-lambda/src/main.rs
+++ b/cfn-guard-lambda/src/main.rs
@@ -4,7 +4,7 @@ use std::error::Error;
 
 use cfn_guard;
 use lambda_runtime::{error::HandlerError, lambda, Context};
-use log::{self, debug};
+use log::{self, info};
 use serde_derive::{Deserialize, Serialize};
 use simple_logger;
 
@@ -14,7 +14,7 @@ struct CustomEvent {
     template: String,
     #[serde(rename = "ruleSet")]
     rule_set: String,
-    strict_checks: bool
+    strict_checks: bool,
 }
 
 #[derive(Serialize)]
@@ -24,7 +24,7 @@ struct CustomOutput {
 }
 
 fn main() -> Result<(), Box<dyn Error>> {
-    simple_logger::init_with_level(log::Level::Debug)?;
+    simple_logger::init_with_level(log::Level::Info)?;
     lambda!(my_handler);
 
     Ok(())
@@ -32,8 +32,8 @@ fn main() -> Result<(), Box<dyn Error>> {
 
 fn my_handler(e: CustomEvent, _c: Context) -> Result<CustomOutput, HandlerError> {
     //dbg!(&e);
-    debug!("Template is [{}]", &e.template);
-    debug!("Rule Set is [{}]", &e.rule_set);
+    info!("Template is [{}]", &e.template);
+    info!("Rule Set is [{}]", &e.rule_set);
     let (result, exit_code) = cfn_guard::run_check(&e.template, &e.rule_set, e.strict_checks);
 
     let exit_status = match exit_code {

--- a/cfn-guard-rulegen/Cargo.lock
+++ b/cfn-guard-rulegen/Cargo.lock
@@ -40,7 +40,7 @@ checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
 name = "cfn-guard-rulegen"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "clap",
  "log",

--- a/cfn-guard-rulegen/Cargo.toml
+++ b/cfn-guard-rulegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cfn-guard-rulegen"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2018"
 
 [dependencies]

--- a/cfn-guard-rulegen/README.md
+++ b/cfn-guard-rulegen/README.md
@@ -2,6 +2,27 @@
 
 A CLI tool to automatically generate [CloudFormation Guard](https://github.com/aws-cloudformation/cloudformation-guard) rules from CloudFormation Templates.
 
+### Runtime Arguments
+
+Rulegen uses the Rust Clap library to parse arguments.  Its `--help` output will show you what options are available:
+
+```
+$> cfn-guard-rulegen --help
+
+CloudFormation Guard RuleGen
+Generate CloudFormation Guard rules from a CloudFormation template
+
+USAGE:
+    cfn-guard-rulegen [FLAGS] <TEMPLATE>
+
+FLAGS:
+    -h, --help       Prints help information
+    -v               Sets the level of verbosity - add v's to increase output
+    -V, --version    Prints version information
+
+ARGS:
+    <TEMPLATE> 
+```
 # Example
 
 If you supply the `cfn-guard-rulegen` tool with a CloudFormation template:
@@ -126,27 +147,6 @@ will compile the release binary and drop it in the `bin/` directory under the di
 1. Run `cargo build --release`.
 2. Run the binary with `target\release\cfn-guard-rulegen.exe`
 
-### Runtime Arguments
-
-Rulegen uses the Rust Clap library to parse arguments.  Its `--help` output will show you what options are available:
-
-```
-$> cfn-guard-rulegen --help
-
-CloudFormation Guard RuleGen 0.5.0
-Generate CloudFormation Guard rules from a CloudFormation template
-
-USAGE:
-    cfn-guard-rulegen [FLAGS] <TEMPLATE>
-
-FLAGS:
-    -h, --help       Prints help information
-    -v               Sets the level of verbosity - add v's to increase output
-    -V, --version    Prints version information
-
-ARGS:
-    <TEMPLATE> 
-```
 
 ### Logging
 

--- a/cfn-guard-rulegen/src/lib.rs
+++ b/cfn-guard-rulegen/src/lib.rs
@@ -1,4 +1,4 @@
-// © 2020 Amazon Web Services, Inc. or its affiliates. All Rights Reserved. This AWS Content is provided subject to the terms of the AWS Customer Agreement available at http://aws.amazon.com/agreement or other written agreement between Customer and either Amazon Web Services, Inc. or Amazon Web Services EMEA SARL or both.
+// © Amazon Web Services, Inc. or its affiliates. All Rights Reserved. This AWS Content is provided subject to the terms of the AWS Customer Agreement available at http://aws.amazon.com/agreement or other written agreement between Customer and either Amazon Web Services, Inc. or Amazon Web Services EMEA SARL or both.
 
 use log::{self, debug, info, trace};
 use serde_json::Value;

--- a/cfn-guard-rulegen/src/lib.rs
+++ b/cfn-guard-rulegen/src/lib.rs
@@ -44,7 +44,10 @@ fn gen_rules(cfn_resources: HashMap<String, Value>) -> Vec<String> {
     for (name, cfn_resource) in cfn_resources {
         trace!("{} is {:?}", name, &cfn_resource);
         let props: HashMap<String, Value> =
-            serde_json::from_value(cfn_resource["Properties"].clone()).unwrap();
+            match serde_json::from_value(cfn_resource["Properties"].clone()) {
+                Ok(s) => s,
+                Err(_) => continue
+            };
         for (prop_name, prop_val) in props {
             let stripped_val = match prop_val.as_str() {
                 Some(v) => String::from(v),
@@ -79,3 +82,4 @@ fn gen_rules(cfn_resources: HashMap<String, Value>) -> Vec<String> {
     }
     rule_set.into_iter().collect()
 }
+

--- a/cfn-guard-rulegen/src/main.rs
+++ b/cfn-guard-rulegen/src/main.rs
@@ -1,4 +1,4 @@
-// © 2020 Amazon Web Services, Inc. or its affiliates. All Rights Reserved. This AWS Content is provided subject to the terms of the AWS Customer Agreement available at http://aws.amazon.com/agreement or other written agreement between Customer and either Amazon Web Services, Inc. or Amazon Web Services EMEA SARL or both.
+// © Amazon Web Services, Inc. or its affiliates. All Rights Reserved. This AWS Content is provided subject to the terms of the AWS Customer Agreement available at http://aws.amazon.com/agreement or other written agreement between Customer and either Amazon Web Services, Inc. or Amazon Web Services EMEA SARL or both.
 
 use std::process;
 #[macro_use]

--- a/cfn-guard-rulegen/src/main.rs
+++ b/cfn-guard-rulegen/src/main.rs
@@ -4,12 +4,12 @@ use std::process;
 #[macro_use]
 extern crate log;
 extern crate simple_logger;
-use clap::{App, Arg};
+use clap::{crate_version, App, Arg};
 use log::Level;
 
 fn main() {
     let matches = App::new("CloudFormation Guard RuleGen")
-        .version("0.5.0")
+        .version(crate_version!())
         .about("Generate cfn-guard rules from a CloudFormation template")
         .arg(Arg::with_name("TEMPLATE").index(1).required(true))
         .arg(

--- a/cfn-guard-rulegen/tests/functional.rs
+++ b/cfn-guard-rulegen/tests/functional.rs
@@ -1,0 +1,48 @@
+// © Amazon Web Services, Inc. or its affiliates. All Rights Reserved. This AWS Content is provided subject to the terms of the AWS Customer Agreement available at http://aws.amazon.com/agreement or other written agreement between Customer and either Amazon Web Services, Inc. or Amazon Web Services EMEA SARL or both.
+
+// Tests
+// use cfn_guard_rulegen;
+
+mod tests {
+
+    #[test]
+    fn test_simple_mixed_template() {
+        let template_contents = String::from(r#"
+Resources:
+  LambdaRoleHelper:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      AssumeRolePolicyDocument: |
+        {
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "notlambda.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        }
+"#);
+        assert_eq!(
+            cfn_guard_rulegen::run_gen(&template_contents ),
+            vec![String::from(r#"AWS::IAM::Role AssumeRolePolicyDocument == {  "Statement": [    {      "Effect": "Allow",      "Principal": {        "Service": [          "notlambda.amazonaws.com"        ]      }    }  ]}"#)]
+        );
+    }
+
+#[test]
+fn test_no_properties_template() {
+    let template_contents = String::from(r#"
+Resources:
+  LambdaRoleHelper:
+    Type: 'AWS::IAM::Role'
+"#);
+    let empty_vec: Vec<String> = vec![];
+        assert_eq!(
+            cfn_guard_rulegen::run_gen(&template_contents ),
+            empty_vec
+        );
+    }
+}

--- a/cfn-guard/Cargo.lock
+++ b/cfn-guard/Cargo.lock
@@ -49,7 +49,7 @@ checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
 name = "cfn-guard"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "clap",
  "lazy_static",

--- a/cfn-guard/Cargo.lock
+++ b/cfn-guard/Cargo.lock
@@ -52,6 +52,7 @@ name = "cfn-guard"
 version = "0.5.0"
 dependencies = [
  "clap",
+ "lazy_static",
  "log",
  "regex",
  "serde",

--- a/cfn-guard/Cargo.toml
+++ b/cfn-guard/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cfn-guard"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2018"
 
 [dependencies]

--- a/cfn-guard/Cargo.toml
+++ b/cfn-guard/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 serde = { version = "1.0.92", features = ["derive"] }
 serde_json = "1.0"
 serde_yaml = "0.8.9"
+lazy_static = "1.4.0"
 log = "0.4.6"
 clap = "2.33.0"
 simple_logger = "1.3.0"

--- a/cfn-guard/README.md
+++ b/cfn-guard/README.md
@@ -109,6 +109,13 @@ The available operations are:
 * `IN` - In a list of form `[x, y, z]`
 * `NOT_IN` - Not in a list of form `[x, y, z]` 
 
+## Comments
+
+Comments can be added to a rule set via the `#` operator:
+```
+# This is a comment
+```
+
 
 ## Rule Logic
 

--- a/cfn-guard/README.md
+++ b/cfn-guard/README.md
@@ -9,7 +9,24 @@ A command line tool for validating AWS CloudFormation resources against policy.
 * [Testing Code Changes](#to-test)
 
 # About
+```
+CloudFormation Guard
+Check CloudFormation templates against rules
 
+USAGE:
+    cfn-guard [FLAGS] --rule_set <RULE_SET_FILE> --template <TEMPLATE_FILE>
+
+FLAGS:
+    -h, --help             Prints help information
+    -s, --strict-checks    Fail resources if they're missing the property that a rule checks
+    -v                     Sets the level of verbosity - add v's to increase output
+    -V, --version          Prints version information
+    -w, --warn_only        Show results but return an exit code of 0 regardless of rule violations
+
+OPTIONS:
+    -r, --rule_set <RULE_SET_FILE>    Rules to check the template against
+    -t, --template <TEMPLATE_FILE>    CloudFormation Template
+```
 `cfn-guard` is a tool for checking CloudFormation resources for properties using a light-weight, firewall-rule-like syntax.
 
 As an example of how to use it, given a CloudFormation template:
@@ -373,29 +390,6 @@ will compile the release binary and drop it in the `bin/` directory under the di
 #### Windows
 1. Run `cargo build --release`.
 2. Run the binary with `target\release\cfn-guard.exe`
-
-### Runtime Arguments
-
-`cfn-guard` uses the Rust Clap library to parse arguments.  Its `--help` output will show you what options are available:
-
-```
-CloudFormation Guard 0.5.0
-Check CloudFormation templates against rules
-
-USAGE:
-    cfn-guard [FLAGS] --rule_set <RULE_SET_FILE> --template <TEMPLATE_FILE>
-
-FLAGS:
-    -h, --help             Prints help information
-    -s, --strict-checks    Fail resources if they're missing the property that a rule checks
-    -v                     Sets the level of verbosity - add v's to increase output
-    -V, --version          Prints version information
-    -w, --warn_only        Show results but return an exit code of 0 regardless of rule violations
-
-OPTIONS:
-    -r, --rule_set <RULE_SET_FILE>    Rules to check the template against
-    -t, --template <TEMPLATE_FILE>    CloudFormation Template
-```
 
 ### Logging
 

--- a/cfn-guard/src/guard_types.rs
+++ b/cfn-guard/src/guard_types.rs
@@ -2,7 +2,7 @@
 // Structs, Enums and Impls
 
 pub mod enums {
-    #[derive(Debug)]
+    #[derive(Debug, PartialEq)]
     pub enum LineType {
         Assignment,
         Comment,

--- a/cfn-guard/src/guard_types.rs
+++ b/cfn-guard/src/guard_types.rs
@@ -10,6 +10,9 @@ pub mod enums {
     }
 
     #[derive(Debug)]
+    #[derive(Hash)]
+    #[derive(PartialEq, Eq)]
+    #[derive(Clone)]
     pub enum OpCode {
         Require,
         RequireNot,
@@ -18,6 +21,9 @@ pub mod enums {
     }
 
     #[derive(Debug)]
+    #[derive(Hash)]
+    #[derive(PartialEq, Eq)]
+    #[derive(Clone)]
     pub enum RValueType {
         Value,
         List,
@@ -25,6 +31,7 @@ pub mod enums {
         Variable,
     }
     #[derive(Debug)]
+    #[derive(Clone)]
     pub enum CompoundType {
         OR,
         AND,
@@ -35,6 +42,9 @@ pub mod structs {
     use std::collections::HashMap;
 
     #[derive(Debug)]
+    #[derive(Hash)]
+    #[derive(Eq)]
+    #[derive(Clone)]
     pub struct Rule {
         pub(crate) resource_type: String,
         pub(crate) field: String,
@@ -42,6 +52,14 @@ pub mod structs {
         pub(crate) value: String,
         pub(crate) rule_vtype: super::enums::RValueType,
         pub(crate) custom_msg: Option<String>,
+    }
+
+    impl PartialEq for Rule {
+        fn eq(&self, other: &Rule) -> bool {
+            let self_string: String = format!("{:#?}", self);
+            let other_string: String = format!("{:#?}", other);
+            self_string == other_string
+        }
     }
 
     #[derive(Debug)]

--- a/cfn-guard/src/guard_types.rs
+++ b/cfn-guard/src/guard_types.rs
@@ -1,4 +1,4 @@
-// © 2020 Amazon Web Services, Inc. or its affiliates. All Rights Reserved. This AWS Content is provided subject to the terms of the AWS Customer Agreement available at http://aws.amazon.com/agreement or other written agreement between Customer and either Amazon Web Services, Inc. or Amazon Web Services EMEA SARL or both.
+// © Amazon Web Services, Inc. or its affiliates. All Rights Reserved. This AWS Content is provided subject to the terms of the AWS Customer Agreement available at http://aws.amazon.com/agreement or other written agreement between Customer and either Amazon Web Services, Inc. or Amazon Web Services EMEA SARL or both.
 // Structs, Enums and Impls
 
 pub mod enums {

--- a/cfn-guard/src/guard_types.rs
+++ b/cfn-guard/src/guard_types.rs
@@ -56,4 +56,3 @@ pub mod structs {
         pub(crate) rule_set: Vec<CompoundRule>,
     }
 }
-

--- a/cfn-guard/src/guard_types.rs
+++ b/cfn-guard/src/guard_types.rs
@@ -9,10 +9,7 @@ pub mod enums {
         Rule,
     }
 
-    #[derive(Debug)]
-    #[derive(Hash)]
-    #[derive(PartialEq, Eq)]
-    #[derive(Clone)]
+    #[derive(Debug, Hash, PartialEq, Eq, Clone)]
     pub enum OpCode {
         Require,
         RequireNot,
@@ -20,18 +17,14 @@ pub mod enums {
         NotIn,
     }
 
-    #[derive(Debug)]
-    #[derive(Hash)]
-    #[derive(PartialEq, Eq)]
-    #[derive(Clone)]
+    #[derive(Debug, Hash, PartialEq, Eq, Clone)]
     pub enum RValueType {
         Value,
         List,
         Regex,
         Variable,
     }
-    #[derive(Debug)]
-    #[derive(Clone)]
+    #[derive(Debug, Clone)]
     pub enum CompoundType {
         OR,
         AND,
@@ -41,10 +34,7 @@ pub mod enums {
 pub mod structs {
     use std::collections::HashMap;
 
-    #[derive(Debug)]
-    #[derive(Hash)]
-    #[derive(Eq)]
-    #[derive(Clone)]
+    #[derive(Debug, Hash, Eq, PartialEq, Clone)]
     pub struct Rule {
         pub(crate) resource_type: String,
         pub(crate) field: String,
@@ -52,14 +42,6 @@ pub mod structs {
         pub(crate) value: String,
         pub(crate) rule_vtype: super::enums::RValueType,
         pub(crate) custom_msg: Option<String>,
-    }
-
-    impl PartialEq for Rule {
-        fn eq(&self, other: &Rule) -> bool {
-            let self_string: String = format!("{:#?}", self);
-            let other_string: String = format!("{:#?}", other);
-            self_string == other_string
-        }
     }
 
     #[derive(Debug)]

--- a/cfn-guard/src/lib.rs
+++ b/cfn-guard/src/lib.rs
@@ -81,8 +81,19 @@ pub fn run_check(
         };
     trace!("CFN Template is '{:#?}'", &cfn_template);
 
-    let cfn_resources: HashMap<String, Value> =
-        serde_json::from_value(cfn_template["Resources"].clone()).unwrap();
+    let cfn_resources: HashMap<String, Value> = match cfn_template.get("Resources") {
+        Some(r) => serde_json::from_value(r.clone()).unwrap(),
+        None => {
+            return (
+                vec![
+                    "ERROR:  Template file does not contain a [Resources] section to check"
+                        .to_string(),
+                ],
+                1,
+            );
+        }
+    };
+
     trace!("CFN resources are: {:?}", cfn_resources);
 
     info!("Parsing rule set");

--- a/cfn-guard/src/lib.rs
+++ b/cfn-guard/src/lib.rs
@@ -1,4 +1,4 @@
-// © 2020 Amazon Web Services, Inc. or its affiliates. All Rights Reserved. This AWS Content is provided subject to the terms of the AWS Customer Agreement available at http://aws.amazon.com/agreement or other written agreement between Customer and either Amazon Web Services, Inc. or Amazon Web Services EMEA SARL or both.
+// © Amazon Web Services, Inc. or its affiliates. All Rights Reserved. This AWS Content is provided subject to the terms of the AWS Customer Agreement available at http://aws.amazon.com/agreement or other written agreement between Customer and either Amazon Web Services, Inc. or Amazon Web Services EMEA SARL or both.
 
 use log::{self, debug, error, info, trace};
 use serde_json::Value;

--- a/cfn-guard/src/lib.rs
+++ b/cfn-guard/src/lib.rs
@@ -33,7 +33,7 @@ pub fn run(
     trace!(
         "Rules file is '{}' and its contents are: {}",
         rules_file,
-        format!("{}", rules_file_contents)
+        rules_file_contents.to_string()
     );
 
     let (outcome, exit_code) = run_check(&template_contents, &rules_file_contents, strict_checks);
@@ -140,16 +140,13 @@ fn check_resources(
             }
             enums::CompoundType::AND => {
                 for rule in &c_rule.rule_list {
-                    match apply_rule(
+                    if let Some(rule_result) = apply_rule(
                         &cfn_resources,
                         &rule,
                         &parsed_rule_set.variables,
                         strict_checks,
                     ) {
-                        Some(rule_result) => {
-                            result.extend(rule_result);
-                        }
-                        None => (),
+                        result.extend(rule_result);
                     }
                 }
             }
@@ -345,10 +342,7 @@ fn apply_rule_operation(
             let value_vec = util::convert_list_var_to_vec(rule_val);
             let val_as_string = match val.as_str() {
                 Some(s) => s.to_string(),
-                None => {
-                    let serde_string = serde_json::to_string(val).unwrap();
-                    serde_string
-                }
+                None => serde_json::to_string(val).unwrap(),
             };
             if !value_vec.contains(&util::strip_ws_nl(val_as_string)) {
                 info!("Result: FAIL");
@@ -377,10 +371,7 @@ fn apply_rule_operation(
             let value_vec = util::convert_list_var_to_vec(rule_val);
             let val_as_string = match val.as_str() {
                 Some(s) => s.to_string(),
-                None => {
-                    let serde_string = serde_json::to_string(val).unwrap();
-                    serde_string
-                }
+                None => serde_json::to_string(val).unwrap(),
             };
             if value_vec.contains(&util::strip_ws_nl(val_as_string)) {
                 info!("Result: FAIL");

--- a/cfn-guard/src/main.rs
+++ b/cfn-guard/src/main.rs
@@ -44,7 +44,7 @@ fn main() {
             Arg::with_name("strict-checks")
                 .short("s")
                 .long("strict-checks")
-                .help("Fail resources if they're missing the property that a rule checks")
+                .help("Fail resources if they're missing the property that a rule checks"),
         )
         .get_matches();
 
@@ -67,7 +67,12 @@ fn main() {
         &template_file, &rule_set_file
     );
 
-    let (result, exit_code) = cfn_guard::run(template_file, rule_set_file, matches.is_present("strict-checks")).unwrap_or_else(|err| {
+    let (result, exit_code) = cfn_guard::run(
+        template_file,
+        rule_set_file,
+        matches.is_present("strict-checks"),
+    )
+    .unwrap_or_else(|err| {
         println!("Problem checking template: {}", err);
         process::exit(1);
     });

--- a/cfn-guard/src/main.rs
+++ b/cfn-guard/src/main.rs
@@ -1,4 +1,4 @@
-// © 2020 Amazon Web Services, Inc. or its affiliates. All Rights Reserved. This AWS Content is provided subject to the terms of the AWS Customer Agreement available at http://aws.amazon.com/agreement or other written agreement between Customer and either Amazon Web Services, Inc. or Amazon Web Services EMEA SARL or both.
+// © Amazon Web Services, Inc. or its affiliates. All Rights Reserved. This AWS Content is provided subject to the terms of the AWS Customer Agreement available at http://aws.amazon.com/agreement or other written agreement between Customer and either Amazon Web Services, Inc. or Amazon Web Services EMEA SARL or both.
 
 use std::process;
 #[macro_use]

--- a/cfn-guard/src/main.rs
+++ b/cfn-guard/src/main.rs
@@ -5,12 +5,12 @@ use std::process;
 extern crate log;
 extern crate lazy_static;
 extern crate simple_logger;
-use clap::{App, Arg};
+use clap::{crate_version, App, Arg};
 use log::Level;
 
 fn main() {
     let matches = App::new("CloudFormation Guard")
-        .version("0.5.0")
+        .version(crate_version!())
         .about("Check CloudFormation templates against rules")
         .arg(
             Arg::with_name("template")

--- a/cfn-guard/src/main.rs
+++ b/cfn-guard/src/main.rs
@@ -3,6 +3,7 @@
 use std::process;
 #[macro_use]
 extern crate log;
+extern crate lazy_static;
 extern crate simple_logger;
 use clap::{App, Arg};
 use log::Level;

--- a/cfn-guard/src/main.rs
+++ b/cfn-guard/src/main.rs
@@ -52,7 +52,7 @@ fn main() {
         0 => Level::Error,
         1 => Level::Info,
         2 => Level::Debug,
-        3 | _ => Level::Trace,
+        _ => Level::Trace,
     };
 
     simple_logger::init_with_level(log_level).unwrap();

--- a/cfn-guard/src/parser.rs
+++ b/cfn-guard/src/parser.rs
@@ -83,14 +83,14 @@ pub(crate) fn parse_rules(
 }
 
 fn find_line_type(line: &str) -> LineType {
+    if COMMENT_REG.is_match(line) {
+        return LineType::Comment;
+    };
     if ASSIGN_REG.is_match(line) {
         return LineType::Assignment;
     };
     if RULE_REG.is_match(line) {
         return LineType::Rule;
-    };
-    if COMMENT_REG.is_match(line) {
-        return LineType::Comment;
     };
     panic!("BAD RULE: {:?}", line)
 }
@@ -194,4 +194,18 @@ fn destructure_rule(rule_text: &str, cfn_resources: &HashMap<String, Value>) -> 
     let rules = rules_hash.into_iter().collect::<Vec<Rule>>();
     trace!("Destructured rules are: {:#?}", &rules);
     rules
+}
+
+mod tests {
+    use crate::parser::find_line_type;
+
+    #[test]
+    fn test_find_line_type() {
+        let comment = find_line_type("# This is a comment");
+        let assignment = find_line_type("let x = assignment");
+        let rule = find_line_type("AWS::EC2::Volume Encryption == true");
+        assert_eq!(comment, crate::enums::LineType::Comment);
+        assert_eq!(assignment, crate::enums::LineType::Assignment);
+        assert_eq!(rule, crate::enums::LineType::Rule);
+    }
 }

--- a/cfn-guard/src/parser.rs
+++ b/cfn-guard/src/parser.rs
@@ -197,6 +197,7 @@ fn destructure_rule(rule_text: &str, cfn_resources: &HashMap<String, Value>) -> 
 }
 
 mod tests {
+    #[cfg(test)]
     use crate::parser::find_line_type;
 
     #[test]

--- a/cfn-guard/src/parser.rs
+++ b/cfn-guard/src/parser.rs
@@ -1,4 +1,4 @@
-// © 2020 Amazon Web Services, Inc. or its affiliates. All Rights Reserved. This AWS Content is provided subject to the terms of the AWS Customer Agreement available at http://aws.amazon.com/agreement or other written agreement between Customer and either Amazon Web Services, Inc. or Amazon Web Services EMEA SARL or both.
+// © Amazon Web Services, Inc. or its affiliates. All Rights Reserved. This AWS Content is provided subject to the terms of the AWS Customer Agreement available at http://aws.amazon.com/agreement or other written agreement between Customer and either Amazon Web Services, Inc. or Amazon Web Services EMEA SARL or both.
 
 use std::collections::HashMap;
 use std::env;

--- a/cfn-guard/src/util.rs
+++ b/cfn-guard/src/util.rs
@@ -1,15 +1,20 @@
 // © Amazon Web Services, Inc. or its affiliates. All Rights Reserved. This AWS Content is provided subject to the terms of the AWS Customer Agreement available at http://aws.amazon.com/agreement or other written agreement between Customer and either Amazon Web Services, Inc. or Amazon Web Services EMEA SARL or both.
 
+use crate::{enums, structs};
+use lazy_static::lazy_static;
 use log::{self, debug, error, trace};
-use crate::{structs, enums};
-use std::collections::HashMap;
+use regex::{Captures, Regex};
 use serde_json::Value;
-use regex::{Regex, Captures};
+use std::collections::HashMap;
 
+// This sets it up so the regex only gets compiled once
+// See: https://docs.rs/regex/1.3.9/regex/#example-avoid-compiling-the-same-regex-in-a-loop
+lazy_static! {
+    static ref STRINGIFIED_BOOLS: Regex =
+        Regex::new(r"[:=]\s*([fF]alse|[tT]rue)\s*([,}]+|$)").unwrap();
+}
 pub fn fix_stringified_bools(fstr: &str) -> String {
-    let regex_pattern = r"[:=]\s*([fF]alse|[tT]rue)\s*([,}]+|$)";
-    let re = Regex::new(regex_pattern).unwrap();
-    let after = re.replace_all(fstr, |caps: &Captures| {
+    let after = STRINGIFIED_BOOLS.replace_all(fstr, |caps: &Captures| {
         format!("{}", &caps[0].to_lowercase())
     });
     after.to_string()
@@ -137,11 +142,17 @@ pub fn deref_rule_value<'a>(
     }
 }
 
-pub fn expand_wildcard_props(props: &Value, address: String, accumulator: String) -> Option<Vec<String>> {
-    trace!("Entering expand_wildcard_props() with props: {:#?} , address: {:#?} , accumulator: {:#?}",
+pub fn expand_wildcard_props(
+    props: &Value,
+    address: String,
+    accumulator: String,
+) -> Option<Vec<String>> {
+    trace!(
+        "Entering expand_wildcard_props() with props: {:#?} , address: {:#?} , accumulator: {:#?}",
         &props,
         &address,
-        &accumulator);
+        &accumulator
+    );
     let mut segments = address.split("*").collect::<Vec<&str>>();
     trace!("Segments are {:#?}", &segments);
     let segment = segments.remove(0);
@@ -151,28 +162,26 @@ pub fn expand_wildcard_props(props: &Value, address: String, accumulator: String
         let s = segment.trim_end_matches(".").trim_start_matches(".");
         let steps = s.split(".").collect::<Vec<&str>>();
         match get_resource_prop_value(props, &steps) {
-            Ok(v) => {
-                match v.as_array() {
-                    Some(result_array) => {
-                        trace!("Value is an array");
-                        let mut counter = 0;
-                        for r in result_array {
-                            trace!("Counter is {:#?}", counter);
-                            let next_segment = segments.join("*");
-                            trace!("next_segment is {:#?}", &next_segment);
-                            let temp_address = format!("{}{}{}",accumulator, segment, counter);
-                            trace!("temp_address is {:#?}", &temp_address);
-                            match expand_wildcard_props(&r, next_segment, temp_address) {
-                                Some(result) => expanded_props.append(&mut result.clone()),
-                                None => return None
-                            }
-                            counter += 1;
+            Ok(v) => match v.as_array() {
+                Some(result_array) => {
+                    trace!("Value is an array");
+                    let mut counter = 0;
+                    for r in result_array {
+                        trace!("Counter is {:#?}", counter);
+                        let next_segment = segments.join("*");
+                        trace!("next_segment is {:#?}", &next_segment);
+                        let temp_address = format!("{}{}{}", accumulator, segment, counter);
+                        trace!("temp_address is {:#?}", &temp_address);
+                        match expand_wildcard_props(&r, next_segment, temp_address) {
+                            Some(result) => expanded_props.append(&mut result.clone()),
+                            None => return None,
                         }
-                    },
-                    None => expanded_props.push(format!("{}{}", accumulator, segment))
+                        counter += 1;
+                    }
                 }
+                None => expanded_props.push(format!("{}{}", accumulator, segment)),
             },
-            Err(_) => return None
+            Err(_) => return None,
         }
         Some(expanded_props)
     } else {
@@ -181,14 +190,13 @@ pub fn expand_wildcard_props(props: &Value, address: String, accumulator: String
     }
 }
 
-
 mod tests {
     #[cfg(test)]
-    use std::collections::HashMap;
+    use crate::util::expand_wildcard_props;
     #[cfg(test)]
     use serde_yaml;
     #[cfg(test)]
-    use crate::util::expand_wildcard_props;
+    use std::collections::HashMap;
 
     #[test]
     fn test_wildcard_expansion() {
@@ -222,23 +230,29 @@ Resources:
             Action:
               - 'sts:AssumeRole'
 "#;
-        let cfn_template: HashMap<String, serde_json::Value> = serde_yaml::from_str(&iam_template).unwrap();
+        let cfn_template: HashMap<String, serde_json::Value> =
+            serde_yaml::from_str(&iam_template).unwrap();
         let mut wildcard = String::from("AssumeRolePolicyDocument.Statement.*.Effect");
         let root = &cfn_template["Resources"]["LambdaRoleHelper"]["Properties"];
-        let mut expanded_wildcards = expand_wildcard_props(&root, wildcard, String::from("")).unwrap();
-        assert_eq!(expanded_wildcards,
-                    vec![String::from("AssumeRolePolicyDocument.Statement.0.Effect"),
-                         String::from("AssumeRolePolicyDocument.Statement.1.Effect"),
-                         String::from("AssumeRolePolicyDocument.Statement.2.Effect"),
-                    ]
+        let mut expanded_wildcards =
+            expand_wildcard_props(&root, wildcard, String::from("")).unwrap();
+        assert_eq!(
+            expanded_wildcards,
+            vec![
+                String::from("AssumeRolePolicyDocument.Statement.0.Effect"),
+                String::from("AssumeRolePolicyDocument.Statement.1.Effect"),
+                String::from("AssumeRolePolicyDocument.Statement.2.Effect"),
+            ]
         );
         wildcard = String::from("AssumeRolePolicyDocument.Statement.*.Action.*");
         expanded_wildcards = expand_wildcard_props(&root, wildcard, String::from("")).unwrap();
-        assert_eq!(expanded_wildcards,
-                   vec![String::from("AssumeRolePolicyDocument.Statement.0.Action.0"),
-                        String::from("AssumeRolePolicyDocument.Statement.1.Action.0"),
-                        String::from("AssumeRolePolicyDocument.Statement.2.Action.0"),
-                   ]
+        assert_eq!(
+            expanded_wildcards,
+            vec![
+                String::from("AssumeRolePolicyDocument.Statement.0.Action.0"),
+                String::from("AssumeRolePolicyDocument.Statement.1.Action.0"),
+                String::from("AssumeRolePolicyDocument.Statement.2.Action.0"),
+            ]
         );
     }
 }

--- a/cfn-guard/src/util.rs
+++ b/cfn-guard/src/util.rs
@@ -1,4 +1,4 @@
-// © 2020 Amazon Web Services, Inc. or its affiliates. All Rights Reserved. This AWS Content is provided subject to the terms of the AWS Customer Agreement available at http://aws.amazon.com/agreement or other written agreement between Customer and either Amazon Web Services, Inc. or Amazon Web Services EMEA SARL or both.
+// © Amazon Web Services, Inc. or its affiliates. All Rights Reserved. This AWS Content is provided subject to the terms of the AWS Customer Agreement available at http://aws.amazon.com/agreement or other written agreement between Customer and either Amazon Web Services, Inc. or Amazon Web Services EMEA SARL or both.
 
 use log::{self, debug, error, trace};
 use crate::{structs, enums};

--- a/cfn-guard/src/util.rs
+++ b/cfn-guard/src/util.rs
@@ -14,9 +14,7 @@ lazy_static! {
         Regex::new(r"[:=]\s*([fF]alse|[tT]rue)\s*([,}]+|$)").unwrap();
 }
 pub fn fix_stringified_bools(fstr: &str) -> String {
-    let after = STRINGIFIED_BOOLS.replace_all(fstr, |caps: &Captures| {
-        format!("{}", &caps[0].to_lowercase())
-    });
+    let after = STRINGIFIED_BOOLS.replace_all(fstr, |caps: &Captures| caps[0].to_lowercase());
     after.to_string()
 }
 
@@ -153,20 +151,19 @@ pub fn expand_wildcard_props(
         &address,
         &accumulator
     );
-    let mut segments = address.split("*").collect::<Vec<&str>>();
+    let mut segments = address.split('*').collect::<Vec<&str>>();
     trace!("Segments are {:#?}", &segments);
     let segment = segments.remove(0);
     trace!("Processing segment {:#?}", &segment);
     if segment != "" {
         let mut expanded_props: Vec<String> = vec![];
-        let s = segment.trim_end_matches(".").trim_start_matches(".");
-        let steps = s.split(".").collect::<Vec<&str>>();
+        let s = segment.trim_end_matches('.').trim_start_matches('.');
+        let steps = s.split('.').collect::<Vec<&str>>();
         match get_resource_prop_value(props, &steps) {
             Ok(v) => match v.as_array() {
                 Some(result_array) => {
                     trace!("Value is an array");
-                    let mut counter = 0;
-                    for r in result_array {
+                    for (counter, r) in result_array.iter().enumerate() {
                         trace!("Counter is {:#?}", counter);
                         let next_segment = segments.join("*");
                         trace!("next_segment is {:#?}", &next_segment);
@@ -176,7 +173,6 @@ pub fn expand_wildcard_props(
                             Some(result) => expanded_props.append(&mut result.clone()),
                             None => return None,
                         }
-                        counter += 1;
                     }
                 }
                 None => expanded_props.push(format!("{}{}", accumulator, segment)),
@@ -193,8 +189,6 @@ pub fn expand_wildcard_props(
 mod tests {
     #[cfg(test)]
     use crate::util::expand_wildcard_props;
-    #[cfg(test)]
-    use serde_yaml;
     #[cfg(test)]
     use std::collections::HashMap;
 

--- a/cfn-guard/tests/ebs_volume_rule_set_custom_msg.failing
+++ b/cfn-guard/tests/ebs_volume_rule_set_custom_msg.failing
@@ -1,6 +1,7 @@
 let encryption_flag = false
 let allowed_azs = [us-east-1a,us-east-1b,us-east-1c]
 
+# Test comment
 AWS::EC2::Volume AvailabilityZone IN %allowed_azs << azs lorem ipsum
 AWS::EC2::Volume Encrypted == %encryption_flag << enc lorem ipsum
 AWS::EC2::Volume Size == 201 |OR| AWS::EC2::Volume Size == 199 << or lorem ipsum

--- a/cfn-guard/tests/ebs_volume_rule_set_custom_msg.passing
+++ b/cfn-guard/tests/ebs_volume_rule_set_custom_msg.passing
@@ -2,6 +2,7 @@ let encryption_flag = true
 let disallowed_azs = [us-east-1a,us-east-1b,us-east-1c]
 
 AWS::EC2::Volume AvailabilityZone NOT_IN %disallowed_azs << lorem ipsum
+# Test comment
 AWS::EC2::Volume Encrypted == %encryption_flag << lorem ipsum
 AWS::EC2::Volume Size == 101 |OR| AWS::EC2::Volume Size == 99 << lorem ipsum
 AWS::EC2::Volume AvailabilityZone != /us-east-.*/ << lorem ipsum

--- a/cfn-guard/tests/functional.rs
+++ b/cfn-guard/tests/functional.rs
@@ -1,4 +1,4 @@
-// © 2020 Amazon Web Services, Inc. or its affiliates. All Rights Reserved. This AWS Content is provided subject to the terms of the AWS Customer Agreement available at http://aws.amazon.com/agreement or other written agreement between Customer and either Amazon Web Services, Inc. or Amazon Web Services EMEA SARL or both.
+// © Amazon Web Services, Inc. or its affiliates. All Rights Reserved. This AWS Content is provided subject to the terms of the AWS Customer Agreement available at http://aws.amazon.com/agreement or other written agreement between Customer and either Amazon Web Services, Inc. or Amazon Web Services EMEA SARL or both.
 
 // Tests
 use std::env;

--- a/cfn-guard/tests/functional.rs
+++ b/cfn-guard/tests/functional.rs
@@ -1,9 +1,9 @@
 // © Amazon Web Services, Inc. or its affiliates. All Rights Reserved. This AWS Content is provided subject to the terms of the AWS Customer Agreement available at http://aws.amazon.com/agreement or other written agreement between Customer and either Amazon Web Services, Inc. or Amazon Web Services EMEA SARL or both.
 
 // Tests
+use cfn_guard;
 use std::env;
 use std::fs;
-use cfn_guard;
 
 mod tests {
     use super::*;
@@ -30,7 +30,8 @@ mod tests {
 
     #[test]
     fn test_lax_boolean_correction() {
-        let mut template_contents = String::from(r#"
+        let mut template_contents = String::from(
+            r#"
                 {
             "Resources": {
                 "NewVolume" : {
@@ -50,7 +51,8 @@ mod tests {
                     }
                 }
             }
-        }"#);
+        }"#,
+        );
         let mut rules_file_contents = String::from("AWS::EC2::Volume Encrypted == true");
         assert_eq!(
             cfn_guard::run_check(&template_contents, &rules_file_contents, true),
@@ -62,7 +64,8 @@ mod tests {
             (vec![], 0)
         );
 
-        template_contents = String::from(r#"
+        template_contents = String::from(
+            r#"
                 {
             "Resources": {
                 "NewVolume" : {
@@ -82,8 +85,9 @@ mod tests {
                     }
                 }
             }
-        }"#);
-       rules_file_contents = String::from("AWS::EC2::Volume Encrypted == false");
+        }"#,
+        );
+        rules_file_contents = String::from("AWS::EC2::Volume Encrypted == false");
         assert_eq!(
             cfn_guard::run_check(&template_contents, &rules_file_contents, true),
             (vec![], 0)
@@ -95,7 +99,8 @@ mod tests {
             (vec![], 0)
         );
 
-        template_contents = String::from(r#"
+        template_contents = String::from(
+            r#"
                 {
             "Resources": {
                 "NewVolume" : {
@@ -115,7 +120,8 @@ mod tests {
                     }
                 }
             }
-        }"#);
+        }"#,
+        );
         rules_file_contents = String::from("AWS::EC2::Volume Encrypted == false");
         assert_eq!(
             cfn_guard::run_check(&template_contents, &rules_file_contents, true),
@@ -128,7 +134,8 @@ mod tests {
             (vec![], 0)
         );
 
-        template_contents = String::from(r#"
+        template_contents = String::from(
+            r#"
                 {
             "Resources": {
                 "NewVolume" : {
@@ -146,7 +153,8 @@ mod tests {
                     }
                 }
             }
-        }"#);
+        }"#,
+        );
         rules_file_contents = String::from("AWS::EC2::Volume Encrypted == false");
         assert_eq!(
             cfn_guard::run_check(&template_contents, &rules_file_contents, false),
@@ -162,53 +170,76 @@ mod tests {
 
     #[test]
     fn test_fail_on_regex_require_not_match() {
-        let template_contents =
-            fs::read_to_string("tests/ebs_volume_template.json")
-                .unwrap_or_else(|err| format!("{}", err));
+        let template_contents = fs::read_to_string("tests/ebs_volume_template.json")
+            .unwrap_or_else(|err| format!("{}", err));
         let rules_file_content = String::from(r#"AWS::EC2::Volume Encrypted != /true/"#);
         assert_eq!(
             cfn_guard::run_check(&template_contents, &rules_file_content, true),
-            (vec![String::from(r#"[NewVolume2] failed because [Encrypted] is [true] and the pattern [true] is not permitted"#),
-                  String::from(r#"[NewVolume] failed because [Encrypted] is [true] and the pattern [true] is not permitted"#)],
-                  2)
+            (
+                vec![
+                    String::from(
+                        r#"[NewVolume2] failed because [Encrypted] is [true] and the pattern [true] is not permitted"#
+                    ),
+                    String::from(
+                        r#"[NewVolume] failed because [Encrypted] is [true] and the pattern [true] is not permitted"#
+                    )
+                ],
+                2
+            )
         );
     }
 
     #[test]
     fn test_fail_on_regex_require_not_match_custom_message() {
-        let template_contents =
-            fs::read_to_string("tests/ebs_volume_template.json")
-                .unwrap_or_else(|err| format!("{}", err));
-        let rules_file_content = String::from(r#"AWS::EC2::Volume Encrypted != /true/ << lorem ipsum"#);
+        let template_contents = fs::read_to_string("tests/ebs_volume_template.json")
+            .unwrap_or_else(|err| format!("{}", err));
+        let rules_file_content =
+            String::from(r#"AWS::EC2::Volume Encrypted != /true/ << lorem ipsum"#);
         assert_eq!(
             cfn_guard::run_check(&template_contents, &rules_file_content, true),
-            (vec![String::from(r#"[NewVolume2] failed because [Encrypted] is [true] and lorem ipsum"#),
-                  String::from(r#"[NewVolume] failed because [Encrypted] is [true] and lorem ipsum"#)],
-             2)
+            (
+                vec![
+                    String::from(
+                        r#"[NewVolume2] failed because [Encrypted] is [true] and lorem ipsum"#
+                    ),
+                    String::from(
+                        r#"[NewVolume] failed because [Encrypted] is [true] and lorem ipsum"#
+                    )
+                ],
+                2
+            )
         );
     }
 
     #[test]
     fn test_fail_require_not_custom_message() {
-        let template_contents =
-            fs::read_to_string("tests/ebs_volume_template.json")
-                .unwrap_or_else(|err| format!("{}", err));
-        let rules_file_content = String::from(r#"AWS::EC2::Volume Encrypted != true << lorem ipsum"#);
+        let template_contents = fs::read_to_string("tests/ebs_volume_template.json")
+            .unwrap_or_else(|err| format!("{}", err));
+        let rules_file_content =
+            String::from(r#"AWS::EC2::Volume Encrypted != true << lorem ipsum"#);
         assert_eq!(
             cfn_guard::run_check(&template_contents, &rules_file_content, true),
-            (vec![String::from(r#"[NewVolume2] failed because [Encrypted] is [true] and lorem ipsum"#),
-                  String::from(r#"[NewVolume] failed because [Encrypted] is [true] and lorem ipsum"#)],
-             2)
+            (
+                vec![
+                    String::from(
+                        r#"[NewVolume2] failed because [Encrypted] is [true] and lorem ipsum"#
+                    ),
+                    String::from(
+                        r#"[NewVolume] failed because [Encrypted] is [true] and lorem ipsum"#
+                    )
+                ],
+                2
+            )
         );
     }
 
     #[test]
     fn test_bad_template() {
-        let template_contents =
-            fs::read_to_string("tests/broken_template_file.json")
-                .unwrap_or_else(|err| format!("{}", err));
-        let rules_file_contents = fs::read_to_string("tests/ebs_volume_rule_set_custom_msg.passing")
+        let template_contents = fs::read_to_string("tests/broken_template_file.json")
             .unwrap_or_else(|err| format!("{}", err));
+        let rules_file_contents =
+            fs::read_to_string("tests/ebs_volume_rule_set_custom_msg.passing")
+                .unwrap_or_else(|err| format!("{}", err));
         assert_eq!(
             cfn_guard::run_check(&template_contents, &rules_file_contents, true),
             (vec![String::from("ERROR:  Template file format was unreadable as json or yaml: invalid type: string \"THIS IS MEANT TO BE INVALID\", expected a map at line 1 column 1")], 1)
@@ -217,11 +248,11 @@ mod tests {
 
     #[test]
     fn test_custom_fail_message_pass() {
-        let template_contents =
-            fs::read_to_string("tests/ebs_volume_template.json")
-                .unwrap_or_else(|err| format!("{}", err));
-        let rules_file_contents = fs::read_to_string("tests/ebs_volume_rule_set_custom_msg.passing")
+        let template_contents = fs::read_to_string("tests/ebs_volume_template.json")
             .unwrap_or_else(|err| format!("{}", err));
+        let rules_file_contents =
+            fs::read_to_string("tests/ebs_volume_rule_set_custom_msg.passing")
+                .unwrap_or_else(|err| format!("{}", err));
         assert_eq!(
             cfn_guard::run_check(&template_contents, &rules_file_contents, true),
             (vec![], 0)
@@ -237,11 +268,11 @@ mod tests {
         // Since an |OR| is a join of two discrete rules, you can see how the first half lacks a custom message.
         // I decided to leave that detail in the results to underscore the behavior so that it doesn't get
         // lost in the shuffle.
-        let template_contents =
-            fs::read_to_string("tests/ebs_volume_template.json")
-                .unwrap_or_else(|err| format!("{}", err));
-        let rules_file_contents = fs::read_to_string("tests/ebs_volume_rule_set_custom_msg.failing")
+        let template_contents = fs::read_to_string("tests/ebs_volume_template.json")
             .unwrap_or_else(|err| format!("{}", err));
+        let rules_file_contents =
+            fs::read_to_string("tests/ebs_volume_rule_set_custom_msg.failing")
+                .unwrap_or_else(|err| format!("{}", err));
         let mut outcome = vec![
             String::from("[NewVolume2] failed because [Encrypted] is [true] and enc lorem ipsum"),
             String::from("[NewVolume2] failed because [Size] is [99] and or lorem ipsum"),
@@ -263,7 +294,8 @@ mod tests {
 
     #[test]
     fn test_not_in_list_fail() {
-        let template_contents = String::from(r#"
+        let template_contents = String::from(
+            r#"
                 {
             "Resources": {
                 "NewVolume" : {
@@ -283,7 +315,8 @@ mod tests {
                     }
                 }
             }
-        }"#);
+        }"#,
+        );
 
         let rules_file_contents = fs::read_to_string("tests/test_not_in_list_fail.ruleset")
             .unwrap_or_else(|err| format!("{}", err));
@@ -298,7 +331,8 @@ mod tests {
 
     #[test]
     fn test_in_list_fail_custom_message() {
-        let template_contents = String::from(r#"
+        let template_contents = String::from(
+            r#"
                 {
             "Resources": {
                 "NewVolume" : {
@@ -318,10 +352,12 @@ mod tests {
                     }
                 }
             }
-        }"#);
+        }"#,
+        );
 
-        let rules_file_contents = fs::read_to_string("tests/test_in_list_fail_custom_message.ruleset")
-            .unwrap_or_else(|err| format!("{}", err));
+        let rules_file_contents =
+            fs::read_to_string("tests/test_in_list_fail_custom_message.ruleset")
+                .unwrap_or_else(|err| format!("{}", err));
         assert_eq!(
             cfn_guard::run_check(&template_contents, &rules_file_contents, true),
             (vec![
@@ -890,9 +926,8 @@ AWS::EC2::Volume Size == 101 |OR| AWS::EC2::Volume Size == 99"#,
 
     #[test]
     fn test_diff_wildcard_type_pass() {
-        let template_contents =
-            fs::read_to_string("tests/aws-waf-security-automations.template")
-                .unwrap_or_else(|err| format!("{}", err));
+        let template_contents = fs::read_to_string("tests/aws-waf-security-automations.template")
+            .unwrap_or_else(|err| format!("{}", err));
         let rules_file_contents = fs::read_to_string("tests/wildcard_iam_rule_set.passing")
             .unwrap_or_else(|err| format!("{}", err));
         assert_eq!(
@@ -903,12 +938,10 @@ AWS::EC2::Volume Size == 101 |OR| AWS::EC2::Volume Size == 99"#,
 
     #[test]
     fn test_diff_wildcard_type_fail() {
-        let template_contents =
-            fs::read_to_string("tests/aws-waf-security-automations.template")
-                .unwrap_or_else(|err| format!("{}", err));
-        let rules_file_contents =
-            fs::read_to_string("tests/wildcard_not_in_iam_rule_set.failing")
-                .unwrap_or_else(|err| format!("{}", err));
+        let template_contents = fs::read_to_string("tests/aws-waf-security-automations.template")
+            .unwrap_or_else(|err| format!("{}", err));
+        let rules_file_contents = fs::read_to_string("tests/wildcard_not_in_iam_rule_set.failing")
+            .unwrap_or_else(|err| format!("{}", err));
         assert_eq!(
             cfn_guard::run_check(&template_contents, &rules_file_contents, true),
             (vec![String::from("[LambdaRoleHelper] failed because [lambda.amazonaws.com] is in [lambda.amazonaws.com, ec2.amazonaws.com] which is not permitted for [AssumeRolePolicyDocument.Statement.0.Principal.Service.0]"), ],
@@ -950,11 +983,14 @@ AWS::EC2::Volume Size == 101 |OR| AWS::EC2::Volume Size == 99"#,
         // That shows up as an empty "error:  test failed"
         // Try running with "cargo test -- --nocapture"
         // If you see "Could not load value"... then it's the process exit
-        let template_contents =
-            fs::read_to_string("tests/test_do_not_fail_when_type_lacks_property_for_wildcard.template")
-                .unwrap_or_else(|err| format!("{}", err));
-        let rules_file_contents = fs::read_to_string("tests/test_do_not_fail_when_type_lacks_property_for_wildcard.ruleset")
-            .unwrap_or_else(|err| format!("{}", err));
+        let template_contents = fs::read_to_string(
+            "tests/test_do_not_fail_when_type_lacks_property_for_wildcard.template",
+        )
+        .unwrap_or_else(|err| format!("{}", err));
+        let rules_file_contents = fs::read_to_string(
+            "tests/test_do_not_fail_when_type_lacks_property_for_wildcard.ruleset",
+        )
+        .unwrap_or_else(|err| format!("{}", err));
         assert_eq!(
             cfn_guard::run_check(&template_contents, &rules_file_contents, true),
             (vec![String::from("[NewVolume2] failed because it does not contain the required property of [Tags]"),
@@ -971,11 +1007,14 @@ AWS::EC2::Volume Size == 101 |OR| AWS::EC2::Volume Size == 99"#,
         // That shows up as an empty "error:  test failed"
         // Try running with "cargo test -- --nocapture"
         // If you see "Could not load value"... then it's the process exit
-        let template_contents =
-            fs::read_to_string("tests/test_do_not_fail_when_type_lacks_property_for_wildcard.template")
-                .unwrap_or_else(|err| format!("{}", err));
-        let rules_file_contents = fs::read_to_string("tests/test_do_not_fail_when_type_lacks_property_for_wildcard.ruleset")
-            .unwrap_or_else(|err| format!("{}", err));
+        let template_contents = fs::read_to_string(
+            "tests/test_do_not_fail_when_type_lacks_property_for_wildcard.template",
+        )
+        .unwrap_or_else(|err| format!("{}", err));
+        let rules_file_contents = fs::read_to_string(
+            "tests/test_do_not_fail_when_type_lacks_property_for_wildcard.ruleset",
+        )
+        .unwrap_or_else(|err| format!("{}", err));
         assert_eq!(
             cfn_guard::run_check(&template_contents, &rules_file_contents, false),
             (vec![String::from("[NewVolume] failed because [Tags.0.Key] is [uaid] and the permitted value is [uai]"),

--- a/cfn-guard/tests/functional.rs
+++ b/cfn-guard/tests/functional.rs
@@ -970,8 +970,6 @@ AWS::EC2::Volume Size == 101 |OR| AWS::EC2::Volume Size == 99"#,
         assert_eq!(
             cfn_guard::run_check(&template_contents, &rules_file_contents, true),
             (vec![String::from("[EndpointCloudWatchRoleC3C64E0F] failed because [AssumeRolePolicyDocument.Statement.0.Action] is [sts:AssumeRole] and that value is not permitted"),
-                  String::from("[EndpointCloudWatchRoleC3C64E0F] failed because [AssumeRolePolicyDocument.Statement.0.Action] is [sts:AssumeRole] and that value is not permitted"),
-                  String::from("[HelloHandlerServiceRole11EF7C63] failed because [AssumeRolePolicyDocument.Statement.0.Action] is [sts:AssumeRole] and that value is not permitted"),
                   String::from("[HelloHandlerServiceRole11EF7C63] failed because [AssumeRolePolicyDocument.Statement.0.Action] is [sts:AssumeRole] and that value is not permitted")],
              2)
         );

--- a/cfn-guard/tests/functional.rs
+++ b/cfn-guard/tests/functional.rs
@@ -1056,4 +1056,21 @@ AWS::EC2::Volume Size == 101 |OR| AWS::EC2::Volume Size == 99"#,
              2)
         )
     }
+
+    #[test]
+    fn test_missing_resources_in_template() {
+        let template_contents = fs::read_to_string("tests/no_resources_template.yaml")
+            .unwrap_or_else(|err| format!("{}", err));
+        let rules_file_contents = fs::read_to_string("tests/no_resources_template.ruleset")
+            .unwrap_or_else(|err| format!("{}", err));
+        assert_eq!(
+            cfn_guard::run_check(&template_contents, &rules_file_contents, false),
+            (
+                vec![String::from(
+                    "ERROR:  Template file does not contain a [Resources] section to check"
+                )],
+                1
+            )
+        )
+    }
 }

--- a/cfn-guard/tests/getatt_template.ruleset
+++ b/cfn-guard/tests/getatt_template.ruleset
@@ -2,9 +2,11 @@ let valid_types = [t2.nano,t2.micro,t2.small,t3.nano,t3.micro,t3.small]
 let require_encryption = true
 let disallowed_azs = [us-east-1a,us-east-1b,us-east-1c]
 
+# Test comment
 AWS::EC2::Instance ImageId == LatestAmiId
 AWS::EC2::Instance InstanceType IN %valid_types
 AWS::EC2::SecurityGroup SecurityGroupIngress == [{"CidrIp":"SSHLocation","FromPort":33322,"IpProtocol":"tcp","ToPort":33322}]
+# Test comment
 AWS::EC2::Volume AvailabilityZone IN %disallowed_azs
 AWS::EC2::Volume Encrypted != %require_encryption
 AWS::EC2::Volume Size == 128 |OR| AWS::EC2::Volume Size == 256

--- a/cfn-guard/tests/no_resources_template.ruleset
+++ b/cfn-guard/tests/no_resources_template.ruleset
@@ -1,0 +1,4 @@
+# This is a comment
+AWS::IAM::ManagedPolicy PolicyDocument.Statement.*.Action.* NOT_IN [ec2:CreateTransitGateway]
+
+# This is a comment

--- a/cfn-guard/tests/no_resources_template.yaml
+++ b/cfn-guard/tests/no_resources_template.yaml
@@ -1,0 +1,1 @@
+Outputs:

--- a/cfn-guard/tests/test_do_not_fail_when_type_lacks_property_for_wildcard.ruleset
+++ b/cfn-guard/tests/test_do_not_fail_when_type_lacks_property_for_wildcard.ruleset
@@ -1,3 +1,4 @@
+# Test comment
 AWS::EC2::Volume Encrypted == true
 AWS::EC2::Volume Tags.*.Key == %compliant_tag_name
 AWS::Lambda::Function Tracing IN %tracing_config

--- a/cfn-guard/tests/test_in_list_fail_custom_message.ruleset
+++ b/cfn-guard/tests/test_in_list_fail_custom_message.ruleset
@@ -1,4 +1,5 @@
 let allowed_azs = [us-west-2b,us-west-2c]
+# Test comment
 
 AWS::EC2::Volume AvailabilityZone NOT_IN %allowed_azs << lorem ipsum
 

--- a/cfn-guard/tests/test_not_in_list_fail.ruleset
+++ b/cfn-guard/tests/test_not_in_list_fail.ruleset
@@ -1,4 +1,5 @@
 let allowed_azs = [us-east-1a,us-east-1b,us-east-1c]
 
 AWS::EC2::Volume AvailabilityZone IN %allowed_azs
+# Test comment
 

--- a/cfn-guard/tests/wildcard_action.fail
+++ b/cfn-guard/tests/wildcard_action.fail
@@ -1,1 +1,2 @@
+# Test comment
 AWS::IAM::Role AssumeRolePolicyDocument.Statement.*.Action != sts:AssumeRole

--- a/cfn-guard/tests/wildcard_action.pass
+++ b/cfn-guard/tests/wildcard_action.pass
@@ -1,1 +1,2 @@
 AWS::IAM::Role AssumeRolePolicyDocument.Statement.*.Action == sts:AssumeRole
+# Test comment

--- a/cfn-guard/tests/wildcard_iam_rule_set.failing
+++ b/cfn-guard/tests/wildcard_iam_rule_set.failing
@@ -1,2 +1,3 @@
 AWS::IAM::Role AssumeRolePolicyDocument.Statement.*.Principal.Service.* == lambda.amazonaws.com
+# Test comment
 AWS::IAM::Role AssumeRolePolicyDocument.Statement.*.Principal.Service.* != ec2.amazonaws.com

--- a/cfn-guard/tests/wildcard_iam_rule_set.passing
+++ b/cfn-guard/tests/wildcard_iam_rule_set.passing
@@ -1,1 +1,2 @@
+# Test comment
 AWS::IAM::Role AssumeRolePolicyDocument.Statement.*.Principal.Service.* == lambda.amazonaws.com |OR| AWS::IAM::Role AssumeRolePolicyDocument.Statement.*.Principal.Service.* != ec2.amazonaws.com

--- a/cfn-guard/tests/wildcard_not_in_iam_rule_set.failing
+++ b/cfn-guard/tests/wildcard_not_in_iam_rule_set.failing
@@ -1,3 +1,4 @@
 let prohibited_principals = [lambda.amazonaws.com, ec2.amazonaws.com]
 
+    # Test comment
 AWS::IAM::Role AssumeRolePolicyDocument.Statement.*.Principal.Service.* NOT_IN %prohibited_principals


### PR DESCRIPTION
# Change Log

* Apply `lazy_static` to improve regex performance
* Add new `#` Comment form (issue #4 )
* Move wildcards processing to HashSet to prevent duplicate rules from being created
* Replace runtime unwraps() with proper matching to more gracefully handle template payloads
* Add travis.yml test hooks (thanks @gliptak!)
* Reduce `cfn-guard-lambda` to INFO by default
* Deduplicate `cfn-guard-lambda` Makefile with targets for FAIL, PASS and ERR tests
* Add a `test` target to to the top-level Makefile to allow for easily testing all three cargo projects
* Reorganize the README's to move the run-time parameters more clear (issue #16 )
* Add `issue` and `feature` github templates

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
