### PR TITLE
Nathanmc cleaner exits

### DIFF
--- a/cfn-guard-rulegen-lambda/src/main.rs
+++ b/cfn-guard-rulegen-lambda/src/main.rs
@@ -3,7 +3,7 @@
 use std::error::Error;
 use cfn_guard_rulegen;
 use lambda_runtime::{error::HandlerError, lambda, Context};
-use log::{self, debug};
+use log::{self, info};
 use serde_derive::{Deserialize, Serialize};
 use simple_logger;
 
@@ -28,7 +28,7 @@ struct CustomOutput {
 
 fn my_handler(e: CustomEvent, _c: Context) -> Result<CustomOutput, HandlerError> {
 
-    debug!("Template is [{}]", &e.template);
+    info!("Template is [{}]", &e.template);
     let result = cfn_guard_rulegen::run_gen(&e.template);
 
     Ok(CustomOutput {

--- a/cfn-guard/src/parser.rs
+++ b/cfn-guard/src/parser.rs
@@ -64,7 +64,6 @@ pub(crate) fn parse_rules(
                         "Bad Assignment Operator: [{}] in '{}'",
                         &caps["operator"], l
                     );
-                    println!("{}", &msg_string);
                     error!("{}", &msg_string);
                     process::exit(1)
                 }
@@ -122,7 +121,6 @@ fn find_line_type(line: &str) -> LineType {
         return LineType::WhiteSpace;
     }
     let msg_string = format!("BAD RULE: {:?}", line);
-    println!("{}", &msg_string);
     error!("{}", &msg_string);
     process::exit(1)
 }
@@ -211,7 +209,6 @@ fn destructure_rule(rule_text: &str, cfn_resources: &HashMap<String, Value>) -> 
                             "Bad Rule Operator: [{}] in '{}'",
                             &caps["operator"], rule_text
                         );
-                        println!("{}", &msg_string);
                         error!("{}", &msg_string);
                         process::exit(1)
                     }
@@ -228,7 +225,6 @@ fn destructure_rule(rule_text: &str, cfn_resources: &HashMap<String, Value>) -> 
                                 "Bad Rule Operator: [{}] in '{}'",
                                 &caps["operator"], rule_text
                             );
-                            println!("{}", &msg_string);
                             error!("{}", &msg_string);
                             process::exit(1)
                         }

--- a/cfn-guard/src/util.rs
+++ b/cfn-guard/src/util.rs
@@ -246,7 +246,6 @@ pub fn expand_wildcard_props(
 
 // TODO: Move all in-proc exits to clean_exit()
 // pub fn clean_exit(msg_string: String) {
-//     println!("{}", &msg_string);
 //     error!("{}", &msg_string);
 //     process::exit(1)
 // }
@@ -258,7 +257,6 @@ pub fn parse_value_as_float(val: &Value) -> f32 {
         Ok(s) => s,
         Err(_) => {
             let msg_string = format!("Value cannot be parsed as a float: {}", val);
-            println!("{}", &msg_string);
             error!("{}", &msg_string);
             process::exit(1)
         }
@@ -270,7 +268,6 @@ pub fn parse_str_as_float(val: &str) -> f32 {
         Ok(s) => s,
         Err(_) => {
             let msg_string = format!("String cannot be parsed as a float: {}", val);
-            println!("{}", &msg_string);
             error!("{}", &msg_string);
             process::exit(1)
         }


### PR DESCRIPTION
*Issue #, if available:*

# What
* Remove redundant println's from cfn-guard clean exits
* Harden rulegen against panics
# Why
* cfn-guard already logs ERROR to console
* To handle behaviors more cleanly locally and to get better messages back from the lambda

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
