### PR TITLE
add security rules for ECS task definition

### DIFF
--- a/Examples/security_rules.ruleset
+++ b/Examples/security_rules.ruleset
@@ -43,6 +43,20 @@ AWS::EC2::Instance SourceDestCheck != false << EC2 source destination check shou
 
 AWS::EC2::Volume Encrypted == true << EC2 volumes should be encrypted
 
+AWS::ECS::TaskDefinition Cpu == /.*/ << CPU limit should be set for a task
+AWS::ECS::TaskDefinition Memory == /.*/ << Memory limit should be set for task
+AWS::ECS::TaskDefinition ContainerDefinitions.*.Memory == /.*/ << container should have a memory limit
+AWS::ECS::TaskDefinition ContainerDefinitions.*.Cpu == /.*/ << cpu limit should be set for container
+AWS::ECS::TaskDefinition ContainerDefinitions.*.DockerSecurityOptions == /.*/ << docker security options should be set
+AWS::ECS::TaskDefinition ContainerDefinitions.*.ReadonlyRootFilesystem == true << container file system should be set as read-only
+AWS::ECS::TaskDefinition ContainerDefinitions.*.Ulimits == /.*/ << ulimits should be set in a container
+AWS::ECS::TaskDefinition ContainerDefinitions.*.User != root << container should be run as a non-root user
+AWS::ECS::TaskDefinition ContainerDefinitions.*.User != 0 << container should be run as a non-root user
+AWS::ECS::TaskDefinition WHEN RequiresCompatibilities == ["EC2"] CHECK IpcMode IN [none, task] << IPC mode should not be set to host
+AWS::ECS::TaskDefinition WHEN RequiresCompatibilities == ["EC2"] CHECK PidMode != host << PidMode should be set to task or left blank for enabling private namespace
+AWS::ECS::TaskDefinition WHEN RequiresCompatibilities == ["EC2"] CHECK ContainerDefinitions.*.Privileged == false << container should not run with all linux capabilties
+
+
 AWS::EFS::FileSystem Encrypted == true << EFS file system should be encrypted
 
 AWS::EKS::Cluster EncryptionConfig.Provider.KeyArn == /.*/ << EKS cluster encryption config should be set

