### PR TITLE
Bug fix for 1.0 compatible expressions

### DIFF
--- a/guard/src/rules/evaluate_tests.rs
+++ b/guard/src/rules/evaluate_tests.rs
@@ -1470,22 +1470,18 @@ fn test_guard_10_compatibility_and_diff() -> Result<()> {
     //
     // Guard 1.0 this would PASS with at-least one semantics for the payload above. This is where docs
     // need to be consulted to understand that == is at-least-one and != is ALL. Due to this decision certain
-    // expressions like ensure that all AWS::EC2::Volume Encrypted == true, could not be specified
+    // expressions like ensure that ALL AWS::EC2::Volume Encrypted == true, could not be specified
     //
     // In Guard 2.0 this would FAIL. The reason being that Guard 2.0 goes for explicitness in specifying
     // clauses. By default it asserts for ALL semantics. If you expecting to match at-least one or more
-    // you must use SOME keyword that would evaluate correctly. With this type of support expressions
-    // like
+    // you must use SOME keyword that would evaluate correctly. With this support in 2.0 we can
+    // support ALL expressions like
     //
     //        AWS::EC2::Volume Properties.Encrypted == true
     //
-    // can be correctly done.
-    //
-    // At the same time
+    // At the same time, one can explicitly express at-least-one or more semantics using SOME
     //
     //         AWS::EC2::Volume SOME Properties.Encrypted == true
-    //
-    // to match 1 or more can be specified.
     //
     // And finally
     //
@@ -1495,10 +1491,12 @@ fn test_guard_10_compatibility_and_diff() -> Result<()> {
     //       }
     //
     // can be correctly specified. This also makes the intent clear to both the rule author and
-    // auditor what was acceptable, that it is okay that Encrypted was not specified as an attribute
-    // or if specified must be true. This makes it clear to the reader/auditor rather than guess
-    // at how Guard engine evaluates. The evaluation engine is dumb and stupid, defaults to working
-    // one way consistently ALL. Needs to told explicitly to do otherwise
+    // auditor what was acceptable. Here, it is okay that accept Encrypted was not specified
+    // as an attribute or when specified it must be true. This makes it clear to the reader/auditor
+    // rather than guess at how Guard engine evaluates.
+    //
+    // The evaluation engine is purposefully dumb and stupid, defaults to working
+    // one way consistently enforcing ALL semantics. Needs to told explicitly to do otherwise
     //
 
     let clause_str = r#"Statement.*.Principal == '*'"#;

--- a/guard/src/rules/path_value.rs
+++ b/guard/src/rules/path_value.rs
@@ -108,10 +108,16 @@ impl Path {
     }
 }
 
-#[derive(PartialEq, Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize)]
 pub(crate) struct MapValue {
     keys: Vec<PathAwareValue>,
     values: indexmap::IndexMap<String, PathAwareValue>,
+}
+
+impl PartialEq for MapValue {
+    fn eq(&self, other: &Self) -> bool {
+        self.values == other.values
+    }
 }
 
 impl MapValue {


### PR DESCRIPTION
*Issue #, if available:*
#142 

*Description of changes:*
Fixing bug that was introduced for handling 1.0 compatible expressions. This also resolves the issue reported in 142 for rulegen clauses.

Issue: 
With 1.0 expressions of the form `Statement.*.Principal == '*'` was allowed. To be backwards compatible with these type of rules support was added to 2.0. However, there are cases that can lead to query results having mixed values of scalars and list of scalars returned. Here is an example of such a case.
```
Statement:
  - Principal: '*'
  - Principal: ['*', 'aws:arn']
```
The query results in 
```YAML
- *
- ['*', 'aws:arn']
```  
This often happens with IAM policies as attributes like `Action`, `Resource`, and `Principal` can be provided both as an array form or single value form. If the Guard 2.0 rule was written as `Statement[*].Principal[*]`, that would result in the right evaluation. However, Guard 2.0 did add support for 1.0 compatible syntax `Statement.*.Principal == '*'`. 1.0 does not handle these checks well and does FAIL them 

```bash
$ cfn-guard check --rule_set iam-v1.guard --template iam-example.yaml 
[iam] failed because [PolicyDocument.Statement.0.Principal] is [aws] and the permitted value is [*]
[iam] failed because [PolicyDocument.Statement.1.Principal] is [["*","aws:arn"]] and the permitted value is [*]
Number of failures: 2
```

2.0 does behave correctly. In 2.0 
```
AWS::IAM::Role Properties.PolicyDocument.Statement[*].Principal == '*'
```
Will FAIL as by default ALL Principal's do not match this. We wanted to check that *at-least-one* did match. We should use the SOME keyword to indicate that 
```
AWS::IAM::Role SOME Properties.PolicyDocument.Statement[*].Principal == '*'
```

Here is the rule examples
```
rule some_clause_pass {
    AWS::IAM::Role SOME Properties.PolicyDocument.Statement[*].Principal == '*'
}

rule all_clause_fail {
    AWS::IAM::Role Properties.PolicyDocument.Statement[*].Principal == '*'
}
```

Sample run with fix
```bash
$ cfn-guard validate -r iam-v2.guard -d iam-example.yaml 
Summary Report Overall File Status = FAIL
PASS/SKIP rules
some_clause_pass    PASS
FAILED rules
all_clause_fail     FAIL
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
