### PR TITLE
Fix makefile; test makefiles in CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,14 +18,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Build
-      run: cargo build --verbose --release
-    - name: Run tests
-      run: cargo test --verbose
-    - name: Test Makefiles
+    - name: Build and test makefiles
       run: |
         make
-        cd ./cfn-guard
-        make
-        cd ../cfn-guard-rulegen
-        make
+        make cfn-guard
+        make cfn-guard-rulegen
+    - name: Run tests
+      run: make test

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,3 +22,11 @@ jobs:
       run: cargo build --verbose --release
     - name: Run tests
       run: cargo test --verbose
+    - name: Test Makefiles
+      run: |
+      make
+      cd ./cfn-guard
+      make
+      cd ../cfn-guard-rulegen
+      make
+

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -24,9 +24,8 @@ jobs:
       run: cargo test --verbose
     - name: Test Makefiles
       run: |
-      make
-      cd ./cfn-guard
-      make
-      cd ../cfn-guard-rulegen
-      make
-
+        make
+        cd ./cfn-guard
+        make
+        cd ../cfn-guard-rulegen
+        make

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,13 @@
 .PHONY: cfn-guard cfn-guard-rulegen
 
+default:
+	cargo build --verbose --release; cp target/release/cfn-guard ./bin
+
 cfn-guard:
-	cargo build --release; cp target/release/cfn-guard ./bin
+	cd cfn-guard; make
 
 cfn-guard-rulegen:
-	cargo build --release; cp target/release/cfn-guard-rulegen ./bin
+	cd cfn-guard-rulegen; make
 
 cfn-guard-lambda_install:
 	cd cfn-guard-lambda; make install
@@ -16,7 +19,7 @@ clean:
 	if test -f cloudformation-guard.tar.gz; then rm cloudformation-guard.tar.gz; fi
 
 test:
-	cargo test
+	cargo test --verbose
 
 release_with_binaries: clean cfn-guard cfn-guard-rulegen
 	tar czvf cloudformation-guard.tar.gz -X Exclude.txt .

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
 .PHONY: cfn-guard cfn-guard-rulegen
 
+default:
+	cargo build --release; cp target/release/cfn-guard ./bin
+
 cfn-guard:
 	cargo build --release; cp target/release/cfn-guard ./bin
 

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,5 @@
 .PHONY: cfn-guard cfn-guard-rulegen
 
-default:
-	cargo build --release; cp target/release/cfn-guard ./bin
-
 cfn-guard:
 	cargo build --release; cp target/release/cfn-guard ./bin
 

--- a/cfn-guard-rulegen/Makefile
+++ b/cfn-guard-rulegen/Makefile
@@ -1,2 +1,2 @@
 default:
-	cargo build --release; cp target/release/cfn-guard-rulegen ./bin
+	cargo build --release; cp ../target/release/cfn-guard-rulegen ../bin

--- a/cfn-guard/Makefile
+++ b/cfn-guard/Makefile
@@ -1,2 +1,2 @@
 default:
-	cargo build --release; cp target/release/cfn-guard ./bin
+	cargo build --release; cp ../target/release/cfn-guard ../bin


### PR DESCRIPTION
*Issue #, if available:* #85

*Description of changes:* This fixes the rulegen and guard makefiles while also ensuring that these are tested in the CI. Since the commands run by make were the same as the ones tested in the CI, just replaced the CI commands with make commands so both paths are tested.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
