### PR TITLE
Update makefile to reflect workspace refactor in #64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 .PHONY: cfn-guard cfn-guard-rulegen
 
 cfn-guard:
-	cd cfn-guard; cargo build --release; cp target/release/cfn-guard ../bin
+	cargo build --release; cp target/release/cfn-guard ../bin
 
 cfn-guard-rulegen:
-	cd cfn-guard-rulegen; cargo build --release; cp target/release/cfn-guard-rulegen ../bin
+	cargo build --release; cp target/release/cfn-guard-rulegen ../bin
 
 cfn-guard-lambda_install:
 	cd cfn-guard-lambda; make install
@@ -16,10 +16,7 @@ clean:
 	if test -f cloudformation-guard.tar.gz; then rm cloudformation-guard.tar.gz; fi
 
 test:
-	cd cfn-guard; cargo test
-	cd cfn-guard-rulegen; cargo test
-	cd cfn-guard-lambda; make test
-	cd cfn-guard-rulegen-lambda; make test
+	cargo test
 
 release_with_binaries: clean cfn-guard cfn-guard-rulegen
 	tar czvf cloudformation-guard.tar.gz -X Exclude.txt .


### PR DESCRIPTION
*Issue #, if available:* #73

*Description of changes:* Updates makefile to reflect workspace structure of repo introduced in #64. Just removes any directory changes since the target directory is under the root of the repo and is not in each cargo package directory.

Tested via running `make` in the repo's root directory.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
