### PR TITLE
Release 0.6.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ cloudformation-guard.tar.gz
 .idea/
 *~
 cmake-build-debug
+*gcno
+*gcda

--- a/Examples/conditional-ddb-template.ruleset
+++ b/Examples/conditional-ddb-template.ruleset
@@ -1,0 +1,3 @@
+# https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-product-attribute-reference.html
+AWS::DynamoDB::Table if Tags == /.*PROD.*/ then .DeletionPolicy == Retain
+AWS::DynamoDB::Table if Tags == /.*PROD.*/ then .DeletionPolicy != Retain

--- a/Examples/conditional-ddb-template.yaml
+++ b/Examples/conditional-ddb-template.yaml
@@ -1,0 +1,64 @@
+{
+  "Resources": {
+    "DDBTable": {
+      "Type": "AWS::DynamoDB::Table",
+      "UpdateReplacePolicy": "Abort",
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "AttributeDefinitions": [
+          {
+            "AttributeName": "ArtistId",
+            "AttributeType": "S"
+          },
+          {
+            "AttributeName": "Concert",
+            "AttributeType": "S"
+          },
+          {
+            "AttributeName": "TicketSales",
+            "AttributeType": "S"
+          }
+        ],
+        "KeySchema": [
+          {
+            "AttributeName": "ArtistId",
+
+            "KeyType": "HASH"
+          },
+          {
+            "AttributeName": "Concert",
+            "KeyType": "RANGE"
+          }
+        ],
+        "GlobalSecondaryIndexes": [
+          {
+
+            "IndexName": "GSI",
+            "KeySchema": [
+
+              {
+
+                "AttributeName": "TicketSales",
+                "KeyType": "HASH"
+              }
+            ],
+            "Projection": {
+              "ProjectionType": "KEYS_ONLY"
+            },
+            "ProvisionedThroughput": {
+              "ReadCapacityUnits": 5,
+              "WriteCapacityUnits": 5
+            }
+          }
+        ],
+        "ProvisionedThroughput": {
+          "ReadCapacityUnits": 5,
+          "WriteCapacityUnits": 5
+        },
+        "Tags": [
+          {"Key": "ENV", "Value": "PROD"}
+        ]
+      }
+    }
+  }
+}

--- a/Examples/ddb-template.yaml
+++ b/Examples/ddb-template.yaml
@@ -1,0 +1,64 @@
+{
+  "Resources": {
+    "DDBTable": {
+      "Type": "AWS::DynamoDB::Table",
+      "UpdateReplacePolicy": "Abort",
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "AttributeDefinitions": [
+          {
+            "AttributeName": "ArtistId",
+            "AttributeType": "S"
+          },
+          {
+            "AttributeName": "Concert",
+            "AttributeType": "S"
+          },
+          {
+            "AttributeName": "TicketSales",
+            "AttributeType": "S"
+          }
+        ],
+        "KeySchema": [
+          {
+            "AttributeName": "ArtistId",
+
+            "KeyType": "HASH"
+          },
+          {
+            "AttributeName": "Concert",
+            "KeyType": "RANGE"
+          }
+        ],
+        "GlobalSecondaryIndexes": [
+          {
+
+            "IndexName": "GSI",
+            "KeySchema": [
+
+              {
+
+                "AttributeName": "TicketSales",
+                "KeyType": "HASH"
+              }
+            ],
+            "Projection": {
+              "ProjectionType": "KEYS_ONLY"
+            },
+            "ProvisionedThroughput": {
+              "ReadCapacityUnits": 5,
+              "WriteCapacityUnits": 5
+            }
+          }
+        ],
+        "ProvisionedThroughput": {
+          "ReadCapacityUnits": 5,
+          "WriteCapacityUnits": 5
+        },
+        "Tags": [
+          {"Key": "ENV", "Value": "PROD"}
+        ]
+      }
+    }
+  }
+}

--- a/Examples/ddb.ruleset
+++ b/Examples/ddb.ruleset
@@ -1,0 +1,1 @@
+AWS::DynamoDB::Table if Tags == /.*PROD.*/ then .DeletionPolicy == Retain