--- a/Examples/security_template.json
+++ b/Examples/security_template.json
@@ -1,8 +1,8 @@
 {
     "Resources": {
-        "AmazonMQBroker" : {
-            "Type" : "AWS::AmazonMQ::Broker",
-            "Properties" : {
+        "AmazonMQBroker": {
+            "Type": "AWS::AmazonMQ::Broker",
+            "Properties": {
                 "AutoMinorVersionUpgrade": false,
                 "EncryptionOptions": {
                     "UseAwsOwnedKey": true
@@ -15,125 +15,331 @@
                 "PubliclyAccessible": true
             }
         },
-        "ApiGatewayDomain" : {
-            "Type" : "AWS::ApiGateway::DomainName",
-            "Properties" : {
+        "ApiGatewayDomain": {
+            "Type": "AWS::ApiGateway::DomainName",
+            "Properties": {
                 "DomainName": "test.com",
                 "SecurityPolicy": "TLS_1_0"
             }
         },
-        "ApiGatewayDomainSecure" : {
-            "Type" : "AWS::ApiGateway::DomainName",
-            "Properties" : {
+        "ApiGatewayDomainSecure": {
+            "Type": "AWS::ApiGateway::DomainName",
+            "Properties": {
                 "DomainName": "test.com",
                 "SecurityPolicy": "TLS_1_2"
             }
         },
-        "CloudFrontDistribution" : {
-            "Type" : "AWS::CloudFront::Distribution",
-            "Properties" : {
-                "ViewerCertificate" : {
-                    "MinimumProtocolVersion" : "TLSv1"
+        "CloudFrontDistribution": {
+            "Type": "AWS::CloudFront::Distribution",
+            "Properties": {
+                "ViewerCertificate": {
+                    "MinimumProtocolVersion": "TLSv1"
                 }
             }
         },
-        "CloudTrailTrail" : {
-            "Type" : "AWS::CloudTrail::Trail",
-            "Properties" : {
-                "EnableLogFileValidation" : false,
+        "CloudTrailTrail": {
+            "Type": "AWS::CloudTrail::Trail",
+            "Properties": {
+                "EnableLogFileValidation": false,
                 "IncludeGlobalServiceEvents": false,
                 "IsLogging": false,
                 "IsMultiRegionTrail": false
             }
         },
-        "CodeBuildProject" : {
-            "Type" : "AWS::CodeBuild::Project",
-            "Properties" : {
-                
-            }
+        "CodeBuildProject": {
+            "Type": "AWS::CodeBuild::Project",
+            "Properties": {}
         },
-        "CodeBuildCredentials" : {
-            "Type" : "AWS::CodeBuild::SourceCredential",
-            "Properties" : {
+        "CodeBuildCredentials": {
+            "Type": "AWS::CodeBuild::SourceCredential",
+            "Properties": {
                 "Token": "{{resolve:secretsmanager}}"
             }
         },
-        "CodeStarRepo" : {
-            "Type" : "AWS::CodeStar::GitHubRepository",
-            "Properties" : {
+        "CodeStarRepo": {
+            "Type": "AWS::CodeStar::GitHubRepository",
+            "Properties": {
                 "IsPrivate": false
             }
         },
-        "DMSInstance" : {
-            "Type" : "AWS::DMS::ReplicationInstance",
-            "Properties" : {
+        "DMSInstance": {
+            "Type": "AWS::DMS::ReplicationInstance",
+            "Properties": {
                 "AllowMajorVersionUpgrade": false,
                 "AutoMinorVersionUpgrade": false,
                 "MultiAZ": false,
                 "PubliclyAccessible": true
             }
         },
-        "DocDBCluster" : {
-            "Type" : "AWS::DocDB::DBCluster",
-            "Properties" : {
+        "DocDBCluster": {
+            "Type": "AWS::DocDB::DBCluster",
+            "Properties": {
                 "BackupRetentionPeriod": 1,
                 "StorageEncrypted": false
             }
         },
-        "DynamoDBTable" : {
-            "Type" : "AWS::DynamoDB::Table",
-            "Properties" : {
+        "DynamoDBTable": {
+            "Type": "AWS::DynamoDB::Table",
+            "Properties": {
                 "SSESpecification": {
                     "SSEEnabled": false
                 }
             }
         },
-        "EC2Instance" : {
-            "Type" : "AWS::EC2::Instance",
-            "Properties" : {
+        "EC2Instance": {
+            "Type": "AWS::EC2::Instance",
+            "Properties": {
                 "SourceDestCheck": false
             }
         },
-        "EC2SecurityGroup" : {
-            "Type" : "AWS::EC2::SecurityGroup",
-            "Properties" : {
+        "EC2SecurityGroup": {
+            "Type": "AWS::EC2::SecurityGroup",
+            "Properties": {
                 "CidrIp": "0.0.0.0/0",
                 "FromPort": 22,
                 "ToPort": 22
             }
         },
-        "EC2Volume" : {
-            "Type" : "AWS::EC2::Volume",
-            "Properties" : {
+        "EC2Volume": {
+            "Type": "AWS::EC2::Volume",
+            "Properties": {
                 "Encrypted": false
             }
         },
-        "EFSFileSystem" : {
-            "Type" : "AWS::EFS::FileSystem",
-            "Properties" : {
-                "Encrypted": false
-            }
-        },
-        "EKSCluster" : {
-            "Type" : "AWS::EKS::Cluster",
-            "Properties" : {
-                "EncryptionConfig": {
-                    "Provider": {
-                        
+        "ECSTask": {
+            "Type": "AWS::ECS::TaskDefinition",
+            "Properties": {
+                "ContainerDefinitions": [
+                    {
+                        "Command": [
+                            "CMD-SHELL"
+                        ],
+                        "Cpu": 128,
+                        "DisableNetworking": true,
+                        "DnsSearchDomains": [
+                            "example.com"
+                        ],
+                        "DnsServers": [
+                            "10.0.0.1"
+                        ],
+                        "DockerLabels": {
+                            "key": "fooLabel",
+                            "value": "barLabel"
+                        },
+                        "DockerSecurityOptions": [
+                            "no-new-privileges"
+                        ],
+                        "EntryPoint": [
+                            "top",
+                            "-b"
+                        ],
+                        "Essential": true,
+                        "ExtraHosts": [
+                            {
+                                "Hostname": "name",
+                                "IpAddress": "10.0.0.19"
+                            }
+                        ],
+                        "HealthCheck": {
+                            "Command": [
+                                "CMD-SHELL",
+                                "curl localhost:8000"
+                            ],
+                            "Interval": 30,
+                            "Retries": 3,
+                            "Timeout": 5
+                        },
+                        "Hostname": "host.example.com",
+                        "Image": "/aws/aws-example-app",
+                        "Ulimits": {
+                            "HardLimit": 1024,
+                            "Name": "nofile",
+                            "SoftLimit": 512
+                        },
+                        "LinuxParameters": {
+                            "Capabilities": {
+                                "Drop": [
+                                    "SETUID",
+                                    "SETGID",
+                                    "FOWNER"
+                                ]
+                            }
+                        },
+                        "LogConfiguration": {
+                            "LogDriver": "awslogs",
+                            "Options": {
+                                "awslogs-group": {
+                                    "Ref": "ContainerLogGroupE6FD74A4"
+                                },
+                                "awslogs-stream-prefix": "prefix",
+                                "awslogs-region": {
+                                    "Ref": "AWS::Region"
+                                }
+                            }
+                        },
+                        "Memory": 1024,
+                        "MemoryReservation": 512,
+                        "Name": "Container",
+                        "Privileged": false,
+                        "ReadonlyRootFilesystem": true,
+                        "ResourceRequirements": [
+                            {
+                                "Type": "GPU",
+                                "Value": "16"
+                            }
+                        ],
+                        "StartTimeout": 2,
+                        "StopTimeout": 5,
+                        "User": "test",
+                        "WorkingDirectory": "a/b/c"
                     }
+                ],
+                "Cpu": "512",
+                "Memory": "1024",
+                "ExecutionRoleArn": {
+                    "Fn::GetAtt": [
+                        "TaskDefExecutionRoleB4775C97",
+                        "Arn"
+                    ]
+                },
+                "Family": "TestStackTaskDefA6238255",
+                "IpcMode": "none",
+                "PidMode": "task",
+                "NetworkMode": "bridge",
+                "RequiresCompatibilities": [
+                    "EC2"
+                ],
+                "TaskRoleArn": {
+                    "Fn::GetAtt": [
+                        "TaskDefTaskRole1EDB4A67",
+                        "Arn"
+                    ]
                 }
             }
         },
-        "ElastiCacheCluster" : {
-            "Type" : "AWS::ElastiCache::CacheCluster",
-            "Properties" : {
+        "InsecureECSTask": {
+            "Type": "AWS::ECS::TaskDefinition",
+            "Properties": {
+                "ContainerDefinitions": [
+                    {
+                        "Command": [
+                            "CMD-SHELL"
+                        ],
+                        "DisableNetworking": true,
+                        "DnsSearchDomains": [
+                            "example.com"
+                        ],
+                        "DnsServers": [
+                            "10.0.0.1"
+                        ],
+                        "DockerLabels": {
+                            "key": "fooLabel",
+                            "value": "barLabel"
+                        },
+                        "EntryPoint": [
+                            "top",
+                            "-b"
+                        ],
+                        "Essential": true,
+                        "ExtraHosts": [
+                            {
+                                "Hostname": "name",
+                                "IpAddress": "10.0.0.19"
+                            }
+                        ],
+                        "HealthCheck": {
+                            "Command": [
+                                "CMD-SHELL",
+                                "curl localhost:8000"
+                            ],
+                            "Interval": 30,
+                            "Retries": 3,
+                            "Timeout": 5
+                        },
+                        "Hostname": "host.example.com",
+                        "Image": "/aws/aws-example-app",
+                        "LinuxParameters": {
+                            "Capabilities": {
+                                "Drop": [
+                                    "SETUID",
+                                    "SETGID",
+                                    "FOWNER"
+                                ]
+                            }
+                        },
+                        "LogConfiguration": {
+                            "LogDriver": "awslogs",
+                            "Options": {
+                                "awslogs-group": {
+                                    "Ref": "ContainerLogGroupE6FD74A4"
+                                },
+                                "awslogs-stream-prefix": "prefix",
+                                "awslogs-region": {
+                                    "Ref": "AWS::Region"
+                                }
+                            }
+                        },
+                        "MemoryReservation": 512,
+                        "Name": "Container",
+                        "Privileged": true,
+                        "ReadonlyRootFilesystem": false,
+                        "ResourceRequirements": [
+                            {
+                                "Type": "GPU",
+                                "Value": "16"
+                            }
+                        ],
+                        "StartTimeout": 2,
+                        "StopTimeout": 5,
+                        "User": "root",
+                        "WorkingDirectory": "a/b/c"
+                    }
+                ],
+                "ExecutionRoleArn": {
+                    "Fn::GetAtt": [
+                        "TaskDefExecutionRoleB4775C97",
+                        "Arn"
+                    ]
+                },
+                "Family": "TestStackTaskDefA6238255",
+                "IpcMode": "host",
+                "PidMode": "host",
+                "NetworkMode": "bridge",
+                "RequiresCompatibilities": [
+                    "EC2"
+                ],
+                "TaskRoleArn": {
+                    "Fn::GetAtt": [
+                        "TaskDefTaskRole1EDB4A67",
+                        "Arn"
+                    ]
+                }
+            }
+        },
+        "EFSFileSystem": {
+            "Type": "AWS::EFS::FileSystem",
+            "Properties": {
+                "Encrypted": false
+            }
+        },
+        "EKSCluster": {
+            "Type": "AWS::EKS::Cluster",
+            "Properties": {
+                "EncryptionConfig": {
+                    "Provider": {}
+                }
+            }
+        },
+        "ElastiCacheCluster": {
+            "Type": "AWS::ElastiCache::CacheCluster",
+            "Properties": {
                 "AutoMinorVersionUpgrade": false,
                 "SnapshotRetentionLimit": 1
             }
         },
-        "ElasticsearchDomain" : {
-            "Type" : "AWS::Elasticsearch::Domain",
-            "Properties" : {
+        "ElasticsearchDomain": {
+            "Type": "AWS::Elasticsearch::Domain",
+            "Properties": {
                 "EncryptionAtRestOptions": {
                     "Enabled": false
                 },
@@ -142,74 +348,64 @@
                 }
             }
         },
-        "ELB" : {
-            "Type" : "AWS::ElasticLoadBalancing::LoadBalancer",
-            "Properties" : {
+        "ELB": {
+            "Type": "AWS::ElasticLoadBalancing::LoadBalancer",
+            "Properties": {
                 "AccessLoggingPolicy": {
                     "Enabled": false
                 }
             }
         },
-        "FsXFilesystem" : {
-            "Type" : "AWS::FSx::FileSystem",
-            "Properties" : {
-                
-            }
+        "FsXFilesystem": {
+            "Type": "AWS::FSx::FileSystem",
+            "Properties": {}
         },
-        "GuardDutyDetector" : {
-            "Type" : "AWS::GuardDuty::Detector",
-            "Properties" : {
+        "GuardDutyDetector": {
+            "Type": "AWS::GuardDuty::Detector",
+            "Properties": {
                 "Enabled": true
             }
         },
-        "ImageBuilderComponent" : {
-            "Type" : "AWS::ImageBuilder::Component",
-            "Properties" : {
-                
-            }
+        "ImageBuilderComponent": {
+            "Type": "AWS::ImageBuilder::Component",
+            "Properties": {}
         },
         "ImageBuilderInfrastructureConfiguration": {
             "Type": "AWS::ImageBuilder::InfrastructureConfiguration",
             "Properties": {
-                "Logging": {
-                    
-                }
+                "Logging": {}
             }
         },
-        "KinesisStream" : {
-            "Type" : "AWS::Kinesis::Stream",
-            "Properties" : {
+        "KinesisStream": {
+            "Type": "AWS::Kinesis::Stream",
+            "Properties": {
                 "StreamEncryption": {
                     "EncryptionType": "invalid"
                 }
             }
         },
-        "KMSKey" : {
-            "Type" : "AWS::KMS::Key",
-            "Properties" : {
+        "KMSKey": {
+            "Type": "AWS::KMS::Key",
+            "Properties": {
                 "EnableKeyRotation": false
             }
         },
-        "LambdaFunction" : {
-            "Type" : "AWS::Lambda::Function",
-            "Properties" : {
-                "VpcConfig": {
-
-                }
+        "LambdaFunction": {
+            "Type": "AWS::Lambda::Function",
+            "Properties": {
+                "VpcConfig": {}
             }
         },
-        "MediaStoreContainer" : {
-            "Type" : "AWS::MediaStore::Container",
-            "Properties" : {
+        "MediaStoreContainer": {
+            "Type": "AWS::MediaStore::Container",
+            "Properties": {
                 "AccessLoggingEnabled": false
             }
         },
-        "MSKCluster" : {
-            "Type" : "AWS::MSK::Cluster",
-            "Properties" : {
-                "ClientAuthentication": {
-                    
-                },
+        "MSKCluster": {
+            "Type": "AWS::MSK::Cluster",
+            "Properties": {
+                "ClientAuthentication": {},
                 "EncryptionInfo": {
                     "EncryptionAtRest": false,
                     "EncryptionInTransit": false
@@ -217,44 +413,44 @@
                 "EnhancedMonitoring": "PER_BROKER"
             }
         },
-        "NeptuneCluster" : {
-            "Type" : "AWS::Neptune::DBCluster",
-            "Properties" : {
+        "NeptuneCluster": {
+            "Type": "AWS::Neptune::DBCluster",
+            "Properties": {
                 "BackupRetentionPeriod": 1,
                 "IamAuthEnabled": false,
                 "StorageEncrypted": false
             }
         },
-        "NeptuneInstance" : {
-            "Type" : "AWS::Neptune::DBInstance",
-            "Properties" : {
+        "NeptuneInstance": {
+            "Type": "AWS::Neptune::DBInstance",
+            "Properties": {
                 "AllowMajorVersionUpgrade": false,
                 "AutoMinorVersionUpgrade": false
             }
         },
-        "OpsWorksApp" : {
-            "Type" : "AWS::OpsWorks::App",
-            "Properties" : {
+        "OpsWorksApp": {
+            "Type": "AWS::OpsWorks::App",
+            "Properties": {
                 "EnableSslx": false
             }
         },
-        "OpsWorksCMServer" : {
-            "Type" : "AWS::OpsWorksCM::Server",
-            "Properties" : {
+        "OpsWorksCMServer": {
+            "Type": "AWS::OpsWorksCM::Server",
+            "Properties": {
                 "AssociatePublicIpAddress": true,
                 "DisableAutomatedBackup": true
             }
         },
-        "RDSDBCluster" : {
-            "Type" : "AWS::RDS::DBCluster",
-            "Properties" : {
+        "RDSDBCluster": {
+            "Type": "AWS::RDS::DBCluster",
+            "Properties": {
                 "BackupRetentionPeriod": 1,
                 "StorageEncrypted": false
             }
         },
-        "RDSDBInstance" : {
-            "Type" : "AWS::RDS::DBInstance",
-            "Properties" : {
+        "RDSDBInstance": {
+            "Type": "AWS::RDS::DBInstance",
+            "Properties": {
                 "AllowMajorVersionUpgrade": false,
                 "AutoMinorVersionUpgrade": false,
                 "BackupRetentionPeriod": 1,
@@ -262,25 +458,25 @@
                 "StorageEncrypted": false
             }
         },
-        "RDSDBProxy" : {
-            "Type" : "AWS::RDS::DBProxy",
-            "Properties" : {
+        "RDSDBProxy": {
+            "Type": "AWS::RDS::DBProxy",
+            "Properties": {
                 "DebugLogging": true,
                 "RequireTLS": false
             }
         },
-        "RedshiftCluster" : {
-            "Type" : "AWS::Redshift::Cluster",
-            "Properties" : {
+        "RedshiftCluster": {
+            "Type": "AWS::Redshift::Cluster",
+            "Properties": {
                 "AllowVersionUpgrade": false,
                 "AutomatedSnapshotRetentionPeriod": 1,
                 "Encrypted": false,
                 "PubliclyAccessible": true
             }
         },
-        "S3AccessPoint" : {
-            "Type" : "AWS::S3::AccessPoint",
-            "Properties" : {
+        "S3AccessPoint": {
+            "Type": "AWS::S3::AccessPoint",
+            "Properties": {
                 "PublicAccessBlockConfiguration": {
                     "BlockPublicAcls": false,
                     "BlockPublicPolicy": false,
@@ -289,9 +485,9 @@
                 }
             }
         },
-        "S3Bucket" : {
-            "Type" : "AWS::S3::AccessPoint",
-            "Properties" : {
+        "S3Bucket": {
+            "Type": "AWS::S3::AccessPoint",
+            "Properties": {
                 "PublicAccessBlockConfiguration": {
                     "BlockPublicAcls": false,
                     "BlockPublicPolicy": false,
@@ -300,34 +496,28 @@
                 }
             }
         },
-        "SageMakerNotebook" : {
-            "Type" : "AWS::SageMaker::NotebookInstance",
-            "Properties" : {
+        "SageMakerNotebook": {
+            "Type": "AWS::SageMaker::NotebookInstance",
+            "Properties": {
                 "DirectInternetAccess": "Enabled",
                 "RootAccess": true
             }
         },
-        "SNSTopic" : {
-            "Type" : "AWS::SNS::Topic",
-            "Properties" : {
-                
-            }
+        "SNSTopic": {
+            "Type": "AWS::SNS::Topic",
+            "Properties": {}
         },
-        "SQSQueue" : {
-            "Type" : "AWS::SQS::Queue",
-            "Properties" : {
-                
-            }
+        "SQSQueue": {
+            "Type": "AWS::SQS::Queue",
+            "Properties": {}
         },
-        "StepFunctionsStateMachine" : {
-            "Type" : "AWS::StepFunctions::StateMachine",
-            "Properties" : {
-                
-            }
+        "StepFunctionsStateMachine": {
+            "Type": "AWS::StepFunctions::StateMachine",
+            "Properties": {}
         },
-        "WorkspacesWorkspace" : {
-            "Type" : "AWS::WorkSpaces::Workspace",
-            "Properties" : {
+        "WorkspacesWorkspace": {
+            "Type": "AWS::WorkSpaces::Workspace",
+            "Properties": {
                 "RootVolumeEncryptionEnabled": false,
                 "UserVolumeEncryptionEnabled": false
             }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adding security rules for [`AWS::ECS::TaskDefinition`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-ecs-taskdefinition.html) resource . 

Added secure and insecure resources to the `security_template.json`. 

See results for `[InsecureECSTask]` in the following test output : 

```
codespace ➜ ~/workspace/cloudformation-guard/bin (master ✗) $ ./cfn-guard check  -t "/home/codespace/workspace/cloudformation-guard/Examples/security_template.json" -r "/home/codespace/workspace/cloudformation-guard/Examples/security_rules.ruleset" --strict-checks
[AmazonMQBroker] failed because [AutoMinorVersionUpgrade] is [false] and Version upgrades should be enabled to receive security updates
[AmazonMQBroker] failed because [EncryptionOptions.UseAwsOwnedKey] is [true] and CMKs should be used instead of AWS-provided KMS keys
[AmazonMQBroker] failed because [EngineVersion] is [5.15.9] and Broker engine version should be at least 5.15.10
[AmazonMQBroker] failed because [Logs.Audit] is [false] and Audit logging should be enabled
[AmazonMQBroker] failed because [Logs.General] is [false] and General logging should be enabled
[AmazonMQBroker] failed because [PubliclyAccessible] is [true] and Broker should not be publicly accessible
[ApiGatewayDomain] failed because [SecurityPolicy] is [TLS_1_0] and API Gateway DomainName SecurityPolicy should use TLS 1.2
[CloudFrontDistribution] failed because [ViewerCertificate.MinimumProtocolVersion] is [TLSv1] and CloudFront TLS version should be 1.2
[CloudTrailTrail] failed because [EnableLogFileValidation] is [false] and CloudTrail file validation should be enabled
[CloudTrailTrail] failed because [IncludeGlobalServiceEvents] is [false] and CloudTrail should include global service events
[CloudTrailTrail] failed because [IsLogging] is [false] and CloudTrail logging should be enabled
[CloudTrailTrail] failed because [IsMultiRegionTrail] is [false] and CloudTrail trails should cover all regions
[CodeBuildCredentials] failed because [Token] is [{{resolve:secretsmanager}}] and CodeBuild credentials should use a reference instead of plaintext
[CodeBuildProject] failed because CodeBuild projects should be built in a VPC
[CodeBuildProject] failed because CodeBuild should use a CMK instead of AWS-provided KMS keys
[CodeStarRepo] failed because [IsPrivate] is [false] and GitHub repository should be private
[DMSInstance] failed because A KMS key should be provided for encryption
[DMSInstance] failed because [AllowMajorVersionUpgrade] is [false] and DMS instance upgrades should be enabled
[DMSInstance] failed because [AutoMinorVersionUpgrade] is [false] and DMS instance upgrades should be enabled
[DMSInstance] failed because [MultiAZ] is [false] and DMS instance should be deployed in multiple AZs
[DMSInstance] failed because [PubliclyAccessible] is [true] and DMS instance should not be publicly accessible
[DocDBCluster] failed because [BackupRetentionPeriod] is [1] and Backups should be retained for set retention period
[DocDBCluster] failed because [StorageEncrypted] is [false] and Storage should be encrypted
[DynamoDBTable] failed because [SSESpecification.SSEEnabled] is [false] and DynamoDB tables should be encrypted with CMKs
[EC2Instance] failed because [SourceDestCheck] is [false] and EC2 source destination check should be enabled unless the instance is performing NAT
[EC2Volume] failed because [Encrypted] is [false] and EC2 volumes should be encrypted
[EFSFileSystem] failed because [Encrypted] is [false] and EFS file system should be encrypted
[EKSCluster] failed because EKS cluster encryption config should be set
[ELB] failed because [AccessLoggingPolicy.Enabled] is [false] and Load balancer logging should be enabled
[ElastiCacheCluster] failed because [AutoMinorVersionUpgrade] is [false] and ElastiCache upgrades should be enabled
[ElastiCacheCluster] failed because [SnapshotRetentionLimit] is [1] and Backups should be retained for set retention period
[ElasticsearchDomain] failed because [EncryptionAtRestOptions.Enabled] is [false] and Domain encryption should be enabled
[ElasticsearchDomain] failed because [NodeToNodeEncryptionOptions.Enabled] is [false] and Node-to-node encryption should be enabled
[FsXFilesystem] failed because CMKs should be used instead of AWS-provided KMS keys
[GuardDutyDetector] failed because Detector should be enabled
[ImageBuilderComponent] failed because A KMS key should be provided for encryption
[ImageBuilderInfrastructureConfiguration] failed because Logging should be enabled
[InsecureECSTask] failed because CPU limit should be set for a task
[InsecureECSTask] failed because Memory limit should be set for task
[InsecureECSTask] failed because [ContainerDefinitions.0.Privileged] is [true] and container should not run with all linux capabilties when AWS::ECS::TaskDefinition RequiresCompatibilities == ["EC2"]
[InsecureECSTask] failed because [ContainerDefinitions.0.ReadonlyRootFilesystem] is [false] and container file system should be set as read-only
[InsecureECSTask] failed because [ContainerDefinitions.0.User] is [root] and container should be run as a non-root user
[InsecureECSTask] failed because [IpcMode] is [host] and IPC mode should not be set to host when AWS::ECS::TaskDefinition RequiresCompatibilities == ["EC2"]
[InsecureECSTask] failed because [PidMode] is [host] and PidMode should be set to task or left blank for enabling private namespace when AWS::ECS::TaskDefinition RequiresCompatibilities == ["EC2"]
[InsecureECSTask] failed because container should have a memory limit
[InsecureECSTask] failed because cpu limit should be set for container
[InsecureECSTask] failed because docker security options should be set
[InsecureECSTask] failed because ulimits should be set in a container
[KMSKey] failed because [EnableKeyRotation] is [false] and Key rotation should be enabled
[KinesisStream] failed because [StreamEncryption.EncryptionType] is [invalid] and Stream encryption should be enabled
[LambdaFunction] failed because KMS key should be set for encryption
[MSKCluster] failed because Clusters should authenticate clients with TLS
[MSKCluster] failed because [EncryptionInfo.EncryptionAtRest] is [false] and Encryption at rest should be enabled
[MSKCluster] failed because [EncryptionInfo.EncryptionInTransit] is [false] and Encryption in transit should be enabled
[MSKCluster] failed because [EnhancedMonitoring] is [PER_BROKER] and Enhanced monitoring should be enabled
[MediaStoreContainer] failed because [AccessLoggingEnabled] is [false] and Logging should be enabled
[NeptuneCluster] failed because CloudWatch log exports should be enabled
[NeptuneCluster] failed because [BackupRetentionPeriod] is [1] and Backups should be retained for set retention period
[NeptuneCluster] failed because [IamAuthEnabled] is [false] and Cluster should use IAM authentication
[NeptuneCluster] failed because [StorageEncrypted] is [false] and Storage encryption should be enabled
[NeptuneInstance] failed because [AllowMajorVersionUpgrade] is [false] and Major version upgrades should be enabled to receive security updates
[NeptuneInstance] failed because [AutoMinorVersionUpgrade] is [false] and Minor version upgrades should be enabled to receive security updates
[OpsWorksApp] failed because TLS should be enabled
[OpsWorksCMServer] failed because [AssociatePublicIpAddress] is [true] and Public IPs should not be assigned by default
[OpsWorksCMServer] failed because [DisableAutomatedBackup] is [true] and Backups should not be enabled
[RDSDBCluster] failed because CloudWatch log exports should be enabled
[RDSDBCluster] failed because [BackupRetentionPeriod] is [1] and Backups should be retained for set retention period
[RDSDBCluster] failed because [StorageEncrypted] is [false] and Storage encryption should be enabled
[RDSDBInstance] failed because CloudWatch log exports should be enabled
[RDSDBInstance] failed because [AllowMajorVersionUpgrade] is [false] and Major version upgrades should be enabled to receive security updates
[RDSDBInstance] failed because [AutoMinorVersionUpgrade] is [false] and Minor version upgrades should be enabled to receive security updates
[RDSDBInstance] failed because [BackupRetentionPeriod] is [1] and Backups should be retained for set retention period
[RDSDBInstance] failed because [PubliclyAccessible] is [true] and Databasae should not be publicly accessible
[RDSDBInstance] failed because [StorageEncrypted] is [false] and Storage encryption should be enabled
[RDSDBProxy] failed because [DebugLogging] is [true] and Debug logging should not be enabled to avoid exposing SQL queries
[RDSDBProxy] failed because [RequireTLS] is [false] and TLS should be required for proxy connections
[RedshiftCluster] failed because [AllowVersionUpgrade] is [false] and Minor version upgrades should be enabled to receive security updates
[RedshiftCluster] failed because [AutomatedSnapshotRetentionPeriod] is [1] and Backups should be retained for set retention period
[RedshiftCluster] failed because [Encrypted] is [false] and Storage encryption should be enabled
[RedshiftCluster] failed because [PubliclyAccessible] is [true] and Databasae should not be publicly accessible
[S3AccessPoint] failed because [PublicAccessBlockConfiguration.BlockPublicAcls] is [false] and S3 should be set to block public ACLs
[S3AccessPoint] failed because [PublicAccessBlockConfiguration.BlockPublicPolicy] is [false] and S3 should be set to block public policies
[S3AccessPoint] failed because [PublicAccessBlockConfiguration.IgnorePublicAcls] is [false] and S3 should be set to ignore public ACLs
[S3AccessPoint] failed because [PublicAccessBlockConfiguration.RestrictPublicBuckets] is [false] and S3 should be set to restrict public buckets
[S3Bucket] failed because [PublicAccessBlockConfiguration.BlockPublicAcls] is [false] and S3 should be set to block public ACLs
[S3Bucket] failed because [PublicAccessBlockConfiguration.BlockPublicPolicy] is [false] and S3 should be set to block public policies
[S3Bucket] failed because [PublicAccessBlockConfiguration.IgnorePublicAcls] is [false] and S3 should be set to ignore public ACLs
[S3Bucket] failed because [PublicAccessBlockConfiguration.RestrictPublicBuckets] is [false] and S3 should be set to restrict public buckets
[SNSTopic] failed because KMS encryption should be enabled
[SQSQueue] failed because KMS encryption should be enabled
[SageMakerNotebook] failed because KMS encryption should be enabled
[SageMakerNotebook] failed because [DirectInternetAccess] is [Enabled] and Notebooks should not have direct internet access
[SageMakerNotebook] failed because [RootAccess] is [true] and Root access for users should be disabled
[StepFunctionsStateMachine] failed because Logging should be enabled
[WorkspacesWorkspace] failed because [RootVolumeEncryptionEnabled] is [false] and Encryption should be enabled
[WorkspacesWorkspace] failed because [UserVolumeEncryptionEnabled] is [false] and Encryption should be enabled
Number of failures: 96
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
