### PR TITLE
Move panics to clean process exits

### DIFF
--- a/cfn-guard/README.md
+++ b/cfn-guard/README.md
@@ -85,7 +85,7 @@ Number of failures: 7
 
 We designed `cfn-guard` to be plugged into your build processes.  
 
-If CloudFormation Guard validates the CloudFormation templates successfully, it gives you no output and an exit status (`$?` in bash) of `0`. If CloudFormation Guard identifies a rule violation, it gives you a count of the rule violations, an explanation for why the rules failed, and an exit status of `2`.
+If CloudFormation Guard validates the CloudFormation templates successfully, it gives you no output and an exit status (`$?` in bash) of `0`. If CloudFormation Guard identifies a rule violation, it gives you a count of the rule violations, an explanation for why the rules failed, and an exit status of `2`.  If there's a runtime error with the rule set or processing, it will exit with a `1`. 
 
 If you want CloudFormation Guard to get the result of the rule check but still get an exit value of `0`, use the `-w` Warn flag.
 

--- a/cfn-guard/src/parser.rs
+++ b/cfn-guard/src/parser.rs
@@ -2,8 +2,9 @@
 
 use std::collections::{HashMap, HashSet};
 use std::env;
+use std::process;
 
-use log::{self, debug, trace};
+use log::{self, debug, error, trace};
 use regex::{Captures, Regex};
 use serde_json::Value;
 
@@ -95,7 +96,10 @@ fn find_line_type(line: &str) -> LineType {
     if RULE_REG.is_match(line) {
         return LineType::Rule;
     };
-    panic!("BAD RULE: {:?}", line)
+    let msg_string = format!("BAD RULE: {:?}", line);
+    println!("{}", &msg_string);
+    error!("{}", &msg_string);
+    process::exit(1)
 }
 
 fn process_assignment(line: &str) -> Option<Captures> {
@@ -173,7 +177,13 @@ fn destructure_rule(rule_text: &str, cfn_resources: &HashMap<String, Value>) -> 
                     "!=" => OpCode::RequireNot,
                     "IN" => OpCode::In,
                     "NOT_IN" => OpCode::NotIn,
-                    _ => panic!(format!("Bad Rule Operator: {}", &caps["operator"])),
+                    _ => {
+                        let msg_string =
+                            format!("Bad Rule Operator: {} in {}", &caps["operator"], rule_text);
+                        println!("{}", &msg_string);
+                        error!("{}", &msg_string);
+                        process::exit(1)
+                    }
                 }
             },
             rule_vtype: {
@@ -182,7 +192,15 @@ fn destructure_rule(rule_text: &str, cfn_resources: &HashMap<String, Value>) -> 
                     '[' => match &caps["operator"] {
                         "==" | "!=" => RValueType::Value,
                         "IN" | "NOT_IN" => RValueType::List,
-                        _ => panic!(format!("Bad Rule Operator: {}", &caps["operator"])),
+                        _ => {
+                            let msg_string = format!(
+                                "Bad Rule Operator: {} in {}",
+                                &caps["operator"], rule_text
+                            );
+                            println!("{}", &msg_string);
+                            error!("{}", &msg_string);
+                            process::exit(1)
+                        }
                     },
                     '/' => RValueType::Regex,
                     '%' => RValueType::Variable,

--- a/cfn-guard/src/parser.rs
+++ b/cfn-guard/src/parser.rs
@@ -178,8 +178,10 @@ fn destructure_rule(rule_text: &str, cfn_resources: &HashMap<String, Value>) -> 
                     "IN" => OpCode::In,
                     "NOT_IN" => OpCode::NotIn,
                     _ => {
-                        let msg_string =
-                            format!("Bad Rule Operator: {} in {}", &caps["operator"], rule_text);
+                        let msg_string = format!(
+                            "Bad Rule Operator: [{}] in '{}'",
+                            &caps["operator"], rule_text
+                        );
                         println!("{}", &msg_string);
                         error!("{}", &msg_string);
                         process::exit(1)
@@ -194,7 +196,7 @@ fn destructure_rule(rule_text: &str, cfn_resources: &HashMap<String, Value>) -> 
                         "IN" | "NOT_IN" => RValueType::List,
                         _ => {
                             let msg_string = format!(
-                                "Bad Rule Operator: {} in {}",
+                                "Bad Rule Operator: [{}] in '{}'",
                                 &caps["operator"], rule_text
                             );
                             println!("{}", &msg_string);


### PR DESCRIPTION
# What
Move `panic!`'s on bad rule structures to clean exits with a `$?` of `1`

# Why
Preserves the user experience of stopping when the rule is processed without the ugly stack dump.  Also prints the message to STDOUT and logs it to `error` so that there are multiple records of what happened.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
