### PR TITLE
Add instructions on how to install via cargo

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,14 @@ Everything that can be checked from the command-line version of the tool can be 
 
 ## Installation
 
+If you have [rust and cargo installed](https://doc.rust-lang.org/cargo/getting-started/installation.html), installation is easy via cargo:
+
+```
+cargo install cfn-guard
+```
+
+If cargo and rust are not installed on your machine, we also offer other installation paths:
+
 ### Mac
 
 The CLI tool for cfn-guard is available via [homebrew](https://formulae.brew.sh/formula/cloudformation-guard).


### PR DESCRIPTION
*Issue #, if available:* #106, #73, #72

*Description of changes:* Clarifies how to install the tool via cargo. If rust and cargo are installed on your machine, installation is platform independent and more reliable than our vended binaries via cargo. Surfacing this as an option for users of the tool.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
