### PR TITLE
Add WildCard JSON Lists

### DIFF
--- a/cfn-guard/src/guard_types.rs
+++ b/cfn-guard/src/guard_types.rs
@@ -7,6 +7,7 @@ pub mod enums {
         Assignment,
         Comment,
         Rule,
+        WhiteSpace,
     }
 
     #[derive(Debug, Hash, PartialEq, Eq, Clone)]

--- a/cfn-guard/src/parser.rs
+++ b/cfn-guard/src/parser.rs
@@ -22,6 +22,7 @@ lazy_static! {
     static ref WILDCARD_OR_RULE_REG: Regex = Regex::new(r"(\S+) (\S+\*\S*) (==|IN) (.+)").unwrap();
     static ref RULE_WITH_OPTIONAL_MESSAGE_REG: Regex = Regex::new(
         r"(?P<resource_type>\S+) +(?P<resource_property>[\w\.\*]+) +(?P<operator>\S+) +(?P<rule_value>[^\n\r]+) +<{2} *(?P<custom_msg>.*)").unwrap();
+    static ref WHITE_SPACE_REG: Regex = Regex::new(r"\s+").unwrap();
 }
 
 pub(crate) fn parse_rules(
@@ -88,6 +89,10 @@ pub(crate) fn parse_rules(
                 debug!("Parsed rule is: {:#?}", &compound_rule);
                 rule_set.push(compound_rule);
             }
+            LineType::WhiteSpace => {
+                debug!("Line is white space");
+                continue;
+            }
         }
     }
     for (key, value) in env::vars() {
@@ -112,6 +117,9 @@ fn find_line_type(line: &str) -> LineType {
     if RULE_REG.is_match(line) {
         return LineType::Rule;
     };
+    if WHITE_SPACE_REG.is_match(line) {
+        return LineType::WhiteSpace;
+    }
     let msg_string = format!("BAD RULE: {:?}", line);
     println!("{}", &msg_string);
     error!("{}", &msg_string);

--- a/cfn-guard/src/parser.rs
+++ b/cfn-guard/src/parser.rs
@@ -265,9 +265,11 @@ mod tests {
         let comment = find_line_type("# This is a comment");
         let assignment = find_line_type("let x = assignment");
         let rule = find_line_type("AWS::EC2::Volume Encryption == true");
+        let white_space = find_line_type("         ");
         assert_eq!(comment, crate::enums::LineType::Comment);
         assert_eq!(assignment, crate::enums::LineType::Assignment);
         assert_eq!(rule, crate::enums::LineType::Rule);
+        assert_eq!(white_space, crate::enums::LineType::WhiteSpace)
     }
 
     #[test]

--- a/cfn-guard/src/parser.rs
+++ b/cfn-guard/src/parser.rs
@@ -19,7 +19,7 @@ lazy_static! {
     static ref ASSIGN_REG: Regex = Regex::new(r"let (?P<var_name>\w+) +(?P<operator>\S+) +(?P<var_value>.*)").unwrap();
     static ref RULE_REG: Regex = Regex::new(r"(?P<resource_type>\S+) +(?P<resource_property>[\w\.\*]+) +(?P<operator>\S+) +(?P<rule_value>[^\n\r]+)").unwrap();
     static ref COMMENT_REG: Regex = Regex::new(r#"#(?P<comment>.*)"#).unwrap();
-    static ref WILDCARD_OR_RULE_REG: Regex = Regex::new(r"(\S+) (\S+\*\S*) (==) (.+)").unwrap();
+    static ref WILDCARD_OR_RULE_REG: Regex = Regex::new(r"(\S+) (\S+\*\S*) (==|IN) (.+)").unwrap();
     static ref RULE_WITH_OPTIONAL_MESSAGE_REG: Regex = Regex::new(
         r"(?P<resource_type>\S+) +(?P<resource_property>[\w\.\*]+) +(?P<operator>\S+) +(?P<rule_value>[^\n\r]+) +<{2} *(?P<custom_msg>.*)").unwrap();
 }

--- a/cfn-guard/src/util.rs
+++ b/cfn-guard/src/util.rs
@@ -38,6 +38,7 @@ pub fn convert_list_var_to_vec(rule_val: &str) -> Vec<String> {
     let mut value_vec: Vec<String> = vec![];
     match serde_json::from_str(rule_val) {
         Ok(v) => {
+            debug!("List {} is a json list", rule_val);
             let val: Value = v;
             match val.as_array() {
                 Some(vv) => {
@@ -49,6 +50,7 @@ pub fn convert_list_var_to_vec(rule_val: &str) -> Vec<String> {
             }
         }
         Err(_) => {
+            debug!("List {} is not a json list", rule_val);
             let value_string: String = rule_val
                 .trim_start_matches('[')
                 .trim_end_matches(']')

--- a/cfn-guard/src/util.rs
+++ b/cfn-guard/src/util.rs
@@ -35,16 +35,31 @@ pub fn strip_ws_nl(v: String) -> String {
 }
 
 pub fn convert_list_var_to_vec(rule_val: &str) -> Vec<String> {
-    let value_string: String = rule_val
-        .trim_start_matches('[')
-        .trim_end_matches(']')
-        .replace(" ", "");
-
     let mut value_vec: Vec<String> = vec![];
+    match serde_json::from_str(rule_val) {
+        Ok(v) => {
+            let val: Value = v;
+            match val.as_array() {
+                Some(vv) => {
+                    for vvv in vv {
+                        value_vec.push(vvv.to_string())
+                    }
+                }
+                None => value_vec.push(val.to_string()),
+            }
+        }
+        Err(_) => {
+            let value_string: String = rule_val
+                .trim_start_matches('[')
+                .trim_end_matches(']')
+                .replace(" ", "");
 
-    for vs in value_string.split(',') {
-        value_vec.push(String::from(vs));
-    }
+            for vs in value_string.split(',') {
+                value_vec.push(String::from(vs));
+            }
+        }
+    };
+
     debug!("Rule value_vec is {:?}", &value_vec);
     value_vec
 }

--- a/cfn-guard/tests/functional.rs
+++ b/cfn-guard/tests/functional.rs
@@ -1309,7 +1309,7 @@ AWS::EC2::Volume Size == 101 |OR| AWS::EC2::Volume Size == 99"#,
                 .unwrap_or_else(|err| format!("{}", err));
         let mut rules_file_contents = String::from(
             r#"
-                let tag_vals = [{"Key":"OwnerContact","Value":"OwnerContact"},{"Key":"OwnerContact","Value":{"Ref":"OwnerContact"}}]
+                let tag_vals = ["test", 1, ["a", "b"], {"Key":"OwnerContact","Value":"OwnerContact"},{"Key":"OwnerContact","Value":{"Ref":"OwnerContact"}}]
                 AWS::EC2::SecurityGroup Tags.* NOT_IN %tag_vals
             "#,
         );
@@ -1317,14 +1317,14 @@ AWS::EC2::Volume Size == 101 |OR| AWS::EC2::Volume Size == 99"#,
             cfn_guard::run_check(&template_contents, &rules_file_contents, false),
             (
                 vec![String::from(
-                    r#"[ClusterSg] failed because [{"Key":"OwnerContact","Value":"OwnerContact"}] is in [{"Key":"OwnerContact","Value":"OwnerContact"},{"Key":"OwnerContact","Value":{"Ref":"OwnerContact"}}] which is not permitted for [Tags.1]"#
+                    r#"[ClusterSg] failed because [{"Key":"OwnerContact","Value":"OwnerContact"}] is in ["test", 1, ["a", "b"], {"Key":"OwnerContact","Value":"OwnerContact"},{"Key":"OwnerContact","Value":{"Ref":"OwnerContact"}}] which is not permitted for [Tags.1]"#
                 )],
                 2
             )
         );
         rules_file_contents = String::from(
             r#"
-                let tag_vals = [{"Key":"OwnerContact","Value":"OwnerContact"},{"Key":"OwnerContact","Value":{"Ref":"OwnerContact"}}]
+                let tag_vals = ["test", 1, ["a", "b"], {"Key":"OwnerContact","Value":"OwnerContact"},{"Key":"OwnerContact","Value":{"Ref":"OwnerContact"}}]
                 AWS::EC2::SecurityGroup Tags.* IN %tag_vals
             "#,
         );
@@ -1336,7 +1336,7 @@ AWS::EC2::Volume Size == 101 |OR| AWS::EC2::Volume Size == 99"#,
             .unwrap_or_else(|err| format!("{}", err));
         let mut rules_file_contents = String::from(
             r#"
-                let tag_vals = [{"Key":"OwnerContact","Value":"OwnerContact"},{"Key":"OwnerContact","Value":{"Ref":"OwnerContact"}}]
+                let tag_vals = ["test", 1, ["a", "b"], {"Key":"OwnerContact","Value":"OwnerContact"},{"Key":"OwnerContact","Value":{"Ref":"OwnerContact"}}]
                 AWS::EC2::SecurityGroup Tags.* NOT_IN %tag_vals
             "#,
         );
@@ -1344,14 +1344,14 @@ AWS::EC2::Volume Size == 101 |OR| AWS::EC2::Volume Size == 99"#,
             cfn_guard::run_check(&template_contents, &rules_file_contents, false),
             (
                 vec![String::from(
-                    r#"[ClusterSg] failed because [{"Key":"OwnerContact","Value":{"Ref":"OwnerContact"}}] is in [{"Key":"OwnerContact","Value":"OwnerContact"},{"Key":"OwnerContact","Value":{"Ref":"OwnerContact"}}] which is not permitted for [Tags.1]"#
+                    r#"[ClusterSg] failed because [{"Key":"OwnerContact","Value":{"Ref":"OwnerContact"}}] is in ["test", 1, ["a", "b"], {"Key":"OwnerContact","Value":"OwnerContact"},{"Key":"OwnerContact","Value":{"Ref":"OwnerContact"}}] which is not permitted for [Tags.1]"#
                 )],
                 2
             )
         );
         rules_file_contents = String::from(
             r#"
-                let tag_vals = [{"Key":"OwnerContact","Value":"OwnerContact"},{"Key":"OwnerContact","Value":{"Ref":"OwnerContact"}}]
+                let tag_vals = ["test", 1, ["a", "b"], {"Key":"OwnerContact","Value":"OwnerContact"},{"Key":"OwnerContact","Value":{"Ref":"OwnerContact"}}]
                 AWS::EC2::SecurityGroup Tags.* IN %tag_vals
             "#,
         );

--- a/cfn-guard/tests/parse_lists_with_json_test-template.json
+++ b/cfn-guard/tests/parse_lists_with_json_test-template.json
@@ -1,0 +1,31 @@
+{
+  "Resources": {
+    "ClusterSg": {
+      "Type": "AWS::EC2::SecurityGroup",
+      "Properties": {
+        "Tags": [
+          {
+            "Key": "EnvironmentType",
+            "Value": {"Ref": "EnvironmentType"}
+          },
+          {
+            "Key": "OwnerContact",
+            "Value": {"Ref": "OwnerContact"}
+          },
+          {
+            "Key": "Name",
+            "Value": {"Sub": "${EnvironmentType}-${ClusterName}-sg"}
+          },
+          {
+            "Key": "ClusterName",
+            "Value": {"Ref": "ECSCluster"}
+          },
+          {
+            "Key": "Scope",
+            "Value": "ecs"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/cfn-guard/tests/parse_lists_with_json_test-template.yaml
+++ b/cfn-guard/tests/parse_lists_with_json_test-template.yaml
@@ -1,0 +1,26 @@
+Resources:
+  ClusterSg:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      VpcId:
+        Fn::ImportValue: !Sub ${EnvironmentType}-net-vpc-VpcId
+      GroupDescription: !Sub ${EnvironmentType}-sg-${ClusterName}
+      SecurityGroupEgress:
+        - CidrIp: "0.0.0.0/0"
+          IpProtocol : "-1"
+          Description: "Allow all outgoing traffic"
+      SecurityGroupIngress:
+        - SourceSecurityGroupId: !Ref AlbSg
+          IpProtocol : "-1"
+          Description: !Sub "Allow incoming traffic from ${ClusterName} ALB"
+      Tags:
+        - Key: EnvironmentType
+          Value: !Ref EnvironmentType
+        - Key: OwnerContact
+          Value: !Ref OwnerContact
+        - Key: Name
+          Value: !Sub ${EnvironmentType}-${ClusterName}-sg
+        - Key: ClusterName
+          Value: !Ref ECSCluster
+        - Key: Scope
+          Value: ecs


### PR DESCRIPTION
*Issue #, if available:*
Addressing some parts of issue #27 

# What 
* Add the ability of wildcards to match against lists
* Create JSON list type
* Add a guard for extraneous whitespace lines
* Update the README to discuss new wildcard and JSON list behavior

# Why
* To allow for somewhat-more-graceful handling of the different parsing of intrinsics by allowing for rules like:
```
let tag_vals = [{"Key":"OwnerContact","Value":"OwnerContact"},{"Key":"OwnerContact","Value":{"Ref":"OwnerContact"}}]
AWS::EC2::SecurityGroup Tags.* NOT_IN %tag_vals 
```
* To fix a list parsing issue with json inside a list form and flatten it out to strings like the other list items
* To prevent strange edge cases with whitespace lines
* To document the changes.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
