### PR TITLE
Adding cut-n-paste installation instructions for MacOS and Ubuntu 

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,36 +153,21 @@ These tenets help guide the development of the Guard DSL:
 
 ##### MacOS
 
+By default this is builds for macOS-10 (Catalina). It has been tested to work on macOS-11 (BigSpur). See [OS Matix](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#github-hosted-runners)
+
 1. Open terminal of your choice. Default `Cmd+Space`, type `terminal`
 2. Cut-n-paste the commands below (change version=X for other versions)
- ```bash
-curl -fsSLI -o /dev/null -w %{url_effective} https://github.com/aws-cloudformation/cloudformation-guard/releases/latest | \
-awk -F '/' '{print $NF}' | awk -F '.' '{ print $1 "\n" $0 }' | \
-while read major; read version; do
-mkdir -p ~/.guard/$major ~/.guard/bin && \
-wget https://github.com/aws-cloudformation/cloudformation-guard/releases/download/$version/cfn-guard-v$major-macos-latest.tar.gz -O /tmp/guard.tar.gz && \
-tar -C ~/.guard/$major -xzf /tmp/guard.tar.gz && \
-ln -sf ~/.guard/$major/cfn-guard-v$major-macos-latest/cfn-guard ~/.guard/bin && \
-~/.guard/bin/cfn-guard help && \
-echo "Set PATH to PATH=${PATH}/:~/.guard/bin"
-done
+```bash
+$ curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/aws-cloudformation/cloudformation-guard/main/install-guard.sh | sh
 ```
+Remember to add `~/.guard/bin/` to your `$PATH`.
 
 ##### Ubuntu
 
 1. Open any terminal of your choice
 2. Cut-n-paste the commands below (change version=X for other versions)
 ```bash
-curl -fsSLI -o /dev/null -w %{url_effective} https://github.com/aws-cloudformation/cloudformation-guard/releases/latest | \
-awk -F '/' '{print $NF}' | awk -F '.' '{ print $1 "\n" $0 }' | \
-while read major; read version; do
-mkdir -p ~/.guard/$major ~/.guard/bin && \
-wget https://github.com/aws-cloudformation/cloudformation-guard/releases/download/$version/cfn-guard-v$major-ubuntu-latest.tar.gz -O /tmp/guard.tar.gz && \
-tar -C ~/.guard/$major -xzf /tmp/guard.tar.gz && \
-ln -sf ~/.guard/$major/cfn-guard-v$major-ubuntu-latest/cfn-guard ~/.guard/bin && \
-~/.guard/bin/cfn-guard help && \
-echo "Set PATH to PATH=${PATH}/:~/.guard/bin"
-done
+$ curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/aws-cloudformation/cloudformation-guard/main/install-guard.sh | sh
 ```
 
 Remember to add `~/.guard/bin/` to your `$PATH`.

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ These tenets help guide the development of the Guard DSL:
 
 ##### MacOS
 
-By default this is builds for macOS-10 (Catalina). It has been tested to work on macOS-11 (BigSpur). See [OS Matix](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#github-hosted-runners)
+By default this is built for macOS-10 (Catalina). It has been tested to work on macOS-11 (BigSpur). See [OS Matix](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#github-hosted-runners)
 
 1. Open terminal of your choice. Default `Cmd+Space`, type `terminal`
 2. Cut-n-paste the commands below (change version=X for other versions)

--- a/README.md
+++ b/README.md
@@ -149,6 +149,44 @@ These tenets help guide the development of the Guard DSL:
 
 ### Installation
 
+#### Installation from Pre-Built Release Binaries
+
+##### MacOS
+
+1. Open terminal of your choice. Default `Cmd+Space`, type `terminal`
+2. Cut-n-paste the commands below (change version=X for other versions)
+ ```bash
+curl -fsSLI -o /dev/null -w %{url_effective} https://github.com/aws-cloudformation/cloudformation-guard/releases/latest | \
+awk -F '/' '{print $NF}' | awk -F '.' '{ print $1 "\n" $0 }' | \
+while read major; read version; do
+mkdir -p ~/.guard/$major ~/.guard/bin && \
+wget https://github.com/aws-cloudformation/cloudformation-guard/releases/download/$version/cfn-guard-v$major-macos-latest.tar.gz -O /tmp/guard.tar.gz && \
+tar -C ~/.guard/$major -xzf /tmp/guard.tar.gz && \
+ln -sf ~/.guard/$major/cfn-guard-v$major-macos-latest/cfn-guard ~/.guard/bin && \
+~/.guard/bin/cfn-guard help && \
+echo "Set PATH to PATH=${PATH}/:~/.guard/bin"
+done
+```
+
+##### Ubuntu
+
+1. Open any terminal of your choice
+2. Cut-n-paste the commands below (change version=X for other versions)
+```bash
+curl -fsSLI -o /dev/null -w %{url_effective} https://github.com/aws-cloudformation/cloudformation-guard/releases/latest | \
+awk -F '/' '{print $NF}' | awk -F '.' '{ print $1 "\n" $0 }' | \
+while read major; read version; do
+mkdir -p ~/.guard/$major ~/.guard/bin && \
+wget https://github.com/aws-cloudformation/cloudformation-guard/releases/download/$version/cfn-guard-v$major-ubuntu-latest.tar.gz -O /tmp/guard.tar.gz && \
+tar -C ~/.guard/$major -xzf /tmp/guard.tar.gz && \
+ln -sf ~/.guard/$major/cfn-guard-v$major-ubuntu-latest/cfn-guard ~/.guard/bin && \
+~/.guard/bin/cfn-guard help && \
+echo "Set PATH to PATH=${PATH}/:~/.guard/bin"
+done
+```
+
+Remember to add `~/.guard/bin/` to your `$PATH`.
+
 #### Installation of Rust and Cargo
 
 ##### Ubuntu/MacOS: Install Rust and Cargo
@@ -219,25 +257,6 @@ SUBCOMMANDS:
                   rules and data files. The directory being pointed to must contain only data files,
                   or rules files.
 ```
-
-#### Installation from Pre-Built Release Binaries
-
-##### Ubuntu
-
-The CLI tool for cfn-guard is available from GitHub release. Grab the latest release from our [releases](https://github.com/aws-cloudformation/cloudformation-guard/releases) page. 
-
-```bash
-$ wget https://github.com/aws-cloudformation/cloudformation-guard/releases/download/VERSION/cfn-guard-v2-ubuntu-latest.tar.gz
-$ tar -xvf cfn-guard-v2-ubuntu-latest.tar.gz
-$ cd ./cfn-guard-v2-ubuntu-latest
-$ ./cfn-guard help
-```
-
-You can then move the installed executable to the directory of your choosing, so it is on your `$PATH`.
-
-##### MacOS
-
-Binaries are also available for Mac [releases](https://github.com/aws-cloudformation/cloudformation-guard/releases) in a tarball. The instructions are the same as Ubuntu.
 
 ### How does Guard CLI work?
 

--- a/install-guard.sh
+++ b/install-guard.sh
@@ -28,7 +28,7 @@ main() {
                 err "unable to symlink to ~/.guard/bin directory"
             ~/.guard/bin/cfn-guard help ||
                 err "cfn-guard was not installed properly"
-            echo "Remeber to SET PATH include PATH=${PATH}:~/.guard/bin"
+            echo "Remember to SET PATH include PATH=${PATH}:~/.guard/bin"
         done
 }
 

--- a/install-guard.sh
+++ b/install-guard.sh
@@ -1,0 +1,77 @@
+#!/bin/sh
+# This scripts downloads and installs cfn-guard latest version from github releases
+# It detects platforms, downloads the pre-built binary for the latest version installs
+# it in the ~/.guard/$MAJOR_VER/cfn-guard-v$MAJOR_VER-$OS_TYPE-latest/cfn-guard and symlinks ~/.guard/bin
+# to the latest one
+
+main() {
+    need_cmd curl
+    need_cmd wget
+    need_cmd awk
+    need_cmd mkdir
+    need_cmd rm
+    need_cmd uname
+    need_cmd tar
+    need_cmd ln
+
+    get_os_type
+    get_latest_release |
+        while read MAJOR_VER; read VERSION; do
+            mkdir -p ~/.guard/$MAJOR_VER ~/.guard/bin ||
+                err "unable to make directories ~/.guard/$MAJOR_VER, ~/.guard/bin"
+            get_os_type
+            wget https://github.com/aws-cloudformation/cloudformation-guard/releases/download/$VERSION/cfn-guard-v$MAJOR_VER-$OS_TYPE-latest.tar.gz -O /tmp/guard.tar.gz ||
+                err "unable to download https://github.com/aws-cloudformation/cloudformation-guard/releases/download/$VERSION/cfn-guard-v$MAJOR_VER-$OS_TYPE-latest.tar.gz"
+            tar -C ~/.guard/$MAJOR_VER -xzf /tmp/guard.tar.gz ||
+                err "unable to untar /tmp/guard.tar.gz"
+            ln -sf ~/.guard/$MAJOR_VER/cfn-guard-v$MAJOR_VER-$OS_TYPE-latest/cfn-guard ~/.guard/bin ||
+                err "unable to symlink to ~/.guard/bin directory"
+            ~/.guard/bin/cfn-guard help ||
+                err "cfn-guard was not installed properly"
+            echo "Remeber to SET PATH include PATH=${PATH}:~/.guard/bin"
+        done
+}
+
+get_os_type() {
+    local _ostype="$(uname -s)"
+    case "$_ostype" in
+        Darwin)
+            OS_TYPE="macos"
+            ;;
+
+        Linux)
+            # IS this RIGHT, we need to build for different ARCH as well.
+            # Need more ARCH level detections
+            OS_TYPE="ubuntu"
+            ;;
+
+        *)
+            err "unsupported OS type $_ostype"
+            ;;
+    esac
+}
+
+
+get_latest_release() {
+    curl -fsSLI -o /dev/null -w %{url_effective} \
+        https://github.com/aws-cloudformation/cloudformation-guard/releases/latest |
+    awk -F '/' '{print $NF}' |
+    awk -F '.' '{ print $1 "\n" $0 }'
+}
+
+err() {
+    say "$1" >&2
+    exit 1
+}
+
+need_cmd() {
+    if ! check_cmd "$1"; then
+        err "need '$1' (command not found)"
+    fi
+}
+
+check_cmd() {
+    command -v "$1" > /dev/null 2>&1
+}
+
+main


### PR DESCRIPTION
- Installation from pre-built binaries
- Moved installation via source through cargo install post cut-n-paste instructions

*Issue #, if available:*
#131 

*Description of changes:*
Providing an easy cut-n-paste into terminal instructions for installing guard binary from pre-built binaries. Tested on Ubuntu and MacOS.

