### PR TITLE
Fix Cargo.toml "author" lines

### DIFF
--- a/cfn-guard-lambda/Cargo.toml
+++ b/cfn-guard-lambda/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cfn-guard-lambda"
 version = "1.0.0"
 edition = "2018"
-authors = ["John Tompkins <jotompki@amazon.com>", "aws-cloudformation-developers <aws-cloudformation-developers@amazon.com>"]
+authors = ["Nathan McCourtney", "John Tompkins <jotompki@amazon.com>", "aws-cloudformation-developers <aws-cloudformation-developers@amazon.com>"]
 description = "Lambda version of cfn-guard. Checks AWS CloudFormation templates for policy compliance using a simple, policy-as-code, declarative syntax"
 license = "Apache-2.0"
 repository = "https://github.com/aws-cloudformation/cloudformation-guard"

--- a/cfn-guard-rulegen-lambda/Cargo.toml
+++ b/cfn-guard-rulegen-lambda/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cfn-guard-rulegen-lambda"
 version = "1.0.0"
 edition = "2018"
-authors = ["John Tompkins <jotompki@amazon.com>", "aws-cloudformation-developers <aws-cloudformation-developers@amazon.com>"]
+authors = ["John Capps", "John Tompkins <jotompki@amazon.com>", "aws-cloudformation-developers <aws-cloudformation-developers@amazon.com>"]
 description = "Lambda version of cfn-guard-rulegen. Takes a CloudFormation template and autogenerates a set of cfn-guard rules that match the properties of its resources. This is a useful way to get started rule-writing or just create ready-to-use rulesets from known-good templates."
 license = "Apache-2.0"
 repository = "https://github.com/aws-cloudformation/cloudformation-guard"

--- a/cfn-guard-rulegen/Cargo.toml
+++ b/cfn-guard-rulegen/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cfn-guard-rulegen"
 version = "1.0.0"
 edition = "2018"
-authors = ["John Tompkins <jotompki@amazon.com>", "aws-cloudformation-developers <aws-cloudformation-developers@amazon.com>"]
+authors = ["Nathan McCourtney", "John Tompkins <jotompki@amazon.com>", "aws-cloudformation-developers <aws-cloudformation-developers@amazon.com>"]
 description = "rulegen takes a CloudFormation template and autogenerates a set of cfn-guard rules that match the properties of its resources. This is a useful way to get started rule-writing or just create ready-to-use rulesets from known-good templates."
 license = "Apache-2.0"
 repository = "https://github.com/aws-cloudformation/cloudformation-guard"

--- a/cfn-guard/Cargo.toml
+++ b/cfn-guard/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cfn-guard"
 version = "1.0.0"
 edition = "2018"
-authors = ["John Tompkins <jotompki@amazon.com>", "aws-cloudformation-developers <aws-cloudformation-developers@amazon.com>"]
+authors = ["Nathan McCourtney", "John Tompkins <jotompki@amazon.com>", "aws-cloudformation-developers <aws-cloudformation-developers@amazon.com>"]
 description = "Library for checking AWS CloudFormation templates for policy compliance using a simple, policy-as-code, declarative syntax"
 license = "Apache-2.0"
 repository = "https://github.com/aws-cloudformation/cloudformation-guard"


### PR DESCRIPTION
# What
Fix the author fields in Cargo.toml

# Why

Proper attribution:  https://doc.rust-lang.org/cargo/reference/manifest.html#the-authors-field

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
