### PR TITLE
Add directory and readmes for RFCs

### DIFF
--- a/rfcs/README.md
+++ b/rfcs/README.md
@@ -2,7 +2,7 @@
 
 Most bug fixes, doc enhancements, and small, incremental improvements for CloudFormation Guard can be surfaced and resolved via GitHub issues and pull requests. However, any suggestions for substantial changes to the ruleset langauge or tooling should be documented and actioned upon via a request for comments (RFC). This will provide a standardized process for discussion of major improvements to the tooling and ruleset language.  
 
-## Process
+## RFC Process
 This goes over the official process for creating, drafting, reviewing, and seeing an RFC to completion.
 
 ### Create an RFC

--- a/rfcs/README.md
+++ b/rfcs/README.md
@@ -1,6 +1,6 @@
 # CloudFormation Guard Request for Comments (RFCs)
 
-Most bug fixes, doc enhancements, and small, incremental improvements for CloudFormation Guard can be surfaced and resolved via GitHub issues and pull requests. However, any suggestions for substantial changes to the ruleset langauge or tooling should be documented and actioned upon via a request for comments (RFC). This will provide a standardized process for discussion major improvements to the tooling and ruleset language.  
+Most bug fixes, doc enhancements, and small, incremental improvements for CloudFormation Guard can be surfaced and resolved via GitHub issues and pull requests. However, any suggestions for substantial changes to the ruleset langauge or tooling should be documented and actioned upon via a request for comments (RFC). This will provide a standardized process for discussion of major improvements to the tooling and ruleset language.  
 
 ## Process
 This goes over the official process for creating, drafting, reviewing, and seeing an RFC to completion.

--- a/rfcs/README.md
+++ b/rfcs/README.md
@@ -1,0 +1,25 @@
+# CloudFormation Guard Request for Comments (RFCs)
+
+Most bug fixes, doc enhancements, and small, incremental improvements for CloudFormation Guard can be surfaced and resolved via GitHub issues and pull requests. However, any suggestions for substantial changes to the ruleset langauge or tooling should be documented and actioned upon via a request for comments (RFC). This will provide a standardized process for discussion major improvements to the tooling and ruleset language.  
+
+## Process
+
+This goes over the official process for creating, drafting, reviewing, and seeing an RFC to completion.
+
+### Create an RFC
+
+Use RFC template in this directory to guide your RFC. This has the basic structure of what we are expecting for RFCs. The RFC should highlight the motivation for the changes, a detailed design/description of that the changes entail, and considerations for not 
+
+### Submit a PR
+
+Submit a Pull Request to the CloudFormation Guard repository. The pull request will be reviewed by CloudFormation team members and open source contributors.
+
+
+### Review State
+
+Once the PR for the RFC is created, the RFC will undergo revisions similar to any other Guard PR until any and all concerns are addressed and the PR reaches a terminal state (accepted/rejected). 
+
+### Approved
+
+If approved, the RFC has been accepted for enhancement, and work can begin to accomplish what is set out in the PR. Accepted PRs will be kept in the repo for reference.
+

--- a/rfcs/README.md
+++ b/rfcs/README.md
@@ -3,23 +3,16 @@
 Most bug fixes, doc enhancements, and small, incremental improvements for CloudFormation Guard can be surfaced and resolved via GitHub issues and pull requests. However, any suggestions for substantial changes to the ruleset langauge or tooling should be documented and actioned upon via a request for comments (RFC). This will provide a standardized process for discussion major improvements to the tooling and ruleset language.  
 
 ## Process
-
 This goes over the official process for creating, drafting, reviewing, and seeing an RFC to completion.
 
 ### Create an RFC
-
 Use RFC template in this directory to guide your RFC. This has the basic structure of what we are expecting for RFCs. The RFC should highlight the motivation for the changes, a detailed design/description of that the changes entail, and considerations for not 
 
 ### Submit a PR
-
 Submit a Pull Request to the CloudFormation Guard repository. The pull request will be reviewed by CloudFormation team members and open source contributors.
 
-
 ### Review State
-
 Once the PR for the RFC is created, the RFC will undergo revisions similar to any other Guard PR until any and all concerns are addressed and the PR reaches a terminal state (accepted/rejected). 
 
 ### Approved
-
 If approved, the RFC has been accepted for enhancement, and work can begin to accomplish what is set out in the PR. Accepted PRs will be kept in the repo for reference.
-

--- a/rfcs/rfc-TEMPLATE.md
+++ b/rfcs/rfc-TEMPLATE.md
@@ -1,0 +1,23 @@
+
+
+# RFC-0000(PR Number) - RFC TITLE HERE
+
+## Summary
+Summary of what is being included in this RFC
+
+
+
+## Motivation
+Factors that are necessitating this change. Why is this change necessary? What features are lacking from the current toolset/language?
+
+## Proposal
+
+This should be an in depth description of what major enhancements are actually being proposed in the RFC. Proposal should describe the finished state of the ruleset/toolchain with the given enhancements.
+
+## Drawbacks
+
+What are the downsides of this change? Why shouldn't we do this? 
+
+
+
+

--- a/rfcs/rfc-TEMPLATE.md
+++ b/rfcs/rfc-TEMPLATE.md
@@ -1,23 +1,13 @@
-
-
 # RFC-0000(PR Number) - RFC TITLE HERE
 
 ## Summary
 Summary of what is being included in this RFC
 
-
-
 ## Motivation
 Factors that are necessitating this change. Why is this change necessary? What features are lacking from the current toolset/language?
 
 ## Proposal
-
 This should be an in depth description of what major enhancements are actually being proposed in the RFC. Proposal should describe the finished state of the ruleset/toolchain with the given enhancements.
 
 ## Drawbacks
-
 What are the downsides of this change? Why shouldn't we do this? 
-
-
-
-


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Adds a bare bones RFC template and guide for creating. Based this off a couple RFC repos (https://github.com/rust-lang/rfcs, https://github.com/aws/aws-cdk-rfcs). I think as we create and engage more on this repo we can define this process. This seems like a good basic structure to have initially.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
