### PR TITLE
Adds JNI dylib to allow Java code to link to the core rule-check func…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ cloudformation-guard.tar.gz
 cmake-build-debug
 *gcno
 *gcda
+**/._*

--- a/cfn-guard/Cargo.toml
+++ b/cfn-guard/Cargo.toml
@@ -3,6 +3,10 @@ name = "cfn-guard"
 version = "0.6.0"
 edition = "2018"
 
+[lib]
+#name = "cfn_guard"
+crate-type = ["rlib", "dylib"]
+
 [dependencies]
 serde = { version = "1.0.92", features = ["derive"] }
 serde_json = "1.0"
@@ -12,3 +16,4 @@ log = "0.4.6"
 clap = "2.33.0"
 simple_logger = "1.3.0"
 regex = "1.1.9"
+jni = "0.14"

--- a/cfn-guard/Cargo.toml
+++ b/cfn-guard/Cargo.toml
@@ -4,7 +4,6 @@ version = "0.6.0"
 edition = "2018"
 
 [lib]
-#name = "cfn_guard"
 crate-type = ["rlib", "dylib"]
 
 [dependencies]

--- a/cfn-guard/src/lib.rs
+++ b/cfn-guard/src/lib.rs
@@ -9,6 +9,10 @@ use std::collections::HashSet;
 use std::error::Error;
 use std::fs;
 
+use jni::objects::{JClass, JString};
+use jni::sys::jstring;
+use jni::JNIEnv;
+
 mod guard_types;
 mod parser;
 pub mod util;
@@ -45,7 +49,7 @@ pub fn run(
     }
 }
 
-pub fn run_check(
+pub extern fn run_check(
     template_file_contents: &str,
     rules_file_contents: &str,
     strict_checks: bool,
@@ -723,4 +727,54 @@ fn apply_rule_operation(
             }
         }
     }
+}
+
+// Template contents, rules contents, and result are multiline strings.
+// strict_checks is a string arg because Rust/JNI doesn't have a simple mapping for bools.
+// Example Java class to link to this library function:
+//
+//package com.amazonaws.cfnguard.javawrapper;
+//
+//import java.nio.file.Path;
+//import java.nio.file.Paths;
+//
+//public final class CfnGuardWrapper {
+//
+//    static {
+//        Path path = Paths.get("libcfn_guard.so");
+//        System.load(path.toAbsolutePath().toString());
+//    }
+//
+//    public static native String runCheck(String templateContents, String rulesContents, String strictChecksBool);
+//}
+#[no_mangle]
+pub extern "system" fn Java_com_amazonaws_cfnguard_javawrapper_CfnGuardWrapper_runCheck(
+    env: JNIEnv,
+    _class: JClass,
+    template_contents: JString,
+    rules_contents: JString,
+    strict_checks: JString,
+) -> jstring {
+    let template_string: String =
+        env.get_string(template_contents).expect("Couldn't get java string for template_contents").into();
+    let rules_string: String =
+        env.get_string(rules_contents).expect("Couldn't get java string for rules_contents").into();
+
+    // Anything but "true" is treated as false.
+    let strict_checks_string: String =
+        env.get_string(strict_checks).expect("Couldn't get java string for strict_checks").into();
+    let strict_checks_bool = 
+        match strict_checks_string.parse() {
+            Ok(res) => res,
+            Err(_e) => false,
+        };
+
+    let outcome_string: String = 
+        match run_check(&template_string, &rules_string, strict_checks_bool) {
+            Ok(res) => res.0.join("\n"),
+            Err(e) => e.to_string(),
+        };
+
+    let result_jni_string = env.new_string(outcome_string).expect("Couldn't cast check outcome to JNI JString");
+    return result_jni_string.into_inner();
 }


### PR DESCRIPTION


*Issue #, if available:*

https://github.com/aws-cloudformation/cloudformation-guard/issues/54

*Description of changes:*

Adds an extern func to lib.rs to bridge with JNI for java calls into the Rust code.

Adds dependency on the jni crate and builds the previous executable along with the new .so dylib file.

Adds a few nice things to .gitignore .


This change was tested with Java code that is basically identical to the example Java class shown in lib.rs. Test cases included template pass/fail rules, invalid template, invalid rule, strict-checks true/fals.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