--- a/Examples/ebs-volume-template.json
+++ b/Examples/ebs-volume-template.json
@@ -3,7 +3,7 @@
         "NewVolume" : {
             "Type" : "AWS::EC2::Volume",
             "Properties" : {
-                "Size" : 101,
+                "Size" : 500,
                 "Encrypted": false,
                 "AvailabilityZone" : "us-west-2b"
             }
@@ -11,7 +11,7 @@
         "NewVolume2" : {
             "Type" : "AWS::EC2::Volume",
             "Properties" : {
-                "Size" : 99,
+                "Size" : 50,
                 "Encrypted": false,
                 "AvailabilityZone" : "us-west-2c"
             }

--- a/Examples/ebs-volume-template.ruleset
+++ b/Examples/ebs-volume-template.ruleset
@@ -1,6 +1,4 @@
 let encryption_flag = true
-let allowed_azs = [us-east-1a,us-east-1b,us-east-1c]
 
-AWS::EC2::Volume AvailabilityZone IN %allowed_azs
 AWS::EC2::Volume Encrypted == %encryption_flag
-AWS::EC2::Volume Size == 100
+AWS::EC2::Volume Size <= 100

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ For example, given a CloudFormation template:
         "NewVolume" : {
             "Type" : "AWS::EC2::Volume",
             "Properties" : {
-                "Size" : 101,
+                "Size" : 500,
                 "Encrypted": false,
                 "AvailabilityZone" : "us-west-2b"
             }
@@ -27,7 +27,7 @@ For example, given a CloudFormation template:
         "NewVolume2" : {
             "Type" : "AWS::EC2::Volume",
             "Properties" : {
-                "Size" : 99,
+                "Size" : 50,
                 "Encrypted": false,
                 "AvailabilityZone" : "us-west-2c"
             }
@@ -40,24 +40,20 @@ And a set of rules:
 
 ```
 let encryption_flag = true
-let allowed_azs = [us-east-1a,us-east-1b,us-east-1c]
 
-AWS::EC2::Volume AvailabilityZone IN %allowed_azs
 AWS::EC2::Volume Encrypted == %encryption_flag
-AWS::EC2::Volume Size == 100
+AWS::EC2::Volume Size <= 100
 ```
 
 You can check the template to ensure that it adheres to the rules.
 
 ```
 $> cfn-guard -t Examples/ebs_volume_template.json -r Examples/ebs_volume_template.ruleset
-   "[NewVolume2] failed because [Encrypted] is [false] and the permitted value is [true]"
-   "[NewVolume2] failed because [Size] is [99] and the permitted value is [100]"
-   "[NewVolume2] failed because [us-west-2c] is not in [us-east-1a,us-east-1b,us-east-1c] for [AvailabilityZone]"
-   "[NewVolume] failed because [Encrypted] is [false] and the permitted value is [true]"
-   "[NewVolume] failed because [Size] is [101] and the permitted value is [100]"
-   "[NewVolume] failed because [us-west-2b] is not in [us-east-1a,us-east-1b,us-east-1c] for [AvailabilityZone]"
-   Number of failures: 6 
+
+[NewVolume2] failed because [Encrypted] is [false] and the permitted value is [true]
+[NewVolume] failed because [Encrypted] is [false] and the permitted value is [true]
+[NewVolume] failed because [Size] is [500] and the permitted value is [<= 100]
+Number of failures: 3
 ```
 
 ### Evaluating Security Policies

--- a/cfn-guard-lambda/Cargo.lock
+++ b/cfn-guard-lambda/Cargo.lock
@@ -88,7 +88,7 @@ checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
 name = "cfn-guard"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "clap",
  "lazy_static",
@@ -102,7 +102,7 @@ dependencies = [
 
 [[package]]
 name = "cfn-guard-lambda"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "cfn-guard",
  "lambda_runtime",

--- a/cfn-guard-lambda/Cargo.toml
+++ b/cfn-guard-lambda/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cfn-guard-lambda"
-version = "0.5.2"
+version = "0.6.0"
 edition = "2018"
 
 [dependencies]

--- a/cfn-guard-lambda/src/main.rs
+++ b/cfn-guard-lambda/src/main.rs
@@ -34,7 +34,11 @@ fn my_handler(e: CustomEvent, _c: Context) -> Result<CustomOutput, HandlerError>
     //dbg!(&e);
     info!("Template is [{}]", &e.template);
     info!("Rule Set is [{}]", &e.rule_set);
-    let (result, exit_code) = cfn_guard::run_check(&e.template, &e.rule_set, e.strict_checks);
+    let (result, exit_code) = match cfn_guard::run_check(&e.template, &e.rule_set, e.strict_checks)
+    {
+        Ok(t) => t,
+        Err(e) => (vec![e], 1),
+    };
 
     let exit_status = match exit_code {
         0 => "PASS",

--- a/cfn-guard-rulegen-lambda/Cargo.lock
+++ b/cfn-guard-rulegen-lambda/Cargo.lock
@@ -89,7 +89,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "cfn-guard-rulegen"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -101,9 +101,9 @@ dependencies = [
 
 [[package]]
 name = "cfn-guard-rulegen-lambda"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
- "cfn-guard-rulegen 0.5.2",
+ "cfn-guard-rulegen 0.6.0",
  "lambda_runtime 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.95 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/cfn-guard-rulegen-lambda/Cargo.toml
+++ b/cfn-guard-rulegen-lambda/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cfn-guard-rulegen-lambda"
-version = "0.5.2"
+version = "0.6.0"
 edition = "2018"
 
 [dependencies]

--- a/cfn-guard-rulegen/Cargo.lock
+++ b/cfn-guard-rulegen/Cargo.lock
@@ -40,7 +40,7 @@ checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
 name = "cfn-guard-rulegen"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "clap",
  "log",

--- a/cfn-guard-rulegen/Cargo.toml
+++ b/cfn-guard-rulegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cfn-guard-rulegen"
-version = "0.5.2"
+version = "0.6.0"
 edition = "2018"
 
 [dependencies]

--- a/cfn-guard-rulegen/src/main.rs
+++ b/cfn-guard-rulegen/src/main.rs
@@ -35,12 +35,13 @@ fn main() {
 
     info!("Generating rules from {}", &template_file);
 
-    let result = cfn_guard_rulegen::run(template_file).unwrap_or_else(|err| {
+    let mut result = cfn_guard_rulegen::run(template_file).unwrap_or_else(|err| {
         println!("Problem generating rules: {}", err);
         process::exit(1);
     });
 
     if !result.is_empty() {
+	result.sort();
         for res in result.iter() {
             println!("{}", res);
         }

--- a/cfn-guard/Cargo.lock
+++ b/cfn-guard/Cargo.lock
@@ -49,7 +49,7 @@ checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
 name = "cfn-guard"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "clap",
  "lazy_static",

--- a/cfn-guard/Cargo.toml
+++ b/cfn-guard/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cfn-guard"
-version = "0.5.2"
+version = "0.6.0"
 edition = "2018"
 
 [dependencies]

--- a/cfn-guard/src/guard_types.rs
+++ b/cfn-guard/src/guard_types.rs
@@ -40,7 +40,8 @@ pub mod enums {
     pub enum RuleType {
         CompoundRule(super::structs::CompoundRule),
         ConditionalRule(super::structs::ConditionalRule),
-        SimpleRule(super::structs::Rule),
+        SimpleRule(super::structs::Rule), // SimpleRule is a rule that cannot be reduced/transformed any further
+                                          // It's the base case for recursing into rule processing
     }
 }
 

--- a/cfn-guard/src/guard_types.rs
+++ b/cfn-guard/src/guard_types.rs
@@ -30,16 +30,17 @@ pub mod enums {
         Regex,
         Variable,
     }
-    #[derive(Debug, Clone, Eq, PartialEq)]
+    #[derive(Debug, Clone, Eq, PartialEq, Hash)]
     pub enum CompoundType {
         OR,
         AND,
     }
 
-    #[derive(Debug, Clone)]
+    #[derive(Debug, Clone, Eq, PartialEq, Hash)]
     pub enum RuleType {
         CompoundRule(super::structs::CompoundRule),
         ConditionalRule(super::structs::ConditionalRule),
+        SimpleRule(super::structs::Rule),
     }
 }
 
@@ -56,14 +57,14 @@ pub mod structs {
         pub(crate) custom_msg: Option<String>,
     }
 
-    #[derive(Debug, Clone, Eq, PartialEq)]
+    #[derive(Debug, Clone, Eq, PartialEq, Hash)]
     pub struct CompoundRule {
         pub(crate) compound_type: super::enums::CompoundType,
         pub(crate) raw_rule: String,
-        pub(crate) rule_list: Vec<Rule>,
+        pub(crate) rule_list: Vec<super::enums::RuleType>,
     }
 
-    #[derive(Debug, Clone, Eq, PartialEq)]
+    #[derive(Debug, Clone, Eq, PartialEq, Hash)]
     pub struct ConditionalRule {
         pub(crate) condition: CompoundRule,
         pub(crate) consequent: CompoundRule,

--- a/cfn-guard/src/guard_types.rs
+++ b/cfn-guard/src/guard_types.rs
@@ -6,6 +6,7 @@ pub mod enums {
     pub enum LineType {
         Assignment,
         Comment,
+        Conditional,
         Rule,
         WhiteSpace,
     }
@@ -34,6 +35,12 @@ pub mod enums {
         OR,
         AND,
     }
+
+    #[derive(Debug, Clone)]
+    pub enum RuleType {
+        CompoundRule(super::structs::CompoundRule),
+        ConditionalRule(super::structs::ConditionalRule),
+    }
 }
 
 pub mod structs {
@@ -49,15 +56,21 @@ pub mod structs {
         pub(crate) custom_msg: Option<String>,
     }
 
-    #[derive(Debug, Eq, PartialEq)]
+    #[derive(Debug, Clone, Eq, PartialEq)]
     pub struct CompoundRule {
         pub(crate) compound_type: super::enums::CompoundType,
         pub(crate) rule_list: Vec<Rule>,
     }
 
-    #[derive(Debug, Eq, PartialEq)]
+    #[derive(Debug, Clone, Eq, PartialEq)]
+    pub struct ConditionalRule {
+        pub(crate) condition: CompoundRule,
+        pub(crate) consequent: CompoundRule,
+    }
+
+    #[derive(Debug)]
     pub struct ParsedRuleSet {
         pub(crate) variables: HashMap<String, String>,
-        pub(crate) rule_set: Vec<CompoundRule>,
+        pub(crate) rule_set: Vec<super::enums::RuleType>,
     }
 }

--- a/cfn-guard/src/guard_types.rs
+++ b/cfn-guard/src/guard_types.rs
@@ -59,6 +59,7 @@ pub mod structs {
     #[derive(Debug, Clone, Eq, PartialEq)]
     pub struct CompoundRule {
         pub(crate) compound_type: super::enums::CompoundType,
+        pub(crate) raw_rule: String,
         pub(crate) rule_list: Vec<Rule>,
     }
 

--- a/cfn-guard/src/lib.rs
+++ b/cfn-guard/src/lib.rs
@@ -350,11 +350,12 @@ fn apply_rule(
             let (property_root, address) = match target_field.first() {
                 Some(x) => {
                     if *x == "" {
+                        // If the first address segment is a '.'
                         target_field.remove(0);
-                        target_field.insert(0, ".");
-                        (cfn_resource, target_field)
+                        target_field.insert(0, "."); // Replace the empty first element with a "."
+                        (cfn_resource, target_field) // Return the root of the Value for lookup
                     } else {
-                        (&cfn_resource["Properties"], target_field)
+                        (&cfn_resource["Properties"], target_field) // Otherwise, treat it as a normal property lookup
                     }
                 }
                 None => {

--- a/cfn-guard/src/lib.rs
+++ b/cfn-guard/src/lib.rs
@@ -137,7 +137,7 @@ fn check_resources(
                             variables: parsed_rule_set.variables.clone(),
                             rule_set: vec![enums::RuleType::CompoundRule(r.clone().consequent)],
                         };
-                        let postscript = format!("when {:?}", r.condition.rule_list);
+                        let postscript = format!("when {}", r.condition.raw_rule);
                         let temp_result =
                             check_resources(&cfn_resource_map, &consequent_rule_set, strict_checks)
                                 .into_iter()

--- a/cfn-guard/src/lib.rs
+++ b/cfn-guard/src/lib.rs
@@ -163,9 +163,6 @@ fn check_resources(
             }
         }
     }
-    if result.is_empty() {
-        info!("All CloudFormation resources passed");
-    }
     result
 }
 

--- a/cfn-guard/src/lib.rs
+++ b/cfn-guard/src/lib.rs
@@ -147,7 +147,8 @@ fn check_resources(
                     // Use the existing rules logic to see if there's a hit on the Condition clause
                     match check_resources(&cfn_resource_map, &condition_rule_set, true) {
                         Some(_) => (), // A result from a condition check means that it *wasn't* met (by def)
-                        None => {
+                    None => {
+                            trace!("Condition met for {}", r.condition.raw_rule);
                             let consequent_rule_set = structs::ParsedRuleSet {
                                 variables: parsed_rule_set.variables.clone(),
                                 rule_set: vec![enums::RuleType::CompoundRule(r.clone().consequent)],
@@ -193,8 +194,8 @@ fn check_resources(
                                 }
                             }
                         }
-                        trace! {"pass_fail set is {:?}", &pass_fail};
                         trace! {"temp_results are {:?}", &temp_results};
+                        trace! {"pass_fail set is {:?}", &pass_fail};
                         if !pass_fail.contains("pass") {
                             result.extend(temp_results);
                         }

--- a/cfn-guard/src/main.rs
+++ b/cfn-guard/src/main.rs
@@ -87,5 +87,7 @@ fn main() {
         } else {
             process::exit(exit_code as i32);
         }
+    } else {
+        info!("All CloudFormation resources passed");
     }
 }

--- a/cfn-guard/src/parser.rs
+++ b/cfn-guard/src/parser.rs
@@ -16,7 +16,7 @@ use lazy_static::lazy_static;
 // This sets it up so the regexen only get compiled once
 // See: https://docs.rs/regex/1.3.9/regex/#example-avoid-compiling-the-same-regex-in-a-loop
 lazy_static! {
-    static ref ASSIGN_REG: Regex = Regex::new(r"let (?P<var_name>\w+) +(?P<operator>\S+) +(?P<var_value>.*)").unwrap();
+    static ref ASSIGN_REG: Regex = Regex::new(r"let (?P<var_name>\w+) +(?P<operator>\S+) +(?P<var_value>.+)").unwrap();
     static ref RULE_REG: Regex = Regex::new(r"(?P<resource_type>\S+) +(?P<resource_property>[\w\.\*]+) +(?P<operator>\S+) +(?P<rule_value>[^\n\r]+)").unwrap();
     static ref COMMENT_REG: Regex = Regex::new(r#"#(?P<comment>.*)"#).unwrap();
     static ref WILDCARD_OR_RULE_REG: Regex = Regex::new(r"(\S+) (\S+\*\S*) (==|IN) (.+)").unwrap();

--- a/cfn-guard/src/parser.rs
+++ b/cfn-guard/src/parser.rs
@@ -321,7 +321,7 @@ fn destructure_rule(
                                 &caps["operator"], rule_text
                             );
                             error!("{}", &msg_string);
-                            process::exit(1)
+                            return Err(msg_string);
                         }
                     }
                 },
@@ -337,7 +337,7 @@ fn destructure_rule(
                                     &caps["operator"], rule_text
                                 );
                                 error!("{}", &msg_string);
-                                process::exit(1)
+                                return Err(msg_string);
                             }
                         },
                         '/' => RValueType::Regex,

--- a/cfn-guard/src/parser.rs
+++ b/cfn-guard/src/parser.rs
@@ -17,11 +17,11 @@ use lazy_static::lazy_static;
 // See: https://docs.rs/regex/1.3.9/regex/#example-avoid-compiling-the-same-regex-in-a-loop
 lazy_static! {
     static ref ASSIGN_REG: Regex = Regex::new(r"let (?P<var_name>\w+) +(?P<operator>\S+) +(?P<var_value>.+)").unwrap();
-    static ref RULE_REG: Regex = Regex::new(r"(?P<resource_type>\S+) +(?P<resource_property>[\w\.\*]+) +(?P<operator>\S+) +(?P<rule_value>[^\n\r]+)").unwrap();
+    static ref RULE_REG: Regex = Regex::new(r"^(?P<resource_type>\S+) +(?P<resource_property>[\w\.\*]+) +(?P<operator>==|!=|<|>|<=|>=|IN|NOT_IN) +(?P<rule_value>[^\n\r]+)").unwrap();
     static ref COMMENT_REG: Regex = Regex::new(r#"#(?P<comment>.*)"#).unwrap();
     static ref WILDCARD_OR_RULE_REG: Regex = Regex::new(r"(\S+) (\S+\*\S*) (==|IN) (.+)").unwrap();
     static ref RULE_WITH_OPTIONAL_MESSAGE_REG: Regex = Regex::new(
-        r"(?P<resource_type>\S+) +(?P<resource_property>[\w\.\*]+) +(?P<operator>\S+) +(?P<rule_value>[^\n\r]+) +<{2} *(?P<custom_msg>.*)").unwrap();
+        r"^(?P<resource_type>\S+) +(?P<resource_property>[\w\.\*]+) +(?P<operator>==|!=|<|>|<=|>=|IN|NOT_IN) +(?P<rule_value>[^\n\r]+) +<{2} *(?P<custom_msg>.*)").unwrap();
     static ref WHITE_SPACE_REG: Regex = Regex::new(r"\s+").unwrap();
     static ref CONDITIONAL_RULE_REG: Regex = Regex::new(r"(?P<resource_type>\S+) +if +(?P<condition>.+) +then +(?P<consequent>.*)").unwrap();
 }

--- a/cfn-guard/src/parser.rs
+++ b/cfn-guard/src/parser.rs
@@ -2,7 +2,6 @@
 
 use std::collections::{HashMap, HashSet};
 use std::env;
-use std::process;
 
 use log::{self, debug, error, trace};
 use regex::{Captures, Regex};
@@ -70,7 +69,7 @@ pub(crate) fn parse_rules(
                         &caps["operator"], trimmed_line
                     );
                     error!("{}", &msg_string);
-                    process::exit(1)
+                    return Err(msg_string);
                 }
                 let var_name = caps["var_name"].to_string();
                 let var_value = caps["var_value"].to_string();

--- a/cfn-guard/src/parser.rs
+++ b/cfn-guard/src/parser.rs
@@ -44,7 +44,10 @@ pub(crate) fn parse_rules(
     let mut variables = HashMap::new();
 
     let lines = rules_file_contents.lines();
-    trace!("Rules file lines: {:#?}", &lines);
+    trace!(
+        "Rules file lines: {:#?}",
+        lines.clone().into_iter().collect::<Vec<&str>>()
+    );
 
     for l in lines {
         debug!("Parsing '{}'", &l);

--- a/cfn-guard/src/parser.rs
+++ b/cfn-guard/src/parser.rs
@@ -173,6 +173,7 @@ fn process_or_rule(line: &str, cfn_resources: &HashMap<String, Value>) -> Compou
     }
     CompoundRule {
         compound_type: CompoundType::OR,
+        raw_rule: line.to_string(),
         rule_list: rules,
     }
 }
@@ -180,6 +181,7 @@ fn process_or_rule(line: &str, cfn_resources: &HashMap<String, Value>) -> Compou
 fn process_and_rule(line: &str, cfn_resources: &HashMap<String, Value>) -> CompoundRule {
     CompoundRule {
         compound_type: CompoundType::AND,
+        raw_rule: line.to_string(),
         rule_list: destructure_rule(line, cfn_resources),
     }
 }

--- a/cfn-guard/src/parser.rs
+++ b/cfn-guard/src/parser.rs
@@ -138,6 +138,14 @@ fn process_conditional(
     let caps = CONDITIONAL_RULE_REG.captures(line).unwrap();
     trace!("ConditionalRule regex captures are {:#?}", &caps);
 
+    if RULE_REG.is_match(&caps["condition"])
+        || RULE_WITH_OPTIONAL_MESSAGE_REG.is_match(&caps["condition"])
+    {
+        return Err(format!(
+            "Invalid condition: '{}' in '{}'",
+            &caps["condition"], line
+        ));
+    }
     let conjd_caps_conditional = format!("{} {}", &caps["resource_type"], &caps["condition"]);
     trace!("conjd_caps_conditional is {:#?}", conjd_caps_conditional);
     match parse_rule_line(&conjd_caps_conditional, cfn_resources) {
@@ -146,6 +154,14 @@ fn process_conditional(
                 RuleType::CompoundRule(s) => s,
                 _ => return Err(format!("Bad destructure of conditional rule: {}", line)),
             };
+            if RULE_REG.is_match(&caps["consequent"])
+                || RULE_WITH_OPTIONAL_MESSAGE_REG.is_match(&caps["consequent"])
+            {
+                return Err(format!(
+                    "Invalid consequent: '{}' in '{}'",
+                    &caps["consequent"], line
+                ));
+            }
             let conjd_caps_consequent =
                 format!("{} {}", &caps["resource_type"], &caps["consequent"]);
             trace!("conjd_caps_consequent is {:#?}", conjd_caps_consequent);

--- a/cfn-guard/src/parser.rs
+++ b/cfn-guard/src/parser.rs
@@ -18,7 +18,7 @@ lazy_static! {
     static ref ASSIGN_REG: Regex = Regex::new(r"let (?P<var_name>\w+) +(?P<operator>\S+) +(?P<var_value>.+)").unwrap();
     static ref RULE_REG: Regex = Regex::new(r"^(?P<resource_type>\S+) +(?P<resource_property>[\w\.\*]+) +(?P<operator>==|!=|<|>|<=|>=|IN|NOT_IN) +(?P<rule_value>[^\n\r]+)").unwrap();
     static ref COMMENT_REG: Regex = Regex::new(r#"#(?P<comment>.*)"#).unwrap();
-    static ref WILDCARD_OR_RULE_REG: Regex = Regex::new(r"(\S+) (\S+\*\S*) (==|IN) (.+)").unwrap();
+    static ref WILDCARD_OR_RULE_REG: Regex = Regex::new(r"(\S+) (\S*\*\S*) (==|IN) (.+)").unwrap();
     static ref RULE_WITH_OPTIONAL_MESSAGE_REG: Regex = Regex::new(
         r"^(?P<resource_type>\S+) +(?P<resource_property>[\w\.\*]+) +(?P<operator>==|!=|<|>|<=|>=|IN|NOT_IN) +(?P<rule_value>[^\n\r]+) +<{2} *(?P<custom_msg>.*)").unwrap();
     static ref WHITE_SPACE_REG: Regex = Regex::new(r"^\s+$").unwrap();

--- a/cfn-guard/src/parser.rs
+++ b/cfn-guard/src/parser.rs
@@ -160,7 +160,7 @@ fn process_conditional(
                 || RULE_WITH_OPTIONAL_MESSAGE_REG.is_match(&caps["consequent"])
             {
                 return Err(format!(
-                    "Invalid consequent: '{}' in '{}'",
+                    "Invalid consequent: '{}' in '{}'. Consequents cannot contain resource types.",
                     &caps["consequent"], line
                 ));
             }

--- a/cfn-guard/src/parser.rs
+++ b/cfn-guard/src/parser.rs
@@ -21,8 +21,8 @@ lazy_static! {
     static ref WILDCARD_OR_RULE_REG: Regex = Regex::new(r"(\S+) (\S+\*\S*) (==|IN) (.+)").unwrap();
     static ref RULE_WITH_OPTIONAL_MESSAGE_REG: Regex = Regex::new(
         r"^(?P<resource_type>\S+) +(?P<resource_property>[\w\.\*]+) +(?P<operator>==|!=|<|>|<=|>=|IN|NOT_IN) +(?P<rule_value>[^\n\r]+) +<{2} *(?P<custom_msg>.*)").unwrap();
-    static ref CONDITIONAL_RULE_REG: Regex = Regex::new(r"(?P<resource_type>\S+) +if +(?P<condition>.+) +then +(?P<consequent>.*)").unwrap();
     static ref WHITE_SPACE_REG: Regex = Regex::new(r"^\s+$").unwrap();
+    static ref CONDITIONAL_RULE_REG: Regex = Regex::new(r"(?P<resource_type>\S+) +(when|WHEN) +(?P<condition>.+) +(check|CHECK) +(?P<consequent>.*)").unwrap();
 }
 
 pub(crate) fn parse_rules(

--- a/cfn-guard/src/parser.rs
+++ b/cfn-guard/src/parser.rs
@@ -22,8 +22,8 @@ lazy_static! {
     static ref WILDCARD_OR_RULE_REG: Regex = Regex::new(r"(\S+) (\S+\*\S*) (==|IN) (.+)").unwrap();
     static ref RULE_WITH_OPTIONAL_MESSAGE_REG: Regex = Regex::new(
         r"^(?P<resource_type>\S+) +(?P<resource_property>[\w\.\*]+) +(?P<operator>==|!=|<|>|<=|>=|IN|NOT_IN) +(?P<rule_value>[^\n\r]+) +<{2} *(?P<custom_msg>.*)").unwrap();
-    static ref WHITE_SPACE_REG: Regex = Regex::new(r"\s+").unwrap();
     static ref CONDITIONAL_RULE_REG: Regex = Regex::new(r"(?P<resource_type>\S+) +if +(?P<condition>.+) +then +(?P<consequent>.*)").unwrap();
+    static ref WHITE_SPACE_REG: Regex = Regex::new(r"^\s+$").unwrap();
 }
 
 pub(crate) fn parse_rules(

--- a/cfn-guard/src/parser.rs
+++ b/cfn-guard/src/parser.rs
@@ -224,9 +224,9 @@ fn process_and_rule(
 ) -> Result<RuleType, String> {
     trace!("Entered process_and_rule");
     let branches = line.split("|AND|");
-    debug!("Rule branches are: {:#?}", &branches);
     let mut rules: Vec<RuleType> = vec![];
     for b in branches {
+        debug!("AND rule branch is: {:#?}", &b);
         match destructure_rule(b.trim(), cfn_resources) {
             Ok(r) => rules.append(&mut r.clone()),
             Err(e) => return Err(e),

--- a/cfn-guard/src/parser.rs
+++ b/cfn-guard/src/parser.rs
@@ -48,14 +48,15 @@ pub(crate) fn parse_rules(
 
     for l in lines {
         debug!("Parsing '{}'", &l);
-        if l.is_empty() {
+        let trimmed_line = l.trim();
+        if trimmed_line.is_empty() {
             continue;
         };
-        let line_type = find_line_type(l);
+        let line_type = find_line_type(trimmed_line);
         debug!("line_type is {:#?}", line_type);
         match line_type {
             LineType::Assignment => {
-                let caps = match process_assignment(l) {
+                let caps = match process_assignment(trimmed_line) {
                     Ok(a) => a,
                     Err(e) => return Err(e),
                 };
@@ -63,7 +64,7 @@ pub(crate) fn parse_rules(
                 if caps["operator"] != *"=" {
                     let msg_string = format!(
                         "Bad Assignment Operator: [{}] in '{}'",
-                        &caps["operator"], l
+                        &caps["operator"], trimmed_line
                     );
                     error!("{}", &msg_string);
                     process::exit(1)
@@ -78,14 +79,14 @@ pub(crate) fn parse_rules(
                 variables.insert(var_name, var_value);
             }
             LineType::Comment => (),
-            LineType::Rule => match parse_rule_line(l, &cfn_resources) {
+            LineType::Rule => match parse_rule_line(trimmed_line, &cfn_resources) {
                 Ok(prl) => {
                     debug!("Parsed rule is: {:#?}", &prl);
                     rule_set.push(prl)
                 }
                 Err(e) => return Err(e),
             },
-            LineType::Conditional => match parse_rule_line(l, &cfn_resources) {
+            LineType::Conditional => match parse_rule_line(trimmed_line, &cfn_resources) {
                 Ok(c) => {
                     debug!("Parsed conditional is {:#?}", &c);
                     rule_set.push(c);

--- a/cfn-guard/src/parser.rs
+++ b/cfn-guard/src/parser.rs
@@ -256,14 +256,6 @@ fn process_and_rule(
         raw_rule: line.to_string(),
         rule_list: rules,
     }))
-    // match destructure_rule(line, cfn_resources) {
-    //     Ok(r) => Ok(CompoundRule {
-    //         compound_type: CompoundType::AND,
-    //         raw_rule: line.to_string(),
-    //         rule_list: r,
-    //     }),
-    //     Err(e) => Err(e),
-    // }
 }
 
 fn destructure_rule(

--- a/cfn-guard/src/parser.rs
+++ b/cfn-guard/src/parser.rs
@@ -126,8 +126,8 @@ fn process_conditional(line: &str, cfn_resources: &HashMap<String, Value>) -> Co
     let condition = parse_rule_line(&conjd_caps_conditional, cfn_resources);
     let consequent = parse_rule_line(&conjd_caps_consequent, cfn_resources);
     ConditionalRule {
-        condition: condition,
-        consequent: consequent,
+        condition,
+        consequent,
     }
 }
 

--- a/cfn-guard/tests/conditional-ddb-template.ruleset
+++ b/cfn-guard/tests/conditional-ddb-template.ruleset
@@ -1,0 +1,3 @@
+# https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-product-attribute-reference.html
+AWS::DynamoDB::Table if Tags == /.*PROD.*/ then .DeletionPolicy == Retain
+AWS::DynamoDB::Table if Tags == /.*PROD.*/ then .DeletionPolicy != Retain

--- a/cfn-guard/tests/conditional-ddb-template.yaml
+++ b/cfn-guard/tests/conditional-ddb-template.yaml
@@ -1,0 +1,64 @@
+{
+  "Resources": {
+    "DDBTable": {
+      "Type": "AWS::DynamoDB::Table",
+      "UpdateReplacePolicy": "Abort",
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "AttributeDefinitions": [
+          {
+            "AttributeName": "ArtistId",
+            "AttributeType": "S"
+          },
+          {
+            "AttributeName": "Concert",
+            "AttributeType": "S"
+          },
+          {
+            "AttributeName": "TicketSales",
+            "AttributeType": "S"
+          }
+        ],
+        "KeySchema": [
+          {
+            "AttributeName": "ArtistId",
+
+            "KeyType": "HASH"
+          },
+          {
+            "AttributeName": "Concert",
+            "KeyType": "RANGE"
+          }
+        ],
+        "GlobalSecondaryIndexes": [
+          {
+
+            "IndexName": "GSI",
+            "KeySchema": [
+
+              {
+
+                "AttributeName": "TicketSales",
+                "KeyType": "HASH"
+              }
+            ],
+            "Projection": {
+              "ProjectionType": "KEYS_ONLY"
+            },
+            "ProvisionedThroughput": {
+              "ReadCapacityUnits": 5,
+              "WriteCapacityUnits": 5
+            }
+          }
+        ],
+        "ProvisionedThroughput": {
+          "ReadCapacityUnits": 5,
+          "WriteCapacityUnits": 5
+        },
+        "Tags": [
+          {"Key": "ENV", "Value": "PROD"}
+        ]
+      }
+    }
+  }
+}

--- a/cfn-guard/tests/functional.rs
+++ b/cfn-guard/tests/functional.rs
@@ -55,12 +55,12 @@ mod tests {
         );
         let mut rules_file_contents = String::from("AWS::EC2::Volume Encrypted == true");
         assert_eq!(
-            cfn_guard::run_check(&template_contents, &rules_file_contents, true),
+            cfn_guard::run_check(&template_contents, &rules_file_contents, true).unwrap(),
             (vec![], 0)
         );
         rules_file_contents = String::from("AWS::EC2::Volume Encrypted == True");
         assert_eq!(
-            cfn_guard::run_check(&template_contents, &rules_file_contents, true),
+            cfn_guard::run_check(&template_contents, &rules_file_contents, true).unwrap(),
             (vec![], 0)
         );
 
@@ -89,13 +89,13 @@ mod tests {
         );
         rules_file_contents = String::from("AWS::EC2::Volume Encrypted == false");
         assert_eq!(
-            cfn_guard::run_check(&template_contents, &rules_file_contents, true),
+            cfn_guard::run_check(&template_contents, &rules_file_contents, true).unwrap(),
             (vec![], 0)
         );
 
         rules_file_contents = String::from("AWS::EC2::Volume Encrypted == False");
         assert_eq!(
-            cfn_guard::run_check(&template_contents, &rules_file_contents, true),
+            cfn_guard::run_check(&template_contents, &rules_file_contents, true).unwrap(),
             (vec![], 0)
         );
 
@@ -124,13 +124,13 @@ mod tests {
         );
         rules_file_contents = String::from("AWS::EC2::Volume Encrypted == false");
         assert_eq!(
-            cfn_guard::run_check(&template_contents, &rules_file_contents, true),
+            cfn_guard::run_check(&template_contents, &rules_file_contents, true).unwrap(),
             (vec![], 0)
         );
 
         rules_file_contents = String::from("AWS::EC2::Volume Encrypted == False");
         assert_eq!(
-            cfn_guard::run_check(&template_contents, &rules_file_contents, true),
+            cfn_guard::run_check(&template_contents, &rules_file_contents, true).unwrap(),
             (vec![], 0)
         );
 
@@ -157,13 +157,13 @@ mod tests {
         );
         rules_file_contents = String::from("AWS::EC2::Volume Encrypted == false");
         assert_eq!(
-            cfn_guard::run_check(&template_contents, &rules_file_contents, false),
+            cfn_guard::run_check(&template_contents, &rules_file_contents, false).unwrap(),
             (vec![], 0)
         );
 
         rules_file_contents = String::from("AWS::EC2::Volume Encrypted == False");
         assert_eq!(
-            cfn_guard::run_check(&template_contents, &rules_file_contents, false),
+            cfn_guard::run_check(&template_contents, &rules_file_contents, false).unwrap(),
             (vec![], 0)
         );
     }
@@ -174,7 +174,7 @@ mod tests {
             .unwrap_or_else(|err| format!("{}", err));
         let rules_file_content = String::from(r#"AWS::EC2::Volume Encrypted != /true/"#);
         assert_eq!(
-            cfn_guard::run_check(&template_contents, &rules_file_content, true),
+            cfn_guard::run_check(&template_contents, &rules_file_content, true).unwrap(),
             (
                 vec![
                     String::from(
@@ -196,7 +196,7 @@ mod tests {
         let rules_file_content =
             String::from(r#"AWS::EC2::Volume Encrypted != /true/ << lorem ipsum"#);
         assert_eq!(
-            cfn_guard::run_check(&template_contents, &rules_file_content, true),
+            cfn_guard::run_check(&template_contents, &rules_file_content, true).unwrap(),
             (
                 vec![
                     String::from(
@@ -218,7 +218,7 @@ mod tests {
         let rules_file_content =
             String::from(r#"AWS::EC2::Volume Encrypted != true << lorem ipsum"#);
         assert_eq!(
-            cfn_guard::run_check(&template_contents, &rules_file_content, true),
+            cfn_guard::run_check(&template_contents, &rules_file_content, true).unwrap(),
             (
                 vec![
                     String::from(
@@ -240,9 +240,13 @@ mod tests {
         let rules_file_contents =
             fs::read_to_string("tests/ebs_volume_rule_set_custom_msg.passing")
                 .unwrap_or_else(|err| format!("{}", err));
+        let error = match cfn_guard::run_check(&template_contents, &rules_file_contents, true) {
+            Ok(_) => "".to_string(),
+            Err(e) => e,
+        };
         assert_eq!(
-            cfn_guard::run_check(&template_contents, &rules_file_contents, true),
-            (vec![String::from("ERROR:  Template file format was unreadable as json or yaml: invalid type: string \"THIS IS MEANT TO BE INVALID\", expected a map at line 1 column 1")], 1)
+            error,
+            String::from("Template file format was unreadable as json or yaml: invalid type: string \"THIS IS MEANT TO BE INVALID\", expected a map at line 1 column 1")
         );
     }
 
@@ -254,7 +258,7 @@ mod tests {
             fs::read_to_string("tests/ebs_volume_rule_set_custom_msg.passing")
                 .unwrap_or_else(|err| format!("{}", err));
         assert_eq!(
-            cfn_guard::run_check(&template_contents, &rules_file_contents, true),
+            cfn_guard::run_check(&template_contents, &rules_file_contents, true).unwrap(),
             (vec![], 0)
         );
     }
@@ -287,7 +291,7 @@ mod tests {
             ];
         outcome.sort();
         assert_eq!(
-            cfn_guard::run_check(&template_contents, &rules_file_contents, true),
+            cfn_guard::run_check(&template_contents, &rules_file_contents, true).unwrap(),
             (outcome, 2)
         );
     }
@@ -321,7 +325,7 @@ mod tests {
         let rules_file_contents = fs::read_to_string("tests/test_not_in_list_fail.ruleset")
             .unwrap_or_else(|err| format!("{}", err));
         assert_eq!(
-            cfn_guard::run_check(&template_contents, &rules_file_contents, true),
+            cfn_guard::run_check(&template_contents, &rules_file_contents, true).unwrap(),
             (vec![
                 String::from("[NewVolume2] failed because [us-west-2c] is not in [us-east-1a,us-east-1b,us-east-1c] for [AvailabilityZone]"),
                 String::from("[NewVolume] failed because [us-west-2b] is not in [us-east-1a,us-east-1b,us-east-1c] for [AvailabilityZone]"),
@@ -359,7 +363,7 @@ mod tests {
             fs::read_to_string("tests/test_in_list_fail_custom_message.ruleset")
                 .unwrap_or_else(|err| format!("{}", err));
         assert_eq!(
-            cfn_guard::run_check(&template_contents, &rules_file_contents, true),
+            cfn_guard::run_check(&template_contents, &rules_file_contents, true).unwrap(),
             (vec![
                 String::from("[NewVolume2] failed because [AvailabilityZone] is [us-west-2c] and lorem ipsum"),
                 String::from("[NewVolume] failed because [AvailabilityZone] is [us-west-2b] and lorem ipsum"),
@@ -421,7 +425,7 @@ mod tests {
         env::set_var("MOTP", "ec2.amazonaws.com"); // Env vars need to be unique to each test because they're global when `cargo test` runs
         let empty_vec: Vec<String> = Vec::new();
         assert_eq!(
-            cfn_guard::run_check(&template_file_contents, &rules_file_contents, true),
+            cfn_guard::run_check(&template_file_contents, &rules_file_contents, true).unwrap(),
             (empty_vec, 0)
         );
     }
@@ -463,7 +467,7 @@ mod tests {
         );
         env::set_var("MOTF", "motf"); // Env vars need to be unique to each test because they're global when `cargo test` runs
         assert_eq!(
-            cfn_guard::run_check(&template_file_contents, &rules_file_contents, true),
+            cfn_guard::run_check(&template_file_contents, &rules_file_contents, true).unwrap(),
             (vec![String::from("[LambdaRoleHelper] failed because [AssumeRolePolicyDocument.Statement.0.Principal.Service.0] is [ec2.amazonaws.com] and the permitted value is [motf]"),
                   String::from("[LambdaRoleHelper] failed because [AssumeRolePolicyDocument.Version] is [2012-10-17] and the permitted pattern is [(\\d{5})-(\\d{2})-(\\d{2})]"), ],
              2)
@@ -507,7 +511,7 @@ mod tests {
             AWS::IAM::Role AssumeRolePolicyDocument.Statement.*.Principal.Service.* != ec2.amazonaws.com"#,
         );
         assert_eq!(
-            cfn_guard::run_check(&template_file_contents, &rules_file_contents, true),
+            cfn_guard::run_check(&template_file_contents, &rules_file_contents, true).unwrap(),
             (vec![
                 String::from("[LambdaRoleHelper] failed because [AssumeRolePolicyDocument.Statement.0.Principal.Service.0] is [ec2.amazonaws.com] and that value is not permitted"),
                 String::from("[LambdaRoleHelper] failed because [AssumeRolePolicyDocument.Statement.0.Principal.Service.1] is [lambda.amazonaws.com] and that value is not permitted"),
@@ -556,7 +560,7 @@ mod tests {
         );
         let empty_vec: Vec<String> = Vec::new();
         assert_eq!(
-            cfn_guard::run_check(&template_file_contents, &rules_file_contents, true),
+            cfn_guard::run_check(&template_file_contents, &rules_file_contents, true).unwrap(),
             (empty_vec, 0)
         );
     }
@@ -598,7 +602,7 @@ mod tests {
         );
         let empty_vec: Vec<String> = Vec::new();
         assert_eq!(
-            cfn_guard::run_check(&template_file_contents, &rules_file_contents, true),
+            cfn_guard::run_check(&template_file_contents, &rules_file_contents, true).unwrap(),
             (empty_vec, 0)
         );
     }
@@ -639,7 +643,7 @@ mod tests {
             r#"AWS::IAM::Role AssumeRolePolicyDocument.Statement.*.Principal.Service.* == wcf"#,
         );
         assert_eq!(
-            cfn_guard::run_check(&template_file_contents, &rules_file_contents, true),
+            cfn_guard::run_check(&template_file_contents, &rules_file_contents, true).unwrap(),
             (vec![String::from("[LambdaRoleHelper] failed because [AssumeRolePolicyDocument.Statement.0.Principal.Service.0] is [ec2.amazonaws.com] and the permitted value is [wcf]"),
                   String::from("[LambdaRoleHelper] failed because [AssumeRolePolicyDocument.Statement.0.Principal.Service.1] is [lambda.amazonaws.com] and the permitted value is [wcf]"),
                   String::from("[LambdaRoleHelper] failed because [AssumeRolePolicyDocument.Statement.1.Principal.Service.0] is [lambda.amazonaws.com] and the permitted value is [wcf]"),
@@ -674,7 +678,7 @@ mod tests {
         env::set_var("SERV_PRIN_EVP", "lambda.amazonaws.com"); // Env vars need to be unique to each test because they're global when `cargo test` runs
         let empty_vec: Vec<String> = Vec::new();
         assert_eq!(
-            cfn_guard::run_check(&template_file_contents, &rules_file_contents, true),
+            cfn_guard::run_check(&template_file_contents, &rules_file_contents, true).unwrap(),
             (empty_vec, 0)
         );
     }
@@ -701,7 +705,7 @@ mod tests {
         );
         env::set_var("SERV_PRIN_EVF", "evf.amazonaws.com"); // Env vars need to be unique to each test because they're global when `cargo test` runs
         assert_eq!(
-            cfn_guard::run_check(&template_file_contents, &rules_file_contents, true),
+            cfn_guard::run_check(&template_file_contents, &rules_file_contents, true).unwrap(),
             (vec![String::from("[LambdaRoleHelper] failed because [AssumeRolePolicyDocument.Statement.0.Principal.Service.0] is [lambda.amazonaws.com] and the permitted value is [evf.amazonaws.com]")], 2)
         );
     }
@@ -728,7 +732,7 @@ mod tests {
         );
         let empty_vec: Vec<String> = Vec::new();
         assert_eq!(
-            cfn_guard::run_check(&template_file_contents, &rules_file_contents, true),
+            cfn_guard::run_check(&template_file_contents, &rules_file_contents, true).unwrap(),
             (empty_vec, 0)
         );
     }
@@ -754,7 +758,7 @@ mod tests {
             r#"AWS::IAM::Role AssumeRolePolicyDocument.Version == /(\d{5})-(\d{2})-(\d{2})/"#,
         );
         assert_eq!(
-            cfn_guard::run_check(&template_file_contents, &rules_file_contents, true),
+            cfn_guard::run_check(&template_file_contents, &rules_file_contents, true).unwrap(),
             (vec![String::from("[LambdaRoleHelper] failed because [AssumeRolePolicyDocument.Version] is [2012-10-17] and the permitted pattern is [(\\d{5})-(\\d{2})-(\\d{2})]")], 2)
         );
     }
@@ -780,7 +784,7 @@ mod tests {
 AWS::EC2::Volume Encrypted != %require_encryption"#,
         );
         assert_eq!(
-            cfn_guard::run_check(&template_file_contents, &rules_file_contents, true),
+            cfn_guard::run_check(&template_file_contents, &rules_file_contents, true).unwrap(),
             (vec![String::from("[NewVolume] failed because it does not contain the required property of [Encrypted]")], 2)
         );
     }
@@ -807,7 +811,7 @@ AWS::EC2::Volume Encrypted != %require_encryption"#,
 AWS::EC2::Volume Encrypted != %require_encryption"#,
         );
         assert_eq!(
-            cfn_guard::run_check(&template_file_contents, &rules_file_contents, true),
+            cfn_guard::run_check(&template_file_contents, &rules_file_contents, true).unwrap(),
             (vec![String::from("[NewVolume] failed because there is no value defined for [%require_encryption] to check [Encrypted] against")], 2)
         );
     }
@@ -843,7 +847,7 @@ AWS::EC2::Volume Encrypted != %require_encryption"#,
 AWS::EC2::Volume Size == 101 |OR| AWS::EC2::Volume Size == 99"#,
         );
         assert_eq!(
-            cfn_guard::run_check(&template_file_contents, &rules_file_contents, true),
+            cfn_guard::run_check(&template_file_contents, &rules_file_contents, true).unwrap(),
             (vec![String::from("[NewVolume] failed because [Size] is [100] and the permitted value is [101]"),
                   String::from("[NewVolume] failed because [Size] is [100] and the permitted value is [99]"),],
              2)
@@ -881,7 +885,7 @@ AWS::EC2::Volume Size == 101 |OR| AWS::EC2::Volume Size == 99"#,
 AWS::EC2::Volume Size < 101"#,
         );
         assert_eq!(
-            cfn_guard::run_check(&template_file_contents, &rules_file_contents, true),
+            cfn_guard::run_check(&template_file_contents, &rules_file_contents, true).unwrap(),
             (vec![String::from("[NewVolume2] failed because [Size] is [101] and the permitted value is [< 101]"), ],
              2)
         );
@@ -918,7 +922,7 @@ AWS::EC2::Volume Size < 101"#,
 AWS::EC2::Volume Size > 100"#,
         );
         assert_eq!(
-            cfn_guard::run_check(&template_file_contents, &rules_file_contents, true),
+            cfn_guard::run_check(&template_file_contents, &rules_file_contents, true).unwrap(),
             (
                 vec![String::from(
                     "[NewVolume] failed because [Size] is [100] and the permitted value is [> 100]"
@@ -959,7 +963,7 @@ AWS::EC2::Volume Size > 100"#,
 AWS::EC2::Volume Size <= 100"#,
         );
         assert_eq!(
-            cfn_guard::run_check(&template_file_contents, &rules_file_contents, true),
+            cfn_guard::run_check(&template_file_contents, &rules_file_contents, true).unwrap(),
             (vec![String::from("[NewVolume2] failed because [Size] is [101] and the permitted value is [<= 100]"), ],
              2)
         );
@@ -996,7 +1000,7 @@ AWS::EC2::Volume Size <= 100"#,
 AWS::EC2::Volume Size >= 101"#,
         );
         assert_eq!(
-            cfn_guard::run_check(&template_file_contents, &rules_file_contents, true),
+            cfn_guard::run_check(&template_file_contents, &rules_file_contents, true).unwrap(),
             (vec![String::from("[NewVolume] failed because [Size] is [100] and the permitted value is [>= 101]"), ],
              2)
         );
@@ -1058,7 +1062,7 @@ AWS::EC2::Volume Encrypted != %require_encryption
 AWS::EC2::Volume Size == 101 |OR| AWS::EC2::Volume Size == 99"#,
         );
         assert_eq!(
-            cfn_guard::run_check(&template_file_contents, &rules_file_contents, true),
+            cfn_guard::run_check(&template_file_contents, &rules_file_contents, true).unwrap(),
             (vec![String::from("[NewVolume] failed because [Encrypted] is [true] and that value is not permitted"),
                   String::from("[NewVolume] failed because [Size] is [100] and the permitted value is [101]"),
                   String::from("[NewVolume] failed because [Size] is [100] and the permitted value is [99]"),
@@ -1092,7 +1096,7 @@ AWS::EC2::Volume Encrypted != %require_encryption
 AWS::EC2::Volume Size == 101 |OR| AWS::EC2::Volume Size == 99"#,
         );
         assert_eq!(
-            cfn_guard::run_check(&template_file_contents, &rules_file_contents, true),
+            cfn_guard::run_check(&template_file_contents, &rules_file_contents, true).unwrap(),
             (vec![
                 String::from("[NewVolume] failed because [Encrypted] is [true] and that value is not permitted"),
                 String::from("[NewVolume] failed because [Size] is [100] and the permitted value is [101]"),
@@ -1111,7 +1115,7 @@ AWS::EC2::Volume Size == 101 |OR| AWS::EC2::Volume Size == 99"#,
                   AWS::EC2::SecurityGroup Tags.* == {"Key":"OwnerContact","Value":"OwnerContact"}"#,
         );
         assert_eq!(
-            cfn_guard::run_check(&template_contents, &rules_file_contents, true),
+            cfn_guard::run_check(&template_contents, &rules_file_contents, true).unwrap(),
             (vec![], 0)
         );
     }
@@ -1125,7 +1129,7 @@ AWS::EC2::Volume Size == 101 |OR| AWS::EC2::Volume Size == 99"#,
                   AWS::EC2::SecurityGroup Tags.* == {"Key":"OwnerContact","Value":"OwnerContact"}"#,
         );
         assert_eq!(
-            cfn_guard::run_check(&template_contents, &rules_file_contents, true),
+            cfn_guard::run_check(&template_contents, &rules_file_contents, true).unwrap(),
             (
                 vec![
                     String::from(
@@ -1159,7 +1163,7 @@ AWS::EC2::Volume Size == 101 |OR| AWS::EC2::Volume Size == 99"#,
         let rules_file_contents = fs::read_to_string("tests/wildcard_iam_rule_set.passing")
             .unwrap_or_else(|err| format!("{}", err));
         assert_eq!(
-            cfn_guard::run_check(&template_contents, &rules_file_contents, true),
+            cfn_guard::run_check(&template_contents, &rules_file_contents, true).unwrap(),
             (vec![], 0)
         );
     }
@@ -1171,7 +1175,7 @@ AWS::EC2::Volume Size == 101 |OR| AWS::EC2::Volume Size == 99"#,
         let rules_file_contents = fs::read_to_string("tests/wildcard_not_in_iam_rule_set.failing")
             .unwrap_or_else(|err| format!("{}", err));
         assert_eq!(
-            cfn_guard::run_check(&template_contents, &rules_file_contents, true),
+            cfn_guard::run_check(&template_contents, &rules_file_contents, true).unwrap(),
             (vec![String::from("[LambdaRoleHelper] failed because [lambda.amazonaws.com] is in [lambda.amazonaws.com, ec2.amazonaws.com] which is not permitted for [AssumeRolePolicyDocument.Statement.0.Principal.Service.0]"), ],
              2)
         );
@@ -1184,7 +1188,7 @@ AWS::EC2::Volume Size == 101 |OR| AWS::EC2::Volume Size == 99"#,
         let rules_file_contents = fs::read_to_string("tests/wildcard_action.pass")
             .unwrap_or_else(|err| format!("{}", err));
         assert_eq!(
-            cfn_guard::run_check(&template_contents, &rules_file_contents, true),
+            cfn_guard::run_check(&template_contents, &rules_file_contents, true).unwrap(),
             (vec![], 0)
         );
     }
@@ -1196,7 +1200,7 @@ AWS::EC2::Volume Size == 101 |OR| AWS::EC2::Volume Size == 99"#,
         let rules_file_contents = fs::read_to_string("tests/wildcard_action.fail")
             .unwrap_or_else(|err| format!("{}", err));
         assert_eq!(
-            cfn_guard::run_check(&template_contents, &rules_file_contents, true),
+            cfn_guard::run_check(&template_contents, &rules_file_contents, true).unwrap(),
             (vec![String::from("[EndpointCloudWatchRoleC3C64E0F] failed because [AssumeRolePolicyDocument.Statement.0.Action] is [sts:AssumeRole] and that value is not permitted"),
                   String::from("[HelloHandlerServiceRole11EF7C63] failed because [AssumeRolePolicyDocument.Statement.0.Action] is [sts:AssumeRole] and that value is not permitted")],
              2)
@@ -1218,7 +1222,7 @@ AWS::EC2::Volume Size == 101 |OR| AWS::EC2::Volume Size == 99"#,
         )
         .unwrap_or_else(|err| format!("{}", err));
         assert_eq!(
-            cfn_guard::run_check(&template_contents, &rules_file_contents, true),
+            cfn_guard::run_check(&template_contents, &rules_file_contents, true).unwrap(),
             (vec![String::from("[NewVolume2] failed because it does not contain the required property of [Tags]"),
                   String::from("[NewVolume2] failed because it does not contain the required property of [Tags]"),
                   String::from("[NewVolume] failed because [Tags.0.Key] is [uaid] and the permitted value is [uai]"),
@@ -1242,7 +1246,7 @@ AWS::EC2::Volume Size == 101 |OR| AWS::EC2::Volume Size == 99"#,
         )
         .unwrap_or_else(|err| format!("{}", err));
         assert_eq!(
-            cfn_guard::run_check(&template_contents, &rules_file_contents, false),
+            cfn_guard::run_check(&template_contents, &rules_file_contents, false).unwrap(),
             (vec![String::from("[NewVolume] failed because [Tags.0.Key] is [uaid] and the permitted value is [uai]"),
                   String::from("[NewVolume] failed because [Tags.1.Key] is [tag2] and the permitted value is [uai]")],
              2)
@@ -1256,7 +1260,7 @@ AWS::EC2::Volume Size == 101 |OR| AWS::EC2::Volume Size == 99"#,
         let rules_file_contents = fs::read_to_string("tests/getatt_template.ruleset")
             .unwrap_or_else(|err| format!("{}", err));
         assert_eq!(
-            cfn_guard::run_check(&template_contents, &rules_file_contents, false),
+            cfn_guard::run_check(&template_contents, &rules_file_contents, false).unwrap(),
             (vec![String::from("[EC2Instance] failed because [t3.medium] is not in [t2.nano,t2.micro,t2.small,t3.nano,t3.micro,t3.small] for [InstanceType]"),
                   String::from("[InstanceSecurityGroup] failed because [SecurityGroupIngress] is [[{\"CidrIp\":\"SSHLocation\",\"FromPort\":22,\"IpProtocol\":\"tcp\",\"ToPort\":22}]] and the permitted value is [[{\"CidrIp\":\"SSHLocation\",\"FromPort\":33322,\"IpProtocol\":\"tcp\",\"ToPort\":33322}]]"),
                   String::from("[NewVolume] failed because [Size] is [512] and the permitted value is [128]"),
@@ -1273,7 +1277,7 @@ AWS::EC2::Volume Size == 101 |OR| AWS::EC2::Volume Size == 99"#,
         let rules_file_contents = fs::read_to_string("tests/getatt_template.ruleset")
             .unwrap_or_else(|err| format!("{}", err));
         assert_eq!(
-            cfn_guard::run_check(&template_contents, &rules_file_contents, false),
+            cfn_guard::run_check(&template_contents, &rules_file_contents, false).unwrap(),
             (vec![String::from("[NewVolume2] failed because [Encrypted] is [true] and that value is not permitted"),
                   String::from("[NewVolume2] failed because [Size] is [99] and the permitted value is [128]"),
                   String::from("[NewVolume2] failed because [Size] is [99] and the permitted value is [256]"),
@@ -1291,14 +1295,13 @@ AWS::EC2::Volume Size == 101 |OR| AWS::EC2::Volume Size == 99"#,
             .unwrap_or_else(|err| format!("{}", err));
         let rules_file_contents = fs::read_to_string("tests/no_resources_template.ruleset")
             .unwrap_or_else(|err| format!("{}", err));
+        let error = match cfn_guard::run_check(&template_contents, &rules_file_contents, true) {
+            Ok(_) => "".to_string(),
+            Err(e) => e,
+        };
         assert_eq!(
-            cfn_guard::run_check(&template_contents, &rules_file_contents, false),
-            (
-                vec![String::from(
-                    "ERROR:  Template file does not contain a [Resources] section to check"
-                )],
-                1
-            )
+            error,
+            String::from("Template file does not contain a [Resources] section to check")
         )
     }
 
@@ -1314,7 +1317,7 @@ AWS::EC2::Volume Size == 101 |OR| AWS::EC2::Volume Size == 99"#,
             "#,
         );
         assert_eq!(
-            cfn_guard::run_check(&template_contents, &rules_file_contents, false),
+            cfn_guard::run_check(&template_contents, &rules_file_contents, false).unwrap(),
             (
                 vec![String::from(
                     r#"[ClusterSg] failed because [{"Key":"OwnerContact","Value":"OwnerContact"}] is in ["test", 1, ["a", "b"], {"Key":"OwnerContact","Value":"OwnerContact"},{"Key":"OwnerContact","Value":{"Ref":"OwnerContact"}}] which is not permitted for [Tags.1]"#
@@ -1329,7 +1332,7 @@ AWS::EC2::Volume Size == 101 |OR| AWS::EC2::Volume Size == 99"#,
             "#,
         );
         assert_eq!(
-            cfn_guard::run_check(&template_contents, &rules_file_contents, false),
+            cfn_guard::run_check(&template_contents, &rules_file_contents, false).unwrap(),
             (vec![], 0)
         );
         template_contents = fs::read_to_string("tests/parse_lists_with_json_test-template.json")
@@ -1341,7 +1344,7 @@ AWS::EC2::Volume Size == 101 |OR| AWS::EC2::Volume Size == 99"#,
             "#,
         );
         assert_eq!(
-            cfn_guard::run_check(&template_contents, &rules_file_contents, false),
+            cfn_guard::run_check(&template_contents, &rules_file_contents, false).unwrap(),
             (
                 vec![String::from(
                     r#"[ClusterSg] failed because [{"Key":"OwnerContact","Value":{"Ref":"OwnerContact"}}] is in ["test", 1, ["a", "b"], {"Key":"OwnerContact","Value":"OwnerContact"},{"Key":"OwnerContact","Value":{"Ref":"OwnerContact"}}] which is not permitted for [Tags.1]"#
@@ -1356,7 +1359,7 @@ AWS::EC2::Volume Size == 101 |OR| AWS::EC2::Volume Size == 99"#,
             "#,
         );
         assert_eq!(
-            cfn_guard::run_check(&template_contents, &rules_file_contents, false),
+            cfn_guard::run_check(&template_contents, &rules_file_contents, false).unwrap(),
             (vec![], 0)
         );
     }
@@ -1372,7 +1375,7 @@ AWS::EC2::Volume Size == 101 |OR| AWS::EC2::Volume Size == 99"#,
             AWS::Lambda::Function Environment.*.*.* IN %log_stuff"#,
         );
         assert_eq!(
-            cfn_guard::run_check(&template_contents, &rules_file_contents, true),
+            cfn_guard::run_check(&template_contents, &rules_file_contents, true).unwrap(),
             (vec![], 0)
         );
 
@@ -1383,7 +1386,7 @@ AWS::EC2::Volume Size == 101 |OR| AWS::EC2::Volume Size == 99"#,
             AWS::Lambda::Function Environment.*.*.* NOT_IN %log_stuff"#,
         );
         assert_eq!(
-            cfn_guard::run_check(&template_contents, &rules_file_contents, true),
+            cfn_guard::run_check(&template_contents, &rules_file_contents, true).unwrap(),
             (
                 vec![
                     String::from(
@@ -1403,7 +1406,7 @@ AWS::EC2::Volume Size == 101 |OR| AWS::EC2::Volume Size == 99"#,
         // Pass over-wildcarding (ie, wildcards in structures that don't extend that deeply
         rules_file_contents = String::from(r#"AWS::Lambda::Function MemorySize.*.* IN [128]"#);
         assert_eq!(
-            cfn_guard::run_check(&template_contents, &rules_file_contents, true),
+            cfn_guard::run_check(&template_contents, &rules_file_contents, true).unwrap(),
             (vec![], 0)
         );
 
@@ -1412,7 +1415,7 @@ AWS::EC2::Volume Size == 101 |OR| AWS::EC2::Volume Size == 99"#,
             r#"AWS::Lambda::Function Environment.*.* IN [["Solution", "Data", "LogLevel"]]"#,
         );
         assert_eq!(
-            cfn_guard::run_check(&template_contents, &rules_file_contents, true),
+            cfn_guard::run_check(&template_contents, &rules_file_contents, true).unwrap(),
             (vec![], 0)
         );
 
@@ -1421,7 +1424,7 @@ AWS::EC2::Volume Size == 101 |OR| AWS::EC2::Volume Size == 99"#,
             r#"AWS::Lambda::Function Environment.*.* NOT_IN [["Solution", "Data", "LogLevel"]]"#,
         );
         assert_eq!(
-            cfn_guard::run_check(&template_contents, &rules_file_contents, true),
+            cfn_guard::run_check(&template_contents, &rules_file_contents, true).unwrap(),
             (
                 vec![String::from(
                     r#"[LambdaWAFHelperFunction] failed because [["Solution","Data","LogLevel"]] is in [["Solution", "Data", "LogLevel"]] which is not permitted for [Environment.Variables.LOG_LEVEL]"#
@@ -1435,7 +1438,7 @@ AWS::EC2::Volume Size == 101 |OR| AWS::EC2::Volume Size == 99"#,
             r#"AWS::Lambda::Function Environment.*.LOG_LEVEL IN [["Solution", "Data", "LogLevel"]]"#,
         );
         assert_eq!(
-            cfn_guard::run_check(&template_contents, &rules_file_contents, true),
+            cfn_guard::run_check(&template_contents, &rules_file_contents, true).unwrap(),
             (vec![], 0)
         );
 
@@ -1444,7 +1447,7 @@ AWS::EC2::Volume Size == 101 |OR| AWS::EC2::Volume Size == 99"#,
             r#"AWS::Lambda::Function Environment.*.LOG_LEVEL NOT_IN [["Solution", "Data", "LogLevel"]]"#,
         );
         assert_eq!(
-            cfn_guard::run_check(&template_contents, &rules_file_contents, true),
+            cfn_guard::run_check(&template_contents, &rules_file_contents, true).unwrap(),
             (
                 vec![String::from(
                     r#"[LambdaWAFHelperFunction] failed because [["Solution","Data","LogLevel"]] is in [["Solution", "Data", "LogLevel"]] which is not permitted for [Environment.Variables.LOG_LEVEL]"#
@@ -1458,7 +1461,7 @@ AWS::EC2::Volume Size == 101 |OR| AWS::EC2::Volume Size == 99"#,
             r#"AWS::Lambda::Function *.*.LOG_LEVEL IN [["Solution", "Data", "LogLevel"]]"#,
         );
         assert_eq!(
-            cfn_guard::run_check(&template_contents, &rules_file_contents, false),
+            cfn_guard::run_check(&template_contents, &rules_file_contents, false).unwrap(),
             (vec![], 0)
         );
 
@@ -1467,7 +1470,7 @@ AWS::EC2::Volume Size == 101 |OR| AWS::EC2::Volume Size == 99"#,
             r#"AWS::Lambda::Function *.*.LOG_LEVEL NOT_IN [["Solution", "Data", "LogLevel"]]"#,
         );
         assert_eq!(
-            cfn_guard::run_check(&template_contents, &rules_file_contents, false),
+            cfn_guard::run_check(&template_contents, &rules_file_contents, false).unwrap(),
             (
                 vec![String::from(
                     r#"[LambdaWAFHelperFunction] failed because [["Solution","Data","LogLevel"]] is in [["Solution", "Data", "LogLevel"]] which is not permitted for [Environment.Variables.LOG_LEVEL]"#
@@ -1482,15 +1485,19 @@ AWS::EC2::Volume Size == 101 |OR| AWS::EC2::Volume Size == 99"#,
         let template_contents = fs::read_to_string("tests/conditional-ddb-template.yaml")
             .unwrap_or_else(|err| format!("{}", err));
 
-        let mut rules_file_contents = String::from("AWS::DynamoDB::Table if Tags == /.*PROD.*/ then .DeletionPolicy == Retain");
+        let mut rules_file_contents = String::from(
+            "AWS::DynamoDB::Table if Tags == /.*PROD.*/ then .DeletionPolicy == Retain",
+        );
         assert_eq!(
-            cfn_guard::run_check(&template_contents, &rules_file_contents, false),
+            cfn_guard::run_check(&template_contents, &rules_file_contents, false).unwrap(),
             (vec![], 0)
         );
 
-        rules_file_contents = String::from("AWS::DynamoDB::Table if Tags == /.*PROD.*/ then .DeletionPolicy != Retain");
+        rules_file_contents = String::from(
+            "AWS::DynamoDB::Table if Tags == /.*PROD.*/ then .DeletionPolicy != Retain",
+        );
         assert_eq!(
-            cfn_guard::run_check(&template_contents, &rules_file_contents, false),
+            cfn_guard::run_check(&template_contents, &rules_file_contents, false).unwrap(),
             (vec![String::from("[DDBTable] failed because [.DeletionPolicy] is [Retain] and that value is not permitted when AWS::DynamoDB::Table Tags == /.*PROD.*/")],
              2)
         )

--- a/cfn-guard/tests/functional.rs
+++ b/cfn-guard/tests/functional.rs
@@ -1006,32 +1006,6 @@ AWS::EC2::Volume Size >= 101"#,
         );
     }
 
-    // TODO: Create test for clean_exit() scenarios
-    //     #[test]
-    //     #[should_panic]
-    //     fn test_non_numeric_value_comparison_fail() {
-    //         let template_file_contents = String::from(
-    //             r#"{
-    //             "Resources": {
-    //                 "NewVolume" : {
-    //                     "Type" : "AWS::EC2::Volume",
-    //                     "Properties" : {
-    //                         "Size" : 100,
-    //                         "Encrypted" : true,
-    //                         "AvailabilityZone" : "us-east-1b",
-    //                         "DeletionPolicy" : "Snapshot"
-    //                     }
-    //                 }
-    //             }
-    //         }"#,
-    //         );
-    //         let rules_file_contents = String::from(
-    //             r#"
-    // AWS::EC2::Volume Size < a"#,
-    //         );
-    //         cfn_guard::run_check(&template_file_contents, &rules_file_contents, true);
-    //     }
-
     #[test]
     fn test_json_results() {
         let template_file_contents = String::from(

--- a/cfn-guard/tests/root-wildcard-template.json
+++ b/cfn-guard/tests/root-wildcard-template.json
@@ -3,6 +3,7 @@
         "NewVolume" : {
             "Type" : "AWS::EC2::Volume",
             "Properties" : {
+                "AutoEnableIO": true,
                 "Size" : 101,
                 "Encrypted": true,
                 "AvailabilityZone" : "us-west-2b"

--- a/cfn-guard/tests/root-wildcard-template.json
+++ b/cfn-guard/tests/root-wildcard-template.json
@@ -1,0 +1,20 @@
+{
+    "Resources": {
+        "NewVolume" : {
+            "Type" : "AWS::EC2::Volume",
+            "Properties" : {
+                "Size" : 101,
+                "Encrypted": true,
+                "AvailabilityZone" : "us-west-2b"
+            }
+        },
+        "NewVolume2" : {
+            "Type" : "AWS::EC2::Volume",
+            "Properties" : {
+                "Size" : 99,
+                "Encrypted": true,
+                "AvailabilityZone" : "us-west-2c"
+            }
+        }
+    }
+}

--- a/cfn-guard/tests/test-multiple-resources-conditional-template.yaml
+++ b/cfn-guard/tests/test-multiple-resources-conditional-template.yaml
@@ -1,0 +1,32 @@
+Resources:
+  lambdaFunction:
+    Type: "AWS::Lambda::Function"
+    Properties:
+      Code:
+        ZipFile: |
+          def handler(event,context):
+            return {
+              'body': 'Hello there {0}'.format(event['requestContext']['identity']['sourceIp']),
+              'headers': {
+                'Content-Type': 'text/plain'
+              },
+              'statusCode': 200
+            }
+      Description: "Governance Lambda Demo"
+      FunctionName: !Ref "lambdaFunctionName"
+      Handler: "index.handler"
+      MemorySize: 128
+      Role: !GetAtt "lambdaIAMRole.Arn"
+      Runtime: "python2.7"
+      Timeout: 10
+
+  APIGatewayPP:
+    Type: "AWS::ServiceCatalog::CloudFormationProvisionedProduct"
+    Properties:
+      AcceptLanguage: en
+      ProvisionedProductName: "PP"
+      ProductName: "PG"
+      ProvisioningArtifactName: "apig_1.0"
+      ProvisioningParameters:
+        - Key: "lambdaFunctionArn"
+          Value: !GetAtt "lambdaFunction.Arn"


### PR DESCRIPTION
# What
* New conditional [`when-check` form](cfn-guard/README.md#when-check)
* Ability to check the resource's CFn attributes using a new `.` address that resolves to the level above properties (eg `.DeletionPolicy`) (See [Checking Resource Properties and Attributes](cfn-guard/README.md#checking-resource-properties-and-attributes))
* Make the `rulegen` output order deterministic (#44)
* Stability and logging improvements

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
