### PR TITLE
Adding support for custom reporters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,6 +92,8 @@ version = "2.0.2"
 dependencies = [
  "clap",
  "colored 2.0.0",
+ "enumflags2",
+ "enumflags2_derive",
  "heck",
  "indexmap",
  "itertools",
@@ -176,6 +178,26 @@ name = "dtoa"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56899898ce76aaf4a0f24d914c97ea6ed976d42fec6ad33fcbb0a1103e07b2b0"
+
+[[package]]
+name = "enumflags2"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8672257d642ffdd235f6e9c723c2326ac1253c8f3c022e7cfd2e57da55b1131"
+dependencies = [
+ "enumflags2_derive",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33526f770a27828ce7c2792fdb7cb240220237e0ff12933ed6c23957fc5dd7cf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "fnv"

--- a/guard-examples/cross-account/sns-cross-account-tests.yaml
+++ b/guard-examples/cross-account/sns-cross-account-tests.yaml
@@ -1,0 +1,88 @@
+---
+- name: Allowed from CORRECT, expected PASS 
+  input:
+    Resources:
+      snsPolicy:
+        Type: AWS::SNS::TopicPolicy
+        Properties:
+          PolicyDocument:
+            Statement: [
+              {
+                "Sid": "grant-1234-publish",
+                "Effect": "Allow",
+                "Principal": {
+                  "AWS": "111122223333"
+                },
+                "Action": ["sns:Publish"],
+                "Resource": "arn:aws:sns:us-east-2:444455556666:MyTopic"
+              }]
+  expectations:
+    rules:
+      sns_cross_account_only_allowed_accounts: PASS
+
+- name: 666677778888 account not in list, FAIL
+  input:
+    Resources:
+      snsPolicy:
+        Type: AWS::SNS::TopicPolicy
+        Properties:
+          PolicyDocument:
+            Statement: [
+              {
+                "Sid": "grant-1234-publish",
+                "Effect": "Allow",
+                "Principal": {
+                  "AWS": ["111122223333", "666677778888"]
+                },
+                "Action": ["sns:Publish"],
+                "Resource": "arn:aws:sns:us-east-2:444455556666:MyTopic"
+              }]
+  expectations:
+    rules:
+      sns_cross_account_only_allowed_accounts: FAIL
+
+- name: Accesse via an AWS service, PASS expected as 444455556666 was allowed
+  input:
+    Resources:
+      snsPolicy:
+        Type: AWS::SNS::TopicPolicy
+        Properties:
+          PolicyDocument:
+            Statement: [
+              {
+                  "Effect": "Allow",
+                  "Principal": { 
+                    "Service": "s3.amazonaws.com" 
+                  },
+                  "Action": "sns:Publish",
+                  "Resource": "arn:aws:sns:us-east-2:111122223333:MyTopic",
+                  "Condition": {
+                    "StringEquals": {
+                      "AWS:SourceAccount": "444455556666"
+                    }
+                  }
+              }]
+  expectations:
+    rules:
+      sns_cross_account_only_allowed_accounts: PASS
+
+- name: Accesse via an AWS service, FAIL expected as no Condition was specified to narrow
+  input:
+    Resources:
+      snsPolicy:
+        Type: AWS::SNS::TopicPolicy
+        Properties:
+          PolicyDocument:
+            Statement: [
+              {
+                  "Effect": "Allow",
+                  "Principal": { 
+                    "Service": "s3.amazonaws.com" 
+                  },
+                  "Action": "sns:Publish",
+                  "Resource": "arn:aws:sns:us-east-2:111122223333:MyTopic",
+              }]
+  expectations:
+    rules:
+      sns_cross_account_only_allowed_accounts: FAIL
+

--- a/guard-examples/cross-account/sns-cross-account.guard
+++ b/guard-examples/cross-account/sns-cross-account.guard
@@ -1,0 +1,61 @@
+let allowed_accounts = [ # we use regex over string, so that we can match inside ARNs as well
+    /111122223333/,
+    /444455556666/
+]
+
+rule sns_cross_account_only_allowed_accounts {
+    Resources.* 
+    {
+        when Type == 'AWS::SNS::TopicPolicy' 
+        {
+            Properties.PolicyDocument.Statement[*] 
+            {
+                when Effect         ==  "Allow"
+                {
+                    Action[*]       ==  /(sns|SNS):Publish/          # ensure that we do not sneak in other permission other than sns:Publish
+
+                    #
+                    # Check for different combinations. 
+                    # 
+                    # We are not using OR disjunction as all of these 
+                    # can ALL occur within the same statement and must be checked 
+                    # 
+                    when Principal is_string {
+                        Principal   in  %allowed_accounts                   # when used directly as a string for principal
+                    }
+
+                    when Principal.AWS exists {
+                        Principal.AWS[*] in %allowed_accounts               # when used for providing access from other accounts
+                    }
+
+                    # 
+                    # when accessed via any AWS service, one MUST specify a Condition with sourceAccount|Owner
+                    # Arn. 
+                    # 
+                    when Principal.Service exists {
+                        # 
+                        # when accessed via any AWS services, ensure that source account is only from allowed lists
+                        # We want to check StringEquals, StringLike, ArnEquals, ArnLike checks
+                        # 
+                        let expected_conditions = Condition[ keys == /String(Equals|Like)|Arn(Equals|Like)/ ].*
+
+                        # 
+                        # Ensure that these are specified, else it is an error 
+                        # 
+                        %expected_conditions not empty 
+
+                        # 
+                        # Then extract values against these (aws|AWS):[sS]ourceAccount, (aws|AWS):[sS]ourceOwner, (aws|AWS):[sS]ource(Arn|ARN)
+                        # 
+                        let source_accounts = %expected_conditions[ keys == /(aws|AWS):[sS]ource(Account|Owner|Arn|ARN)/ ].*
+
+                        # 
+                        # It is an error to not specify this. Ensure the ones specified match allowed accounts
+                        #
+                        %source_accounts in %allowed_accounts
+                    }
+                }
+            }
+        }
+    }
+}

--- a/guard/Cargo.toml
+++ b/guard/Cargo.toml
@@ -31,6 +31,8 @@ heck = "0.3.1"
 lazy_static = "1.4.0"
 itertools = "0.4.7"
 string-builder = "0.2.0"
+enumflags2 = "0.7.1"
+enumflags2_derive = "0.7.0"
 
 [dependencies.serde_json]
 version = "1.0.60"

--- a/guard/src/commands/aws_meta_appender.rs
+++ b/guard/src/commands/aws_meta_appender.rs
@@ -2,6 +2,7 @@ use crate::rules::{EvaluationContext, Status, EvaluationType, Result};
 use crate::rules::path_value::{PathAwareValue, QueryResolver};
 use crate::rules::exprs::{QueryPart, AccessQuery};
 use std::convert::TryFrom;
+use crate::rules::values::CmpOperator;
 
 pub(super) struct MetadataAppender<'d> {
     pub(super) delegate: &'d dyn EvaluationContext,
@@ -17,7 +18,16 @@ impl<'d> EvaluationContext for MetadataAppender<'d> {
         self.delegate.rule_status(rule_name)
     }
 
-    fn end_evaluation(&self, eval_type: EvaluationType, context: &str, msg: String, from: Option<PathAwareValue>, to: Option<PathAwareValue>, status: Option<Status>) {
+    fn end_evaluation(
+        &self,
+        eval_type: EvaluationType,
+        context: &str,
+        msg: String,
+        from: Option<PathAwareValue>,
+        to: Option<PathAwareValue>,
+        status: Option<Status>,
+        cmp: Option<(CmpOperator, bool)>)
+    {
         let msg = if eval_type == EvaluationType::Clause {
             match status {
                 Some(status) => {
@@ -45,7 +55,7 @@ impl<'d> EvaluationContext for MetadataAppender<'d> {
             }
         }
         else { msg };
-        self.delegate.end_evaluation(eval_type, context, msg, from, to, status)
+        self.delegate.end_evaluation(eval_type, context, msg, from, to, status, cmp)
     }
 
     fn start_evaluation(&self, eval_type: EvaluationType, context: &str) {

--- a/guard/src/commands/aws_meta_appender_tests.rs
+++ b/guard/src/commands/aws_meta_appender_tests.rs
@@ -47,7 +47,7 @@ fn append_cdk_metadata_test() -> Result<()> {
             unimplemented!()
         }
 
-        fn end_evaluation(&self, eval_type: EvaluationType, context: &str, msg: String, from: Option<PathAwareValue>, to: Option<PathAwareValue>, status: Option<Status>) {
+        fn end_evaluation(&self, eval_type: EvaluationType, context: &str, msg: String, from: Option<PathAwareValue>, to: Option<PathAwareValue>, status: Option<Status>, _cmp: Option<(CmpOperator, bool)>) {
             assert_ne!(msg.as_str(), "");
             assert_eq!(msg.starts_with("FIRST PART"), true);
             assert_eq!(msg.len() > "FIRST PART".len(), true);
@@ -64,6 +64,6 @@ fn append_cdk_metadata_test() -> Result<()> {
     println!("{:?}", value);
     appender.end_evaluation(EvaluationType::Clause, "Clause",
                             "FIRST PART".to_string(),
-                            Some(value.clone()), None, Some(Status::FAIL));
+                            Some(value.clone()), None, Some(Status::FAIL), None);
     Ok(())
 }

--- a/guard/src/commands/common_test_helpers.rs
+++ b/guard/src/commands/common_test_helpers.rs
@@ -1,6 +1,7 @@
 use crate::rules::{
     EvaluationContext, Result, Status, EvaluationType, path_value::PathAwareValue
 };
+use crate::rules::values::CmpOperator;
 
 pub(super) struct DummyEval{}
 impl EvaluationContext for DummyEval {
@@ -12,7 +13,7 @@ impl EvaluationContext for DummyEval {
         unimplemented!()
     }
 
-    fn end_evaluation(&self, _eval_type: EvaluationType, _context: &str, _msg: String, _from: Option<PathAwareValue>, _to: Option<PathAwareValue>, _status: Option<Status>) {
+    fn end_evaluation(&self, _eval_type: EvaluationType, _context: &str, _msg: String, _from: Option<PathAwareValue>, _to: Option<PathAwareValue>, _status: Option<Status>, _cmp: Option<(CmpOperator, bool)>) {
     }
 
     fn start_evaluation(&self, _eval_type: EvaluationType, _context: &str) {

--- a/guard/src/commands/helper.rs
+++ b/guard/src/commands/helper.rs
@@ -27,7 +27,8 @@ pub fn validate_and_return_json(
                 Ok(root) => {
                     let root_context = RootScope::new(&rules, &root);
                     let stacker = StackTracker::new(&root_context);
-                    let reporter = ConsoleReporter::new(stacker, "lambda-run","lambda-payload", true, true, false);
+                    let reporters = vec![];
+                    let reporter = ConsoleReporter::new(stacker, &reporters, "lambda-run","lambda-payload", true, true, false);
                     rules.evaluate(&root, &reporter)?;
                     let json_result = reporter.get_result_json();
                     return Ok(json_result);

--- a/guard/src/commands/validate.rs
+++ b/guard/src/commands/validate.rs
@@ -80,10 +80,10 @@ or rules files.
             .arg(Arg::with_name("output-format").long("output-format").short("o").takes_value(true)
                 .possible_values(&["json","yaml","single-line-summary"])
                 .help("Specify the type of data file used for improved messaging"))
-            .arg(Arg::with_name("show-summary-table").long("show-summary-table").takes_value(true).use_delimiter(true).multiple(true)
+            .arg(Arg::with_name("show-summary").long("show-summary").takes_value(true).use_delimiter(true).multiple(true)
                 .possible_values(&["none", "all", "pass", "fail", "skip"])
                 .default_value("all")
-                .help("control if the summary table needs to be displayed. --show-summary-table all (default) or --show-summary-table pass,fail (only show rules that did pass/fail) or --show-summary-table none (to turn it off)")
+                .help("control if the summary table needs to be displayed. --show-summary all (default) or --show-summary pass,fail (only show rules that did pass/fail) or --show-summary none (to turn it off)")
             )
             .arg(Arg::with_name("show-clause-failures").long("show-clause-failures").short("s").takes_value(false).required(false)
                 .help("Show clause failure along with summary"))
@@ -155,7 +155,7 @@ or rules files.
             None => OutputFormatType::SingleLineSummary
         };
 
-        let summary_type: BitFlags<SummaryType> = app.values_of("show-summary-table").map_or(
+        let summary_type: BitFlags<SummaryType> = app.values_of("show-summary").map_or(
             SummaryType::PASS | SummaryType::FAIL | SummaryType::SKIP,
             |v| {
                 v.fold(BitFlags::empty(), |mut st, elem| {

--- a/guard/src/commands/validate.rs
+++ b/guard/src/commands/validate.rs
@@ -1,23 +1,51 @@
 use std::convert::TryFrom;
+use std::fmt::Debug;
+use std::fs::File;
+use std::io::{BufReader, Read, Write};
 
 use clap::{App, Arg, ArgMatches};
 use colored::*;
 
 use crate::command::Command;
 use crate::commands::{ALPHABETICAL, LAST_MODIFIED};
-use crate::commands::files::{alpabetical, get_files, last_modified, regular_ordering, iterate_over};
-use crate::rules::{Evaluate, EvaluationContext, Result, Status, EvaluationType};
+use crate::commands::aws_meta_appender::MetadataAppender;
+use crate::commands::files::{alpabetical, get_files, iterate_over, last_modified, regular_ordering};
+use crate::commands::tracker::{StackTracker, StatusContext};
+use crate::rules::{Evaluate, EvaluationContext, EvaluationType, Result, Status};
 use crate::rules::errors::{Error, ErrorKind};
 use crate::rules::evaluate::RootScope;
 use crate::rules::exprs::RulesFile;
-
-
 use crate::rules::path_value::PathAwareValue;
-use crate::commands::tracker::{StackTracker, StatusContext};
-use crate::commands::aws_meta_appender::MetadataAppender;
-use std::io::{BufReader, Read, Write};
-use std::fs::File;
-use std::io;
+use crate::rules::values::CmpOperator;
+use crate::commands::validate::summary_table::SummaryType;
+use enumflags2::{BitFlag, BitFlags};
+
+mod cfn_renderer;
+mod generic_summary;
+mod common;
+mod summary_table;
+
+#[derive(Copy, Eq, Clone, Debug, PartialEq)]
+pub(crate) enum Type {
+    CFNTemplate,
+    Generic
+}
+
+#[derive(Copy, Eq, Clone, Debug, PartialEq)]
+pub(crate) enum OutputFormatType {
+    SingleLineSummary,
+    JSON,
+    YAML
+}
+
+pub(crate) trait Renderer: Debug {
+    fn render(&self,
+              writer: &mut Write,
+              failed_rules: &[&StatusContext],
+              passed_or_skipped: &[&StatusContext],
+              longest_rule_name: usize,
+    ) -> Result<()>;
+}
 
 #[derive(Clone, Copy, Eq, PartialEq)]
 pub(crate) struct Validate {}
@@ -47,6 +75,16 @@ or rules files.
 "#)
             .arg(Arg::with_name("rules").long("rules").short("r").takes_value(true).help("Provide a rules file or a directory of rules files").required(true))
             .arg(Arg::with_name("data").long("data").short("d").takes_value(true).help("Provide a file or dir for data files in JSON or YAML"))
+            .arg(Arg::with_name("type").long("type").short("t").takes_value(true).possible_values(&["CFNTemplate"])
+                .help("Specify the type of data file used for improved messaging"))
+            .arg(Arg::with_name("output-format").long("output-format").short("o").takes_value(true)
+                .possible_values(&["json","yaml","single-line-summary"])
+                .help("Specify the type of data file used for improved messaging"))
+            .arg(Arg::with_name("show-summary-table").long("show-summary-table").takes_value(true).use_delimiter(true).multiple(true)
+                .possible_values(&["none", "all", "pass", "fail", "skip"])
+                .default_value("all")
+                .help("control if the summary table needs to be displayed. --show-summary-table all (default) or --show-summary-table pass,fail (only show rules that did pass/fail) or --show-summary-table none (to turn it off)")
+            )
             .arg(Arg::with_name("show-clause-failures").long("show-clause-failures").short("s").takes_value(false).required(false)
                 .help("Show clause failure along with summary"))
             .arg(Arg::with_name("alphabetical").long("alphabetical").short("a").required(false).help("Validate files in a directory ordered alphabetically"))
@@ -92,6 +130,47 @@ or rules files.
             false
         };
 
+        let data_type = match app.value_of("type")  {
+            Some(t) =>
+                if t == "CFNTemplate" {
+                    Type::CFNTemplate
+                }
+                else {
+                    Type::Generic
+                },
+            None => Type::Generic
+        };
+
+        let output_type = match app.value_of("output-format") {
+            Some(o) =>
+                if o == "single-line-summary" {
+                    OutputFormatType::SingleLineSummary
+                }
+                else if o == "json" {
+                    OutputFormatType::JSON
+                }
+                else {
+                    OutputFormatType::YAML
+                }
+            None => OutputFormatType::SingleLineSummary
+        };
+
+        let summary_type: BitFlags<SummaryType> = app.values_of("show-summary-table").map_or(
+            SummaryType::PASS | SummaryType::FAIL | SummaryType::SKIP,
+            |v| {
+                v.fold(BitFlags::empty(), |mut st, elem| {
+                    match elem {
+                        "pass" => st.insert(SummaryType::PASS),
+                        "fail" => st.insert(SummaryType::FAIL),
+                        "skip" => st.insert(SummaryType::SKIP),
+                        "none" => return BitFlags::empty(),
+                        "all"  => st.insert(SummaryType::PASS | SummaryType::FAIL | SummaryType::SKIP),
+                        _ => unreachable!()
+                    };
+                    st
+                })
+            });
+
         let print_json = app.is_present("print-json");
         let show_clause_failures = app.is_present("show-clause-failures");
 
@@ -113,7 +192,15 @@ or rules files.
 
                         Ok(rules) => {
                             match evaluate_against_data_input(
-                                &data_files, &rules, &rule_file_name, verbose, print_json, show_clause_failures)? {
+                                data_type,
+                                output_type,
+                                &data_files,
+                                &rules,
+                                &rule_file_name,
+                                verbose,
+                                print_json,
+                                show_clause_failures,
+                                summary_type.clone())? {
                                 Status::SKIP | Status::PASS => continue,
                                 Status::FAIL => {
                                     exit_code = 5;
@@ -146,7 +233,8 @@ pub fn validate_and_return_json(
                 Ok(root) => {
                     let root_context = RootScope::new(&rules, &root);
                     let stacker = StackTracker::new(&root_context);
-                    let reporter = ConsoleReporter::new(stacker, "lambda-function", "input-payload", true, true, false);
+                    let reporters = vec![];
+                    let reporter = ConsoleReporter::new(stacker, &reporters, "lambda-function", "input-payload", true, true, false);
                     rules.evaluate(&root, &reporter)?;
                     let json_result = reporter.get_result_json();
                     return Ok(json_result);
@@ -161,23 +249,12 @@ pub fn validate_and_return_json(
 #[derive(Debug)]
 pub(crate) struct ConsoleReporter<'r> {
     root_context: StackTracker<'r>,
+    reporters: &'r Vec<Box<dyn Renderer + 'r>>,
     rules_file_name: &'r str,
     data_file_name: &'r str,
     verbose: bool,
     print_json: bool,
     show_clause_failures: bool,
-}
-
-fn colored_string(status: Option<Status>) -> ColoredString {
-    let status = match status {
-        Some(s) => s,
-        None => Status::SKIP,
-    };
-    match status {
-        Status::PASS => "PASS".green(),
-        Status::FAIL => "FAIL".red().bold(),
-        Status::SKIP => "SKIP".yellow().bold(),
-    }
 }
 
 fn indent_spaces(indent: usize) {
@@ -187,7 +264,7 @@ fn indent_spaces(indent: usize) {
 }
 
 pub(super) fn print_context(cxt: &StatusContext, depth: usize) {
-    let header = format!("{}({}, {})", cxt.eval_type, cxt.context, colored_string(cxt.status)).underline();
+    let header = format!("{}({}, {})", cxt.eval_type, cxt.context, common::colored_string(cxt.status)).underline();
     //let depth = cxt.indent;
     let _sub_indent = depth + 1;
     indent_spaces(depth - 1);
@@ -223,38 +300,13 @@ pub(super) fn print_context(cxt: &StatusContext, depth: usize) {
     }
 }
 
-fn find_all_failing_clauses(context: &StatusContext) -> Vec<&StatusContext> {
-    let mut failed = Vec::with_capacity(context.children.len());
-    for each in &context.children {
-        if each.status.map_or(false, |s| s == Status::FAIL) {
-            match each.eval_type {
-                EvaluationType::Clause |
-                EvaluationType::BlockClause => {
-                    failed.push(each);
-                    if each.eval_type == EvaluationType::BlockClause {
-                        failed.extend(find_all_failing_clauses(each));
-                    }
-                },
-
-                EvaluationType::Filter |
-                EvaluationType::Condition => {
-                    continue;
-                },
-
-                _ => failed.extend(find_all_failing_clauses(each))
-            }
-        }
-    }
-    failed
-}
-
 fn print_failing_clause(rules_file_name: &str, rule: &StatusContext, longest: usize) {
     print!("{file}/{rule:<0$}", longest+4, file=rules_file_name, rule=rule.context);
     let longest = rules_file_name.len() + longest;
     let mut first = true;
-    for (index, matched) in find_all_failing_clauses(rule).iter().enumerate() {
+    for (index, matched) in common::find_all_failing_clauses(rule).iter().enumerate() {
         let matched = *matched;
-        let header = format!("{}({})", colored_string(matched.status), matched.context).underline();
+        let header = format!("{}({})", common::colored_string(matched.status), matched.context).underline();
         if !first {
             print!("{space:>longest$}", space=" ", longest=longest+4)
         }
@@ -288,9 +340,10 @@ fn print_failing_clause(rules_file_name: &str, rule: &StatusContext, longest: us
 }
 
 impl<'r, 'loc> ConsoleReporter<'r> {
-    pub(crate) fn new(root: StackTracker<'r>, rules_file_name: &'r str, data_file_name: &'r str, verbose: bool, print_json: bool, show_clause_failures: bool) -> Self {
+    pub(crate) fn new(root: StackTracker<'r>, renderers: &'r Vec<Box<dyn Renderer + 'r>>, rules_file_name: &'r str, data_file_name: &'r str, verbose: bool, print_json: bool, show_clause_failures: bool) -> Self {
         ConsoleReporter {
             root_context: root,
+            reporters: renderers,
             rules_file_name,
             data_file_name,
             verbose,
@@ -305,16 +358,16 @@ impl<'r, 'loc> ConsoleReporter<'r> {
         return format!("{}", serde_json::to_string_pretty(&top.children).unwrap());
     }
 
-    fn report(self) {
+    fn report(self) -> crate::rules::Result<()> {
         let stack = self.root_context.stack();
         let top = stack.first().unwrap();
+        let mut output = Box::new(std::io::stdout()) as Box<dyn std::io::Write>;
 
         if self.verbose && self.print_json {
             let serialized_user = serde_json::to_string_pretty(&top.children).unwrap();
             println!("{}", serialized_user);
         }
         else {
-            println!("{} Status = {}", self.data_file_name.underline(), colored_string(top.status));
             let longest = top.children.iter()
                 .max_by(|f, s| {
                     (*f).context.len().cmp(&(*s).context.len())
@@ -329,18 +382,19 @@ impl<'r, 'loc> ConsoleReporter<'r> {
                         _ => false
                     });
 
-            println!("{}", "PASS/SKIP rules".bold());
-            Self::print_partition(&self.rules_file_name, &rest, longest);
+            for each_renderer in self.reporters {
+                each_renderer.render(
+                    &mut output,
+                    &failed,
+                    &rest,
+                    longest
+                )?;
+            }
 
-            if !failed.is_empty() {
-                println!("{}", "FAILED rules".bold());
-                Self::print_partition(&self.rules_file_name, &failed, longest);
-
-                if self.show_clause_failures {
-                    println!("{}", "Clause Failure Summary".bold());
-                    for each in failed {
-                        print_failing_clause(self.rules_file_name, each, longest);
-                    }
+            if self.show_clause_failures {
+                println!("{}", "Clause Failure Summary".bold());
+                for each in failed {
+                    print_failing_clause(self.rules_file_name, each, longest);
                 }
             }
 
@@ -350,15 +404,9 @@ impl<'r, 'loc> ConsoleReporter<'r> {
                     print_context(each, 1);
                 }
             }
-            println!("---");
-        }
-    }
-
-    fn print_partition(rules_file_name: &str, part: &Vec<&StatusContext>, longest: usize) {
-        for container in part {
-            println!("{filename}/{context:<0$}{status}", longest+4, filename=rules_file_name, context=(*container).context, status=colored_string((*container).status));
         }
 
+        Ok(())
     }
 }
 
@@ -379,8 +427,9 @@ impl<'r> EvaluationContext for ConsoleReporter<'r> {
                       msg: String,
                       from: Option<PathAwareValue>,
                       to: Option<PathAwareValue>,
-                      status: Option<Status>) {
-        self.root_context.end_evaluation(eval_type, context, msg, from, to, status);
+                      status: Option<Status>,
+                      cmp: Option<(CmpOperator, bool)>) {
+        self.root_context.end_evaluation(eval_type, context, msg, from, to, status, cmp);
     }
 
     fn start_evaluation(&self,
@@ -391,7 +440,15 @@ impl<'r> EvaluationContext for ConsoleReporter<'r> {
 
 }
 
-fn evaluate_against_data_input(data_files: &[(String, String)], rules: &RulesFile<'_>, rules_file_name: &str, verbose: bool, print_json: bool, show_clause_failures: bool) -> Result<Status> {
+fn evaluate_against_data_input<'r>(data_type: Type,
+                                   output: OutputFormatType,
+                                   data_files: &'r [(String, String)],
+                                   rules: &RulesFile<'_>,
+                                   rules_file_name: &'r str,
+                                   verbose: bool,
+                                   print_json: bool,
+                                   show_clause_failures: bool,
+                                   summary_table: BitFlags<SummaryType>) -> Result<Status> {
     let iterator: Result<Vec<(PathAwareValue, &str)>> = data_files.iter().map(|(content, name)|
         match serde_json::from_str::<serde_json::Value>(content) {
             Ok(value) => Ok((PathAwareValue::try_from(value)?, name.as_str())),
@@ -404,9 +461,22 @@ fn evaluate_against_data_input(data_files: &[(String, String)], rules: &RulesFil
 
     let mut overall = Status::PASS;
     for (each, data_file_name) in iterator? {
+        let mut reporters= match data_type {
+            Type::CFNTemplate =>
+                vec![
+                    Box::new(cfn_renderer::CfnRender::new(data_file_name, rules_file_name, output)) as Box<dyn Renderer>],
+            Type::Generic =>
+                vec![
+                    Box::new(generic_summary::GenericSummary::new(data_file_name, rules_file_name, output)) as Box<dyn Renderer>],
+        };
+        if !summary_table.is_empty() {
+            reporters.insert(
+                0, Box::new(
+                    summary_table::SummaryTable::new(rules_file_name, data_file_name, summary_table.clone())) as Box<dyn Renderer>);
+        }
         let root_context = RootScope::new(rules, &each);
         let stacker = StackTracker::new(&root_context);
-        let reporter = ConsoleReporter::new(stacker, rules_file_name, data_file_name, verbose, print_json, show_clause_failures);
+        let reporter = ConsoleReporter::new(stacker, &reporters, rules_file_name, data_file_name, verbose, print_json, show_clause_failures);
         let appender = MetadataAppender{delegate: &reporter, root_context: &each};
         let status = rules.evaluate(&each, &appender)?;
         reporter.report();

--- a/guard/src/commands/validate.rs
+++ b/guard/src/commands/validate.rs
@@ -36,7 +36,6 @@ pub(crate) enum Type {
 #[derive(Copy, Eq, Clone, Debug, PartialEq)]
 pub(crate) enum OutputFormatType {
     SingleLineSummary,
-    SingleLineSummaryBlock,
     JSON,
     YAML
 }
@@ -82,7 +81,7 @@ or rules files.
             .arg(Arg::with_name("type").long("type").short("t").takes_value(true).possible_values(&["CFNTemplate"])
                 .help("Specify the type of data file used for improved messaging"))
             .arg(Arg::with_name("output-format").long("output-format").short("o").takes_value(true)
-                .possible_values(&["json","yaml","single-line-summary", "single-line-summary-block"])
+                .possible_values(&["json","yaml","single-line-summary"])
                 .help("Specify the type of data file used for improved messaging"))
             .arg(Arg::with_name("show-summary").long("show-summary").takes_value(true).use_delimiter(true).multiple(true)
                 .possible_values(&["none", "all", "pass", "fail", "skip"])
@@ -159,9 +158,6 @@ or rules files.
             Some(o) =>
                 if o == "single-line-summary" {
                     OutputFormatType::SingleLineSummary
-                }
-                else if o == "single-line-summary-block" {
-                    OutputFormatType::SingleLineSummaryBlock
                 }
                 else if o == "json" {
                     OutputFormatType::JSON
@@ -504,7 +500,7 @@ fn evaluate_against_data_input<'r>(data_type: Type,
         let reporter = ConsoleReporter::new(stacker, &reporters, rules_file_name, data_file_name, verbose, print_json, show_clause_failures);
         let appender = MetadataAppender{delegate: &reporter, root_context: &each};
         let status = rules.evaluate(&each, &appender)?;
-        reporter.report();
+        reporter.report()?;
         if status == Status::FAIL {
             overall = Status::FAIL
         }

--- a/guard/src/commands/validate/cfn_renderer.rs
+++ b/guard/src/commands/validate/cfn_renderer.rs
@@ -97,59 +97,8 @@ impl super::common::GenericRenderer for SingleLineRenderer {
         writeln!(writer, "Evaluation against template {}, number of resource failures = {}", template_file_name, by_resource_name.len())?;
         writeln!(writer, "-")?;
         for (resource, info) in by_resource_name.iter() {
-            writeln!(writer, "Resource {}, failed due to the following checks", resource)?;
-            for each in info {
-                let (did_or_didnt, operation, cmp) = match &each.comparison {
-                    Some((cmp, not)) => {
-                        if *not {
-                            ("did", format!("NOT {}", cmp), Some(cmp))
-                        } else {
-                            ("did not", format!("{}", cmp), Some(cmp))
-                        }
-                    },
-                    None => {
-                        ("did not", "NONE".to_string(), None)
-                    }
-                };
-                match cmp {
-                    None => {
-                        // Block Clause retrieval error
-                        writeln!(writer, "{0}/{1:<2$}{3} failed due to retrieval error, stopped at [{4}]. Error Message = [{5}]",
-                                 rules_file_name,
-                                 each.rule,
-                                 longest_rule_len+4,
-                                 operation,
-                                 each.from,
-                                 each.message.replace("\n", ";"))?;
-                    },
-
-                    Some(cmp) => {
-                        if cmp.is_unary() {
-                            writeln!(writer, "{0}/{1:<2$}{3} failed on value [{4}] at path {5}. Error Message [{6}]",
-                                     rules_file_name,
-                                     each.rule,
-                                     longest_rule_len+4,
-                                     operation,
-                                     each.from,
-                                     each.path,
-                                     each.message.replace("\n", ";"))?;
-                        }
-                        else {
-                            writeln!(writer, "{0}/{1:<2$}{3} failed on value [{4}] at property path {5} {6} match with [{7}]. Error Message [{8}]",
-                                     rules_file_name,
-                                     each.rule,
-                                     longest_rule_len+4,
-                                     operation,
-                                     each.from,
-                                     each.path,
-                                     did_or_didnt,
-                                     match &each.to { Some(v) => v, None => &serde_json::Value::Null },
-                                     each.message.replace("\n", ";"))?;
-                        }
-                    }
-
-                }
-            }
+            writeln!(writer, "Resource {} failed due to the following checks", resource)?;
+            super::common::print_name_info(writer, info, longest_rule_len, rules_file_name)?;
             writeln!(writer, "-")?;
         }
         Ok(())

--- a/guard/src/commands/validate/cfn_renderer.rs
+++ b/guard/src/commands/validate/cfn_renderer.rs
@@ -1,0 +1,157 @@
+use std::collections::HashMap;
+use std::fmt::Debug;
+use std::io::Write;
+
+use colored::*;
+use lazy_static::*;
+use regex::Regex;
+use serde::{Deserialize, Serialize};
+
+use crate::commands::tracker::StatusContext;
+use crate::commands::validate::{OutputFormatType, Renderer};
+use crate::commands::validate::common::{find_all_failing_clauses, NameInfo, GenericRenderer, StructuredSummary, StructureType};
+use crate::rules::errors::{Error, ErrorKind};
+
+use super::EvaluationType;
+
+lazy_static! {
+    static ref CFN_RESOURCES: Regex = Regex::new(r"^/Resources/(?P<name>[^/]+)/(?P<rest>.*$)").ok().unwrap();
+}
+
+#[derive(Debug)]
+pub(crate) struct CfnRender<'a> {
+    data_file_name: &'a str,
+    rules_file_name: &'a str,
+    output_format_type: OutputFormatType,
+    render: Box<dyn GenericRenderer>,
+}
+
+impl<'a> CfnRender<'a> {
+    pub(crate) fn new<'r>(data_file_name: &'r str,
+                          rules_file_name: &'r str,
+                          output_format_type: OutputFormatType) -> CfnRender<'r> {
+        CfnRender {
+            data_file_name,
+            rules_file_name,
+            output_format_type,
+            render: match output_format_type {
+                OutputFormatType::SingleLineSummary => Box::new(SingleLineRenderer{}) as Box<dyn GenericRenderer>,
+                OutputFormatType::JSON => Box::new(StructuredSummary::new(StructureType::JSON)) as Box<dyn GenericRenderer>,
+                OutputFormatType::YAML => Box::new(StructuredSummary::new(StructureType::YAML)) as Box<dyn GenericRenderer>,
+            }
+        }
+    }
+}
+
+impl<'a> Renderer for CfnRender<'a> {
+    fn render(&self,
+              writer: &mut dyn Write,
+              failed_rules: &[&StatusContext],
+              _passed: &[&StatusContext],
+              longest_rule_name: usize) -> crate::rules::Result<()> {
+        if !failed_rules.is_empty() {
+            let mut by_resource_name = HashMap::new();
+            for each_failed_rule in failed_rules {
+                let failed = find_all_failing_clauses(each_failed_rule);
+                for each_failing_clause in failed {
+                    match each_failing_clause.eval_type {
+                        EvaluationType::Clause |
+                        EvaluationType::BlockClause => {
+                            if each_failing_clause.from.is_some() {
+                                let mut resource_info = super::common::extract_name_info(
+                                    &each_failed_rule.context, each_failing_clause)?;
+                                let (resource_name, property_path) = match CFN_RESOURCES.captures(&resource_info.path) {
+                                    Some(caps) => {
+                                        (caps["name"].to_string(), caps["rest"].replace("/", "."))
+                                    },
+                                    None => return Err(Error::new(ErrorKind::IncompatibleRetrievalError(
+                                        "Expecting CFN Template format for errors".to_string()
+                                    )))
+                                };
+                                resource_info.path = property_path;
+                                by_resource_name.entry(resource_name).or_insert(Vec::new()).push(resource_info);
+                            }
+                        },
+
+                        _ => unreachable!()
+                    }
+                }
+            }
+            self.render.render(writer, self.rules_file_name, self.data_file_name, by_resource_name, longest_rule_name)?;
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug)]
+struct SingleLineRenderer {}
+
+impl super::common::GenericRenderer for SingleLineRenderer {
+    fn render(&self,
+              writer: &mut dyn Write,
+              rules_file_name: &str,
+              template_file_name: &str,
+              by_resource_name: HashMap<String, Vec<NameInfo<'_>>>,
+              longest_rule_len: usize) -> crate::rules::Result<()>
+    {
+        writeln!(writer, "Evaluation against template {}, number of resource failures = {}", template_file_name, by_resource_name.len())?;
+        writeln!(writer, "-")?;
+        for (resource, info) in by_resource_name.iter() {
+            writeln!(writer, "Resource {}, failed due to the following checks", resource)?;
+            for each in info {
+                let (did_or_didnt, operation, cmp) = match &each.comparison {
+                    Some((cmp, not)) => {
+                        if *not {
+                            ("did", format!("NOT {}", cmp), Some(cmp))
+                        } else {
+                            ("did not", format!("{}", cmp), Some(cmp))
+                        }
+                    },
+                    None => {
+                        ("did not", "NONE".to_string(), None)
+                    }
+                };
+                match cmp {
+                    None => {
+                        // Block Clause retrieval error
+                        writeln!(writer, "{0}/{1:<2$}{3} failed due to retrieval error, stopped at [{4}]. Error Message = [{5}]",
+                                 rules_file_name,
+                                 each.rule,
+                                 longest_rule_len+4,
+                                 operation,
+                                 each.from,
+                                 each.message.replace("\n", ";"))?;
+                    },
+
+                    Some(cmp) => {
+                        if cmp.is_unary() {
+                            writeln!(writer, "{0}/{1:<2$}{3} failed on value [{4}] at path {5}. Error Message [{6}]",
+                                     rules_file_name,
+                                     each.rule,
+                                     longest_rule_len+4,
+                                     operation,
+                                     each.from,
+                                     each.path,
+                                     each.message.replace("\n", ";"))?;
+                        }
+                        else {
+                            writeln!(writer, "{0}/{1:<2$}{3} failed on value [{4}] at property path {5} {6} match with [{7}]. Error Message [{8}]",
+                                     rules_file_name,
+                                     each.rule,
+                                     longest_rule_len+4,
+                                     operation,
+                                     each.from,
+                                     each.path,
+                                     did_or_didnt,
+                                     match &each.to { Some(v) => v, None => &serde_json::Value::Null },
+                                     each.message.replace("\n", ";"))?;
+                        }
+                    }
+
+                }
+            }
+            writeln!(writer, "-")?;
+        }
+        Ok(())
+    }
+}

--- a/guard/src/commands/validate/cfn_reporter.rs
+++ b/guard/src/commands/validate/cfn_reporter.rs
@@ -13,6 +13,7 @@ use crate::commands::validate::common::{find_all_failing_clauses, NameInfo, Gene
 use crate::rules::errors::{Error, ErrorKind};
 
 use super::EvaluationType;
+use crate::rules::Status;
 
 lazy_static! {
     static ref CFN_RESOURCES: Regex = Regex::new(r"^/Resources/(?P<name>[^/]+)/(?P<rest>.*$)").ok().unwrap();
@@ -46,6 +47,7 @@ impl<'a> CfnReporter<'a> {
 impl<'a> Reporter for CfnReporter<'a> {
     fn report(&self,
               writer: &mut dyn Write,
+              _status: Option<Status>,
               failed_rules: &[&StatusContext],
               _passed: &[&StatusContext],
               longest_rule_name: usize) -> crate::rules::Result<()> {

--- a/guard/src/commands/validate/cfn_reporter.rs
+++ b/guard/src/commands/validate/cfn_reporter.rs
@@ -142,7 +142,7 @@ impl super::common::GenericReporter for SingleLineReporter {
                     ))
                 },
                 |_, _, op_msg, info| {
-                    Ok(format!("Resource [{resource}] property [{property}] in template [{template}] is not compliant with [{rules}/{rule}] because provided value [{provided}] {op_msg}. Error message [{msg}]",
+                    Ok(format!("Resource [{resource}] property [{property}] in template [{template}] is not compliant with [{rules}/{rule}] because needed value at [{provided}] {op_msg}. Error message [{msg}]",
                                resource=resource,
                                property=info.path,
                                provided=info.provided.as_ref().map_or(&serde_json::Value::Null, std::convert::identity),

--- a/guard/src/commands/validate/cfn_reporter.rs
+++ b/guard/src/commands/validate/cfn_reporter.rs
@@ -59,6 +59,19 @@ impl<'a> Reporter for CfnReporter<'a> {
                     match each_failing_clause.eval_type {
                         EvaluationType::Clause |
                         EvaluationType::BlockClause => {
+                            if each_failing_clause.eval_type == EvaluationType::BlockClause {
+                                match &each_failing_clause.msg {
+                                    Some(msg) => {
+                                        if msg.contains("DEFAULT") {
+                                            continue;
+                                        }
+                                    },
+
+                                    None => {
+                                        continue;
+                                    }
+                                }
+                            }
                             let mut resource_info = super::common::extract_name_info(
                                 &each_failed_rule.context, each_failing_clause)?;
                             let (resource_name, property_path) = match CFN_RESOURCES.captures(&resource_info.path) {

--- a/guard/src/commands/validate/cfn_reporter.rs
+++ b/guard/src/commands/validate/cfn_reporter.rs
@@ -169,19 +169,8 @@ impl super::common::GenericReporter for SingleLineReporter {
 
             )?;
         }
-        if !passed.is_empty() {
-            writeln!(writer, "--");
-        }
-        for pass in passed {
-            writeln!(writer, "Rule [{}/{}] is compliant for template [{}]", rules_file_name, pass, data_file_name);
-        }
-        if !skipped.is_empty() {
-            writeln!(writer, "--");
-        }
-        for skip in skipped {
-            writeln!(writer, "Rule [{}/{}] is not applicable for template [{}]", rules_file_name, skip, data_file_name);
-        }
-        writeln!(writer, "--");
+        super::common::print_compliant_skipped_info(writer, &passed, &skipped, rules_file_name, data_file_name)?;
+        writeln!(writer, "--")?;
         Ok(())
     }
 }

--- a/guard/src/commands/validate/cfn_reporter.rs
+++ b/guard/src/commands/validate/cfn_reporter.rs
@@ -113,6 +113,10 @@ impl super::common::GenericReporter for SingleLineReporter {
         if !by_resource_name.is_empty() {
             writeln!(writer, "--");
         }
+        //
+        // Agreed on text
+        // Resource [NewVolume2] property [Properties.Encrypted] in template [template.json] is not compliant with [sg.guard/aws_ec2_volume_checks] because provided value [false] does not match with expected value [true]. Error Message [[EC2-008] : EC2 volumes should be encrypted]
+        //
         for (resource, info) in by_resource_name.iter() {
             super::common::print_name_info(
                 writer, &info, longest_rule_len, rules_file_name, data_file_name,
@@ -128,28 +132,28 @@ impl super::common::GenericReporter for SingleLineReporter {
                     ))
                 },
                 |_, _, op_msg, info| {
-                    Ok(format!("Resource [{}] property [{}] with value [{}] {} for template [{}] wasn't compliant with [{}/{}]. Error Message [{}]",
-                               resource,
-                               info.path,
-                               info.provided,
-                               op_msg,
-                               data_file_name,
-                               rules_file_name,
-                               info.rule,
-                               info.message.replace("\n", ";")
+                    Ok(format!("Resource [{resource}] property [{property}] in template [{template}] is not compliant with [{rules}/{rule}] because provided value [{provided}] {op_msg}. Error message [{msg}]",
+                               resource=resource,
+                               property=info.path,
+                               provided=info.provided,
+                               op_msg=op_msg,
+                               template=data_file_name,
+                               rules=rules_file_name,
+                               rule=info.rule,
+                               msg=info.message.replace("\n", ";")
                     ))
                 },
                 |_, _, msg, info| {
-                    Ok(format!("Resource [{}] property [{}] with value [{}] {} match [{}] for template [{}] wasn't compliant with [{}/{}]. Error Message [{}]",
-                               resource,
-                               info.path,
-                               info.provided,
-                               msg,
-                               info.expected.as_ref().map_or(&serde_json::Value::Null, std::convert::identity),
-                               data_file_name,
-                               rules_file_name,
-                               info.rule,
-                               info.message.replace("\n", ";")
+                    Ok(format!("Resource [{resource}] property [{property}] in template [{template}] is not compliant with [{rules}/{rule}] because provided value [{provided}] {op_msg} match with expected value [{expected}]. Error message [{msg}]",
+                               resource=resource,
+                               property=info.path,
+                               provided=info.provided,
+                               op_msg=msg,
+                               expected=info.expected.as_ref().map_or(&serde_json::Value::Null, std::convert::identity),
+                               template=data_file_name,
+                               rules=rules_file_name,
+                               rule=info.rule,
+                               msg=info.message.replace("\n", ";")
                     ))
                 }
 
@@ -159,13 +163,13 @@ impl super::common::GenericReporter for SingleLineReporter {
             writeln!(writer, "--");
         }
         for pass in passed {
-            writeln!(writer, "Rule [{}/{}] was compliant for template [{}]", rules_file_name, pass, data_file_name);
+            writeln!(writer, "Rule [{}/{}] is compliant for template [{}]", rules_file_name, pass, data_file_name);
         }
         if !skipped.is_empty() {
             writeln!(writer, "--");
         }
         for skip in skipped {
-            writeln!(writer, "Rule [{}/{}] was not applicable for template [{}]", rules_file_name, skip, data_file_name);
+            writeln!(writer, "Rule [{}/{}] is not applicable for template [{}]", rules_file_name, skip, data_file_name);
         }
         writeln!(writer, "--");
         Ok(())

--- a/guard/src/commands/validate/common.rs
+++ b/guard/src/commands/validate/common.rs
@@ -15,14 +15,14 @@ use lazy_static::*;
 #[derive(Debug, PartialEq, Serialize)]
 pub(super) struct Comparison {
     operator: CmpOperator,
-    not: bool,
+    not_operator_exists: bool,
 }
 
 impl From<(CmpOperator, bool)> for Comparison {
     fn from(input: (CmpOperator, bool)) -> Self {
         Comparison {
             operator: input.0,
-            not: input.1
+            not_operator_exists: input.1
         }
     }
 }
@@ -231,7 +231,7 @@ pub(super) fn print_name_info<R, U, B>(
 {
     for each in info {
         let (cmp, not) = match &each.comparison {
-            Some(cmp) => (Some(cmp.operator), cmp.not),
+            Some(cmp) => (Some(cmp.operator), cmp.not_operator_exists),
             None => (None, false)
         };
         // CFN = Resource [<name>] was not compliant with [<rule-name>] for property [<path>] because provided value [<value>] did not match expected value [<value>]. Error Message [<msg>]

--- a/guard/src/commands/validate/common.rs
+++ b/guard/src/commands/validate/common.rs
@@ -20,8 +20,8 @@ pub(super) struct NameInfo<'a> {
     pub(super) message: String
 }
 
-pub(super) trait GenericRenderer : Debug {
-    fn render(&self,
+pub(super) trait GenericReporter: Debug {
+    fn report(&self,
               writer: &mut dyn Write,
               rules_file_name: &str,
               data_file_name: &str,
@@ -55,8 +55,8 @@ struct DataOutput<'a> {
     failed: HashMap<String, Vec<NameInfo<'a>>>
 }
 
-impl GenericRenderer for StructuredSummary {
-    fn render(&self,
+impl GenericReporter for StructuredSummary {
+    fn report(&self,
               writer: &mut dyn Write,
               rules_file_name: &str,
               data_file_name: &str,

--- a/guard/src/commands/validate/common.rs
+++ b/guard/src/commands/validate/common.rs
@@ -230,11 +230,11 @@ pub(super) fn print_name_info<R, U, B>(
                              rules_file_name,
                              data_file_name,
                              match cmp {
-                                 CmpOperator::Exists => if not { "did not exist" } else { "existed" },
-                                 CmpOperator::Empty => if not { "was not empty"} else { "was empty" },
-                                 CmpOperator::IsList => if not { "was not a list " } else { "was list" },
-                                 CmpOperator::IsMap => if not { "was not a struct" } else { "was struct" },
-                                 CmpOperator::IsString => if not { "was not a string " } else { "was string" },
+                                 CmpOperator::Exists => if !not { "did not exist" } else { "existed" },
+                                 CmpOperator::Empty => if !not { "was not empty"} else { "was empty" },
+                                 CmpOperator::IsList => if !not { "was not a list " } else { "was list" },
+                                 CmpOperator::IsMap => if !not { "was not a struct" } else { "was struct" },
+                                 CmpOperator::IsString => if !not { "was not a string " } else { "was string" },
                                  _ => unreachable!()
                              },
                              each)?,

--- a/guard/src/commands/validate/common.rs
+++ b/guard/src/commands/validate/common.rs
@@ -1,0 +1,134 @@
+use colored::*;
+use serde::Serialize;
+
+use crate::commands::tracker::StatusContext;
+use crate::rules::{EvaluationType, path_value, Status};
+use crate::rules::path_value::Path;
+use crate::rules::values::CmpOperator;
+use std::fmt::Debug;
+use std::io::Write;
+use std::collections::HashMap;
+use std::convert::TryInto;
+
+#[derive(Debug, PartialEq, Serialize)]
+pub(super) struct NameInfo<'a> {
+    pub(super) rule: &'a str,
+    pub(super) path: String,
+    pub(super) from: serde_json::Value,
+    pub(super) to: Option<serde_json::Value>,
+    pub(super) comparison: Option<(CmpOperator, bool)>,
+    pub(super) message: String
+}
+
+pub(super) trait GenericRenderer : Debug {
+    fn render(&self,
+              writer: &mut dyn Write,
+              rules_file_name: &str,
+              data_file_name: &str,
+              resources: HashMap<String, Vec<NameInfo<'_>>>,
+              longest_rule_len: usize) -> crate::rules::Result<()>;
+}
+
+#[derive(Debug)]
+pub(super) enum StructureType {
+    JSON,
+    YAML
+}
+
+#[derive(Debug)]
+pub(super) struct StructuredSummary {
+    hierarchy_type: StructureType
+}
+
+impl StructuredSummary {
+    pub(super) fn new(hierarchy_type: StructureType) -> Self {
+        StructuredSummary {
+            hierarchy_type
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct DataOutput<'a> {
+    data_from: &'a str,
+    rules_from: &'a str,
+    failed: HashMap<String, Vec<NameInfo<'a>>>
+}
+
+impl GenericRenderer for StructuredSummary {
+    fn render(&self,
+              writer: &mut dyn Write,
+              rules_file_name: &str,
+              data_file_name: &str,
+              resources: HashMap<String, Vec<NameInfo<'_>>>,
+              longest_rule_len: usize) -> crate::rules::Result<()> {
+        let value = DataOutput {
+            rules_from: rules_file_name,
+            data_from: data_file_name,
+            failed: resources
+        };
+        match &self.hierarchy_type {
+            StructureType::JSON => writeln!(writer, "{}", serde_json::to_string(&value)?),
+            StructureType::YAML => writeln!(writer, "{}", serde_yaml::to_string(&value)?),
+        };
+        Ok(())
+    }
+}
+
+pub(super) fn extract_name_info<'a>(rule_name: &'a str, each_failing_clause: &StatusContext) -> crate::rules::Result<NameInfo<'a>> {
+    let value = each_failing_clause.from.as_ref().unwrap();
+    let (path, from): (String, serde_json::Value) = value.try_into()?;
+    Ok(NameInfo {
+        rule: rule_name,
+        path,
+        from,
+        to: match &each_failing_clause.to {
+            Some(to) => {
+                let (_, val): (String, serde_json::Value) = to.try_into()?;
+                Some(val)
+            },
+            None => None,
+        },
+        comparison: each_failing_clause.comparator.clone(),
+        message: each_failing_clause.msg.as_ref().map_or(
+            "".to_string(), |e| if !e.contains("DEFAULT") { e.clone() } else { "".to_string() })
+    })
+}
+
+pub(super) fn colored_string(status: Option<Status>) -> ColoredString {
+    let status = match status {
+        Some(s) => s,
+        None => Status::SKIP,
+    };
+    match status {
+        Status::PASS => "PASS".green(),
+        Status::FAIL => "FAIL".red().bold(),
+        Status::SKIP => "SKIP".yellow().bold(),
+    }
+}
+
+pub(super) fn find_all_failing_clauses(context: &StatusContext) -> Vec<&StatusContext> {
+    let mut failed = Vec::with_capacity(context.children.len());
+    for each in &context.children {
+        if each.status.map_or(false, |s| s == Status::FAIL) {
+            match each.eval_type {
+                EvaluationType::Clause |
+                EvaluationType::BlockClause => {
+                    failed.push(each);
+                    if each.eval_type == EvaluationType::BlockClause {
+                        failed.extend(find_all_failing_clauses(each));
+                    }
+                },
+
+                EvaluationType::Filter |
+                EvaluationType::Condition => {
+                    continue;
+                },
+
+                _ => failed.extend(find_all_failing_clauses(each))
+            }
+        }
+    }
+    failed
+}
+

--- a/guard/src/commands/validate/common.rs
+++ b/guard/src/commands/validate/common.rs
@@ -184,8 +184,7 @@ pub(super) fn print_name_info<R, U, B>(
         match cmp {
             None => {
                 // Block Clause retrieval error
-                writeln!(writer, "{}. Error Message [{}]",
-                         retrieval_error(rules_file_name, data_file_name, each)?, each.message.replace("\n", ";"))?;
+                writeln!(writer, "{}", retrieval_error(rules_file_name, data_file_name, each)?)?;
             },
 
             Some(cmp) => {

--- a/guard/src/commands/validate/common.rs
+++ b/guard/src/commands/validate/common.rs
@@ -196,6 +196,26 @@ pub(super) fn find_all_failing_clauses(context: &StatusContext) -> Vec<&StatusCo
     failed
 }
 
+pub(super) fn print_compliant_skipped_info(writer: &mut dyn Write,
+                                           passed: &HashSet<String>,
+                                           skipped: &HashSet<String>,
+                                           rules_file_name: &str,
+                                           data_file_name: &str) -> crate::rules::Result<()> {
+    if !passed.is_empty() {
+        writeln!(writer, "--")?;
+    }
+    for pass in passed {
+        writeln!(writer, "Rule [{}/{}] is compliant for template [{}]", rules_file_name, pass, data_file_name)?;
+    }
+    if !skipped.is_empty() {
+        writeln!(writer, "--")?;
+    }
+    for skip in skipped {
+        writeln!(writer, "Rule [{}/{}] is not applicable for template [{}]", rules_file_name, skip, data_file_name)?;
+    }
+    Ok(())
+}
+
 pub(super) fn print_name_info<R, U, B>(
     writer: &mut dyn Write,
     info: &[NameInfo<'_>],

--- a/guard/src/commands/validate/generic_summary.rs
+++ b/guard/src/commands/validate/generic_summary.rs
@@ -156,20 +156,8 @@ impl GenericReporter for SingleLineSummary {
                 binary_error_message
             )?;
         }
-        if !passed.is_empty() {
-            writeln!(writer, "--");
-        }
-        for pass in passed {
-            writeln!(writer, "Rule [{}/{}] is compliant for data [{}]", rules_file_name, pass, data_file_name);
-        }
-
-        if !skipped.is_empty() {
-            writeln!(writer, "--");
-        }
-        for skip in skipped {
-            writeln!(writer, "Rule [{}/{}] is not applicable for data [{}]", rules_file_name, skip, data_file_name);
-        }
-        writeln!(writer, "--");
+        super::common::print_compliant_skipped_info(writer, &passed, &skipped, rules_file_name, data_file_name)?;
+        writeln!(writer, "--")?;
         Ok(())
     }
 }

--- a/guard/src/commands/validate/generic_summary.rs
+++ b/guard/src/commands/validate/generic_summary.rs
@@ -52,11 +52,9 @@ impl<'a> Reporter for GenericSummary<'a> {
                     match each_failed_clause.eval_type {
                         EvaluationType::Clause |
                         EvaluationType::BlockClause => {
-                            if each_failed_clause.from.is_some() {
-                                by_rule.entry(each_failed_rule.context.clone())
-                                    .or_insert(Vec::new())
-                                    .push(extract_name_info(&each_failed_rule.context, each_failed_clause)?);
-                            }
+                            by_rule.entry(each_failed_rule.context.clone())
+                                .or_insert(Vec::new())
+                                .push(extract_name_info(&each_failed_rule.context, each_failed_clause)?);
                         }
 
                         _ => {}
@@ -98,7 +96,7 @@ fn retrieval_error_message(rules_file: &str, data_file: &str, info: &NameInfo<'_
 fn unary_error_message(rules_file: &str, data_file: &str, op_msg: &str, info: &NameInfo<'_>) -> crate::rules::Result<String> {
     Ok(format!("Property [{path}] in data [{data}] is not compliant with [{rules}/{rule}] because provided value [{provided}] {op_msg}. Error Message [{msg}]",
         path=info.path,
-        provided=info.provided,
+        provided=info.provided.as_ref().map_or(&serde_json::Value::Null, std::convert::identity),
         op_msg=op_msg,
         data=data_file,
         rules=rules_file,
@@ -110,7 +108,7 @@ fn unary_error_message(rules_file: &str, data_file: &str, op_msg: &str, info: &N
 fn binary_error_message(rules_file: &str, data_file: &str, op_msg: &str, info: &NameInfo<'_>) -> crate::rules::Result<String> {
     Ok(format!("Property [{path}] in data [{data}] is not compliant with [{rules}/{rule}] because provided value [{provided}] {op_msg} match expected value [{expected}]. Error Message [{msg}]",
                path=info.path,
-               provided=info.provided,
+               provided=info.provided.as_ref().map_or(&serde_json::Value::Null, std::convert::identity),
                op_msg=op_msg,
                data=data_file,
                rules=rules_file,

--- a/guard/src/commands/validate/generic_summary.rs
+++ b/guard/src/commands/validate/generic_summary.rs
@@ -107,7 +107,7 @@ fn retrieval_error_message(rules_file: &str, data_file: &str, info: &NameInfo<'_
 }
 
 fn unary_error_message(rules_file: &str, data_file: &str, op_msg: &str, info: &NameInfo<'_>) -> crate::rules::Result<String> {
-    Ok(format!("Property [{path}] in data [{data}] is not compliant with [{rules}/{rule}] because provided value [{provided}] {op_msg}. Error Message [{msg}]",
+    Ok(format!("Property [{path}] in data [{data}] is not compliant with [{rules}/{rule}] because needed value at [{provided}] {op_msg}. Error Message [{msg}]",
         path=info.path,
         provided=info.provided.as_ref().map_or(&serde_json::Value::Null, std::convert::identity),
         op_msg=op_msg,

--- a/guard/src/commands/validate/generic_summary.rs
+++ b/guard/src/commands/validate/generic_summary.rs
@@ -30,6 +30,7 @@ impl<'a> GenericSummary<'a> {
             output_format_type,
             renderer: match output_format_type {
                 OutputFormatType::SingleLineSummary => Box::new(SingleLineSummary{}) as Box<dyn GenericReporter>,
+                OutputFormatType::SingleLineSummaryBlock => Box::new(SingleLineSummaryBlock{}) as Box<dyn GenericReporter>,
                 OutputFormatType::JSON => Box::new(StructuredSummary::new(StructureType::JSON)) as Box<dyn GenericReporter>,
                 OutputFormatType::YAML => Box::new(StructuredSummary::new(StructureType::YAML)) as Box<dyn GenericReporter>,
             }
@@ -80,11 +81,33 @@ impl GenericReporter for SingleLineSummary {
               longest_rule_len: usize) -> crate::rules::Result<()> {
 
         writeln!(writer, "Evaluation of rules {} against data {}", rules_file_name, data_file_name)?;
+        writeln!(writer, "--");
         for (_rule, clauses) in resources {
-            super::common::print_name_info(writer, &clauses, longest_rule_len, rules_file_name)?;
+            super::common::print_name_info(writer, "Violation of ", &clauses, longest_rule_len, rules_file_name)?;
         }
-        writeln!(writer, "-");
+        writeln!(writer, "--");
         Ok(())
     }
 }
 
+#[derive(Debug)]
+struct SingleLineSummaryBlock{}
+
+impl GenericReporter for SingleLineSummaryBlock {
+    fn report(&self,
+              writer: &mut dyn Write,
+              rules_file_name: &str,
+              data_file_name: &str,
+              resources: HashMap<String, Vec<NameInfo<'_>>>,
+              longest_rule_len: usize) -> crate::rules::Result<()> {
+
+        writeln!(writer, "Evaluation of rules {} against data {}", rules_file_name, data_file_name)?;
+        writeln!(writer, "--");
+        for (rule, clauses) in resources {
+            writeln!(writer, "{} violations for rule {}", clauses.len(), rule);
+            super::common::print_name_info(writer, "Violation of ", &clauses, longest_rule_len, rules_file_name)?;
+        }
+        writeln!(writer, "--");
+        Ok(())
+    }
+}

--- a/guard/src/commands/validate/generic_summary.rs
+++ b/guard/src/commands/validate/generic_summary.rs
@@ -1,0 +1,140 @@
+use std::collections::HashMap;
+use std::fmt::Debug;
+use std::io::Write;
+
+use colored::*;
+use serde::Serialize;
+
+use crate::commands::tracker::StatusContext;
+use crate::commands::validate::{OutputFormatType, Renderer};
+use crate::commands::validate::common::find_all_failing_clauses;
+use crate::rules::EvaluationType;
+
+use super::common::*;
+
+#[derive(Debug)]
+pub(crate) struct GenericSummary<'a> {
+    data_file_name: &'a str,
+    rules_file_name: &'a str,
+    output_format_type: OutputFormatType,
+    renderer: Box<dyn GenericRenderer + 'a>,
+}
+
+impl<'a> GenericSummary<'a> {
+    pub(crate) fn new<'r>(data_file_name: &'r str,
+                          rules_file_name: &'r str,
+                          output_format_type: OutputFormatType) -> GenericSummary<'r> {
+        GenericSummary {
+            data_file_name,
+            rules_file_name,
+            output_format_type,
+            renderer: match output_format_type {
+                OutputFormatType::SingleLineSummary => Box::new(SingleLineSummary{}) as Box<dyn GenericRenderer>,
+                OutputFormatType::JSON => Box::new(StructuredSummary::new(StructureType::JSON)) as Box<dyn GenericRenderer>,
+                OutputFormatType::YAML => Box::new(StructuredSummary::new(StructureType::YAML)) as Box<dyn GenericRenderer>,
+            }
+        }
+    }
+}
+
+impl<'a> Renderer for GenericSummary<'a> {
+    fn render(&self,
+              writer: &mut dyn Write,
+              failed_rules: &[&StatusContext],
+              _passed_or_skipped: &[&StatusContext],
+              longest_rule_name: usize) -> crate::rules::Result<()> {
+        if !failed_rules.is_empty() {
+            let mut by_rule = HashMap::with_capacity(failed_rules.len());
+            for each_failed_rule in failed_rules {
+                for each_failed_clause in find_all_failing_clauses(each_failed_rule) {
+                    match each_failed_clause.eval_type {
+                        EvaluationType::Clause |
+                        EvaluationType::BlockClause => {
+                            if each_failed_clause.from.is_some() {
+                                by_rule.entry(each_failed_rule.context.clone())
+                                    .or_insert(Vec::new())
+                                    .push(extract_name_info(&each_failed_rule.context, each_failed_clause)?);
+                            }
+                        }
+
+                        _ => {}
+                    }
+                }
+            }
+            self.renderer.render(writer, self.rules_file_name, self.data_file_name, by_rule, longest_rule_name)?;
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug)]
+struct SingleLineSummary{}
+
+impl GenericRenderer for SingleLineSummary {
+    fn render(&self,
+              writer: &mut dyn Write,
+              rules_file_name: &str,
+              _data_file_name: &str,
+              resources: HashMap<String, Vec<NameInfo<'_>>>,
+              longest_rule_len: usize) -> crate::rules::Result<()> {
+
+        writeln!(writer, "{}", "Single Line Summary".underline())?;
+        for (_rule, clauses) in resources {
+            for info in clauses {
+                let (did_or_didnt, operation, cmp) = match &info.comparison {
+                    Some((cmp, not)) => {
+                        if *not {
+                            ("did", format!("NOT {}", cmp), Some(cmp))
+                        } else {
+                            ("did not", format!("{}", cmp), Some(cmp))
+                        }
+                    },
+                    None => {
+                        ("did not", "NONE".to_string(), None)
+                    }
+                };
+                match cmp {
+                    None => {
+                        // Block Clause retrieval error
+                        writeln!(writer, "{0}/{1:<2$}{3} failed due to retrieval error, stopped at [{4}]. Error = [{5}]",
+                                 rules_file_name,
+                                 info.rule,
+                                 longest_rule_len+4,
+                                 operation,
+                                 info.from,
+                                 info.message.replace("\n", ";"))?;
+                    },
+
+                    Some(cmp) => {
+                        if cmp.is_unary() {
+                            writeln!(writer, "{0}/{1:<2$}{3} failed on value [{4}] at path {5}. Error Message [{6}]",
+                                     rules_file_name,
+                                     info.rule,
+                                     longest_rule_len+4,
+                                     operation,
+                                     info.from,
+                                     info.path,
+                                     info.message.replace("\n", ";"))?;
+                        }
+                        else {
+                            writeln!(writer, "{0}/{1:<2$}{3} failed for value [{4}] at path {7} {5} match with [{6}]. Error Message [{8}]",
+                                     rules_file_name,
+                                     info.rule,
+                                     longest_rule_len + 4,
+                                     operation,
+                                     info.from,
+                                     did_or_didnt,
+                                     match &info.to { Some(v) => v, None => &serde_json::Value::Null },
+                                     info.path,
+                                     info.message.replace("\n", ";"))?;
+                        }
+
+                    }
+
+                }
+            }
+        }
+        Ok(())
+    }
+}
+

--- a/guard/src/commands/validate/generic_summary.rs
+++ b/guard/src/commands/validate/generic_summary.rs
@@ -86,20 +86,19 @@ impl<'a> Reporter for GenericSummary<'a> {
 struct SingleLineSummary{}
 
 fn retrieval_error_message(rules_file: &str, data_file: &str, info: &NameInfo<'_>) -> crate::rules::Result<String> {
-    Ok(format!("Property traversed until [{path}] with [{value}] for data [{data}] wasn't compliant with [{rules}/{rule}] due to retrieval error. Error Message [{msg}]",
+    Ok(format!("Property traversed until [{path}] in data [{data}] is not compliant with [{rules}/{rule}] due to retrieval error. Error Message [{msg}]",
        data=data_file,
        rules=rules_file,
        rule=info.rule,
        path=info.path,
-       value=info.provided,
        msg=info.message.replace("\n", ";"),
     ))
 }
 
 fn unary_error_message(rules_file: &str, data_file: &str, op_msg: &str, info: &NameInfo<'_>) -> crate::rules::Result<String> {
-    Ok(format!("Property [{path}] with [{value}] {op_msg} for data [{data}] wasn't compliant with [{rules}/{rule}]. Error Message [{msg}]",
+    Ok(format!("Property [{path}] in data [{data}] is not compliant with [{rules}/{rule}] because provided value [{provided}] {op_msg}. Error Message [{msg}]",
         path=info.path,
-        value=info.provided,
+        provided=info.provided,
         op_msg=op_msg,
         data=data_file,
         rules=rules_file,
@@ -109,9 +108,9 @@ fn unary_error_message(rules_file: &str, data_file: &str, op_msg: &str, info: &N
 }
 
 fn binary_error_message(rules_file: &str, data_file: &str, op_msg: &str, info: &NameInfo<'_>) -> crate::rules::Result<String> {
-    Ok(format!("Property [{path}] with [{value}] {op_msg} match [{expected}] for data [{data}] wasn't compliant with [{rules}/{rule}]. Error Message [{msg}]",
+    Ok(format!("Property [{path}] in data [{data}] is not compliant with [{rules}/{rule}] because provided value [{provided}] {op_msg} match expected value [{expected}]. Error Message [{msg}]",
                path=info.path,
-               value=info.provided,
+               provided=info.provided,
                op_msg=op_msg,
                data=data_file,
                rules=rules_file,
@@ -150,14 +149,14 @@ impl GenericReporter for SingleLineSummary {
             writeln!(writer, "--");
         }
         for pass in passed {
-            writeln!(writer, "Rule [{}/{}] was compliant for data file [{}]", rules_file_name, pass, data_file_name);
+            writeln!(writer, "Rule [{}/{}] is compliant for data [{}]", rules_file_name, pass, data_file_name);
         }
 
         if !skipped.is_empty() {
             writeln!(writer, "--");
         }
         for skip in skipped {
-            writeln!(writer, "Rule [{}/{}] was not applicable for data file [{}]", rules_file_name, skip, data_file_name);
+            writeln!(writer, "Rule [{}/{}] is not applicable for data [{}]", rules_file_name, skip, data_file_name);
         }
         writeln!(writer, "--");
         Ok(())

--- a/guard/src/commands/validate/generic_summary.rs
+++ b/guard/src/commands/validate/generic_summary.rs
@@ -6,7 +6,7 @@ use colored::*;
 use serde::Serialize;
 
 use crate::commands::tracker::StatusContext;
-use crate::commands::validate::{OutputFormatType, Renderer};
+use crate::commands::validate::{OutputFormatType, Reporter};
 use crate::commands::validate::common::find_all_failing_clauses;
 use crate::rules::EvaluationType;
 
@@ -17,7 +17,7 @@ pub(crate) struct GenericSummary<'a> {
     data_file_name: &'a str,
     rules_file_name: &'a str,
     output_format_type: OutputFormatType,
-    renderer: Box<dyn GenericRenderer + 'a>,
+    renderer: Box<dyn GenericReporter + 'a>,
 }
 
 impl<'a> GenericSummary<'a> {
@@ -29,16 +29,16 @@ impl<'a> GenericSummary<'a> {
             rules_file_name,
             output_format_type,
             renderer: match output_format_type {
-                OutputFormatType::SingleLineSummary => Box::new(SingleLineSummary{}) as Box<dyn GenericRenderer>,
-                OutputFormatType::JSON => Box::new(StructuredSummary::new(StructureType::JSON)) as Box<dyn GenericRenderer>,
-                OutputFormatType::YAML => Box::new(StructuredSummary::new(StructureType::YAML)) as Box<dyn GenericRenderer>,
+                OutputFormatType::SingleLineSummary => Box::new(SingleLineSummary{}) as Box<dyn GenericReporter>,
+                OutputFormatType::JSON => Box::new(StructuredSummary::new(StructureType::JSON)) as Box<dyn GenericReporter>,
+                OutputFormatType::YAML => Box::new(StructuredSummary::new(StructureType::YAML)) as Box<dyn GenericReporter>,
             }
         }
     }
 }
 
-impl<'a> Renderer for GenericSummary<'a> {
-    fn render(&self,
+impl<'a> Reporter for GenericSummary<'a> {
+    fn report(&self,
               writer: &mut dyn Write,
               failed_rules: &[&StatusContext],
               _passed_or_skipped: &[&StatusContext],
@@ -61,7 +61,7 @@ impl<'a> Renderer for GenericSummary<'a> {
                     }
                 }
             }
-            self.renderer.render(writer, self.rules_file_name, self.data_file_name, by_rule, longest_rule_name)?;
+            self.renderer.report(writer, self.rules_file_name, self.data_file_name, by_rule, longest_rule_name)?;
         }
         Ok(())
     }
@@ -70,8 +70,8 @@ impl<'a> Renderer for GenericSummary<'a> {
 #[derive(Debug)]
 struct SingleLineSummary{}
 
-impl GenericRenderer for SingleLineSummary {
-    fn render(&self,
+impl GenericReporter for SingleLineSummary {
+    fn report(&self,
               writer: &mut dyn Write,
               rules_file_name: &str,
               data_file_name: &str,

--- a/guard/src/commands/validate/generic_summary.rs
+++ b/guard/src/commands/validate/generic_summary.rs
@@ -8,7 +8,7 @@ use serde::Serialize;
 use crate::commands::tracker::StatusContext;
 use crate::commands::validate::{OutputFormatType, Reporter};
 use crate::commands::validate::common::find_all_failing_clauses;
-use crate::rules::EvaluationType;
+use crate::rules::{EvaluationType, Status};
 
 use super::common::*;
 
@@ -40,6 +40,7 @@ impl<'a> GenericSummary<'a> {
 impl<'a> Reporter for GenericSummary<'a> {
     fn report(&self,
               writer: &mut dyn Write,
+              _status: Option<Status>,
               failed_rules: &[&StatusContext],
               _passed_or_skipped: &[&StatusContext],
               longest_rule_name: usize) -> crate::rules::Result<()> {

--- a/guard/src/commands/validate/generic_summary.rs
+++ b/guard/src/commands/validate/generic_summary.rs
@@ -52,6 +52,19 @@ impl<'a> Reporter for GenericSummary<'a> {
                     match each_failed_clause.eval_type {
                         EvaluationType::Clause |
                         EvaluationType::BlockClause => {
+                            if each_failed_clause.eval_type == EvaluationType::BlockClause {
+                                match &each_failed_clause.msg {
+                                    Some(msg) => {
+                                        if msg.contains("DEFAULT") {
+                                            continue;
+                                        }
+                                    },
+
+                                    None => {
+                                        continue;
+                                    }
+                                }
+                            }
                             by_rule.entry(each_failed_rule.context.clone())
                                 .or_insert(Vec::new())
                                 .push(extract_name_info(&each_failed_rule.context, each_failed_clause)?);

--- a/guard/src/commands/validate/generic_summary.rs
+++ b/guard/src/commands/validate/generic_summary.rs
@@ -74,66 +74,15 @@ impl GenericRenderer for SingleLineSummary {
     fn render(&self,
               writer: &mut dyn Write,
               rules_file_name: &str,
-              _data_file_name: &str,
+              data_file_name: &str,
               resources: HashMap<String, Vec<NameInfo<'_>>>,
               longest_rule_len: usize) -> crate::rules::Result<()> {
 
-        writeln!(writer, "{}", "Single Line Summary".underline())?;
+        writeln!(writer, "Evaluation of rules {} against data {}", rules_file_name, data_file_name)?;
         for (_rule, clauses) in resources {
-            for info in clauses {
-                let (did_or_didnt, operation, cmp) = match &info.comparison {
-                    Some((cmp, not)) => {
-                        if *not {
-                            ("did", format!("NOT {}", cmp), Some(cmp))
-                        } else {
-                            ("did not", format!("{}", cmp), Some(cmp))
-                        }
-                    },
-                    None => {
-                        ("did not", "NONE".to_string(), None)
-                    }
-                };
-                match cmp {
-                    None => {
-                        // Block Clause retrieval error
-                        writeln!(writer, "{0}/{1:<2$}{3} failed due to retrieval error, stopped at [{4}]. Error = [{5}]",
-                                 rules_file_name,
-                                 info.rule,
-                                 longest_rule_len+4,
-                                 operation,
-                                 info.from,
-                                 info.message.replace("\n", ";"))?;
-                    },
-
-                    Some(cmp) => {
-                        if cmp.is_unary() {
-                            writeln!(writer, "{0}/{1:<2$}{3} failed on value [{4}] at path {5}. Error Message [{6}]",
-                                     rules_file_name,
-                                     info.rule,
-                                     longest_rule_len+4,
-                                     operation,
-                                     info.from,
-                                     info.path,
-                                     info.message.replace("\n", ";"))?;
-                        }
-                        else {
-                            writeln!(writer, "{0}/{1:<2$}{3} failed for value [{4}] at path {7} {5} match with [{6}]. Error Message [{8}]",
-                                     rules_file_name,
-                                     info.rule,
-                                     longest_rule_len + 4,
-                                     operation,
-                                     info.from,
-                                     did_or_didnt,
-                                     match &info.to { Some(v) => v, None => &serde_json::Value::Null },
-                                     info.path,
-                                     info.message.replace("\n", ";"))?;
-                        }
-
-                    }
-
-                }
-            }
+            super::common::print_name_info(writer, &clauses, longest_rule_len, rules_file_name)?;
         }
+        writeln!(writer, "-");
         Ok(())
     }
 }

--- a/guard/src/commands/validate/summary_table.rs
+++ b/guard/src/commands/validate/summary_table.rs
@@ -1,0 +1,84 @@
+use crate::commands::validate::Renderer;
+use std::io::Write;
+use crate::commands::tracker::StatusContext;
+use crate::rules::Status;
+use colored::*;
+use itertools::Itertools;
+use enumflags2::{bitflags, BitFlags};
+
+#[bitflags]
+#[repr(u8)]
+#[derive(Debug, Copy, Clone, Eq, PartialOrd, PartialEq)]
+pub(super) enum SummaryType {
+    PASS = 0b0001,
+    FAIL = 0b0010,
+    SKIP = 0b0100,
+}
+
+
+#[derive(Debug)]
+pub(super) struct SummaryTable<'r> {
+    rules_file_name: &'r str,
+    data_file_name: &'r str,
+    summary_type: BitFlags<SummaryType>,
+}
+
+impl<'a> SummaryTable<'a> {
+    pub(crate) fn new<'r>(rules_file_name: &'r str, data_file_name: &'r str, summary_type: BitFlags<SummaryType>) -> SummaryTable<'r> {
+        SummaryTable {
+            rules_file_name, data_file_name, summary_type
+        }
+    }
+}
+
+fn print_partition(writer: &mut dyn Write,
+                   rules_file_name: &str,
+                   part: &[&StatusContext],
+                   longest: usize) -> crate::rules::Result<()> {
+    for container in part {
+        writeln!(writer,
+                 "{filename}/{context:<0$}{status}",
+                 longest+4,
+                 filename=rules_file_name,
+                 context=container.context,
+                 status=super::common::colored_string(container.status)
+        )?;
+    }
+    Ok(())
+}
+
+
+impl<'r> Renderer for SummaryTable<'r> {
+    fn render(&self,
+              writer: &mut dyn Write,
+              failed_rules: &[&StatusContext],
+              passed_or_skipped: &[&StatusContext],
+              longest_rule_name: usize) -> crate::rules::Result<()> {
+
+        let as_vec = passed_or_skipped.iter().map(|s| *s)
+            .collect_vec();
+        let (skipped, passed): (Vec<&StatusContext>, Vec<&StatusContext>) = as_vec.iter()
+            .partition(|status| match status.status { // This uses the dereference deep trait of Rust
+                Some(Status::SKIP) => true,
+                _ => false
+            });
+
+        if self.summary_type.contains(SummaryType::SKIP) && !skipped.is_empty() {
+            writeln!(writer, "{}", "SKIP rules".bold());
+            print_partition(writer, self.rules_file_name, &skipped, longest_rule_name)?;
+
+        }
+
+        if self.summary_type.contains(SummaryType::PASS) && !passed.is_empty() {
+            writeln!(writer, "{}", "PASS rules".bold());
+            print_partition(writer, self.rules_file_name, &passed, longest_rule_name)?;
+        }
+
+        if self.summary_type.contains(SummaryType::FAIL) && !failed_rules.is_empty() {
+            writeln!(writer, "{}", "FAILED rules".bold());
+            print_partition(writer, self.rules_file_name, failed_rules, longest_rule_name)?;
+        }
+
+        Ok(())
+    }
+}

--- a/guard/src/commands/validate/summary_table.rs
+++ b/guard/src/commands/validate/summary_table.rs
@@ -1,4 +1,4 @@
-use crate::commands::validate::Renderer;
+use crate::commands::validate::Reporter;
 use std::io::Write;
 use crate::commands::tracker::StatusContext;
 use crate::rules::Status;
@@ -48,8 +48,8 @@ fn print_partition(writer: &mut dyn Write,
 }
 
 
-impl<'r> Renderer for SummaryTable<'r> {
-    fn render(&self,
+impl<'r> Reporter for SummaryTable<'r> {
+    fn report(&self,
               writer: &mut dyn Write,
               failed_rules: &[&StatusContext],
               passed_or_skipped: &[&StatusContext],

--- a/guard/src/commands/validate/summary_table.rs
+++ b/guard/src/commands/validate/summary_table.rs
@@ -5,6 +5,7 @@ use crate::rules::Status;
 use colored::*;
 use itertools::Itertools;
 use enumflags2::{bitflags, BitFlags};
+use crate::commands::validate::common::colored_string;
 
 #[bitflags]
 #[repr(u8)]
@@ -51,6 +52,7 @@ fn print_partition(writer: &mut dyn Write,
 impl<'r> Reporter for SummaryTable<'r> {
     fn report(&self,
               writer: &mut dyn Write,
+              status: Option<Status>,
               failed_rules: &[&StatusContext],
               passed_or_skipped: &[&StatusContext],
               longest_rule_name: usize) -> crate::rules::Result<()> {
@@ -63,6 +65,7 @@ impl<'r> Reporter for SummaryTable<'r> {
                 _ => false
             });
 
+        writeln!(writer, "{} Status = {}", self.data_file_name, colored_string(status))?;
         if self.summary_type.contains(SummaryType::SKIP) && !skipped.is_empty() {
             writeln!(writer, "{}", "SKIP rules".bold());
             print_partition(writer, self.rules_file_name, &skipped, longest_rule_name)?;
@@ -78,6 +81,8 @@ impl<'r> Reporter for SummaryTable<'r> {
             writeln!(writer, "{}", "FAILED rules".bold());
             print_partition(writer, self.rules_file_name, failed_rules, longest_rule_name)?;
         }
+
+        writeln!(writer, "---")?;
 
         Ok(())
     }

--- a/guard/src/rules/evaluate.rs
+++ b/guard/src/rules/evaluate.rs
@@ -728,7 +728,7 @@ impl<'loc> Evaluate for BlockGuardClause<'loc> {
         let block_values = match resolve_query(all, &self.query.query, context, var_resolver) {
             Err(Error(ErrorKind::RetrievalError(e))) |
             Err(Error(ErrorKind::IncompatibleRetrievalError(e))) => {
-                return Ok(report.from(Some(context.clone())).message(e).status(Status::FAIL).get_status())
+                return Ok(report.message(e).status(Status::FAIL).get_status())
             },
 
             Ok(v) => if v.is_empty() { // one or more

--- a/guard/src/rules/evaluate.rs
+++ b/guard/src/rules/evaluate.rs
@@ -76,16 +76,19 @@ fn compare_loop_all<F>(lhs: &Vec<&PathAwareValue>, rhs: &Vec<&PathAwareValue>, c
     let mut lhs_cmp = true;
     let mut results = Vec::with_capacity(lhs.len());
     'lhs: for lhs_value in lhs {
+        let mut acc = Vec::with_capacity(lhs.len());
         for rhs_value in rhs {
             let check = compare(*lhs_value, *rhs_value)?;
             if check {
-                results.push((true, None, None));
                 if any_one_rhs {
+                    acc.clear();
+                    results.push((true, None, None));
                     continue 'lhs
                 }
+                acc.push((true, None, None));
             }
             else {
-                results.push((false, Some((*lhs_value).clone()), Some((*rhs_value).clone())));
+                acc.push((false, Some((*lhs_value).clone()), Some((*rhs_value).clone())));
                 if !any_one_rhs {
                     lhs_cmp = false;
                 }
@@ -94,6 +97,7 @@ fn compare_loop_all<F>(lhs: &Vec<&PathAwareValue>, rhs: &Vec<&PathAwareValue>, c
         if any_one_rhs {
             lhs_cmp = false;
         }
+        results.extend(acc)
     }
     Ok((lhs_cmp, results))
 }

--- a/guard/src/rules/evaluate.rs
+++ b/guard/src/rules/evaluate.rs
@@ -432,10 +432,6 @@ impl<'loc> Evaluate for GuardAccessClause<'loc> {
             None => {
                 let guard_loc = format!("{}", self);
                 let mut auto_reporter = AutoReport::new(EvaluationType::Clause, var_resolver, &guard_loc);
-                let message = match &clause.access_clause.custom_message {
-                    Some(msg) => msg,
-                    None => "(DEFAULT: NO_MESSAGE)"
-                };
                 if all {
                     return Ok(auto_reporter.status(Status::FAIL)
                         .message(retrieve_error.map_or("".to_string(), |e| e)).get_status())

--- a/guard/src/rules/evaluate.rs
+++ b/guard/src/rules/evaluate.rs
@@ -587,6 +587,7 @@ impl<'loc> Evaluate for GuardAccessClause<'loc> {
             let guard_loc = format!("{}", self);
             let mut auto_reporter = AutoReport::new(EvaluationType::Clause, var_resolver, &guard_loc);
             auto_reporter.status(if outcome { Status::PASS } else { Status::FAIL });
+            auto_reporter.cmp(clause.access_clause.comparator);
             if !outcome {
                 auto_reporter.from(from).to(to).message(match &clause.access_clause.custom_message {
                     Some(msg) => msg.clone(),

--- a/guard/src/rules/evaluate_tests.rs
+++ b/guard/src/rules/evaluate_tests.rs
@@ -54,7 +54,7 @@ impl EvaluationContext for DummyEval {
         unimplemented!()
     }
 
-    fn end_evaluation(&self, _eval_type: EvaluationType, _context: &str, _msg: String, _from: Option<PathAwareValue>, _to: Option<PathAwareValue>, _status: Option<Status>) {
+    fn end_evaluation(&self, _eval_type: EvaluationType, _context: &str, _msg: String, _from: Option<PathAwareValue>, _to: Option<PathAwareValue>, _status: Option<Status>, _cmp: Option<(CmpOperator, bool)>) {
     }
 
     fn start_evaluation(&self, _eval_type: EvaluationType, _context: &str) {
@@ -147,10 +147,10 @@ impl<'r> EvaluationContext for Reporter<'r> {
         self.0.rule_status(rule_name)
     }
 
-    fn end_evaluation(&self, eval_type: EvaluationType, context: &str, msg: String, from: Option<PathAwareValue>, to: Option<PathAwareValue>, status: Option<Status>) {
+    fn end_evaluation(&self, eval_type: EvaluationType, context: &str, msg: String, from: Option<PathAwareValue>, to: Option<PathAwareValue>, status: Option<Status>, cmp: Option<(CmpOperator, bool)>) {
         println!("{} {} {:?}", eval_type, context, status);
         self.0.end_evaluation(
-            eval_type, context, msg, from, to, status
+            eval_type, context, msg, from, to, status, cmp
         )
     }
 
@@ -897,8 +897,8 @@ impl<'a, 'b> EvaluationContext for VariableResolver<'a, 'b> {
         self.0.rule_status(rule_name)
     }
 
-    fn end_evaluation(&self, eval_type: EvaluationType, context: &str, msg: String, from: Option<PathAwareValue>, to: Option<PathAwareValue>, status: Option<Status>) {
-        self.0.end_evaluation(eval_type, context, msg, from, to, status);
+    fn end_evaluation(&self, eval_type: EvaluationType, context: &str, msg: String, from: Option<PathAwareValue>, to: Option<PathAwareValue>, status: Option<Status>, cmp: Option<(CmpOperator, bool)>) {
+        self.0.end_evaluation(eval_type, context, msg, from, to, status, cmp);
     }
 
     fn start_evaluation(&self, eval_type: EvaluationType, context: &str) {
@@ -1799,8 +1799,8 @@ impl<'a> EvaluationContext for Tracker<'a> {
         self.root.rule_status(rule_name)
     }
 
-    fn end_evaluation(&self, eval_type: EvaluationType, context: &str, msg: String, from: Option<PathAwareValue>, to: Option<PathAwareValue>, status: Option<Status>) {
-        self.root.end_evaluation(eval_type, context, msg, from, to, status.clone());
+    fn end_evaluation(&self, eval_type: EvaluationType, context: &str, msg: String, from: Option<PathAwareValue>, to: Option<PathAwareValue>, status: Option<Status>, cmp: Option<(CmpOperator, bool)>) {
+        self.root.end_evaluation(eval_type, context, msg, from, to, status.clone(), cmp);
         if eval_type == EvaluationType::Rule {
             match self.expected.get(context) {
                 Some(e) => {
@@ -2094,7 +2094,7 @@ fn test_multiple_valued_clause_reporting() -> Result<()> {
             todo!()
         }
 
-        fn end_evaluation(&self, eval_type: EvaluationType, context: &str, msg: String, from: Option<PathAwareValue>, to: Option<PathAwareValue>, status: Option<Status>) {
+        fn end_evaluation(&self, eval_type: EvaluationType, context: &str, msg: String, from: Option<PathAwareValue>, to: Option<PathAwareValue>, status: Option<Status>, _cmp: Option<(CmpOperator, bool)>) {
             if eval_type == EvaluationType::Clause {
                 match &status {
                     Some(Status::FAIL) => {
@@ -2159,7 +2159,7 @@ fn test_multiple_valued_clause_reporting_var_access() -> Result<()> {
             self.root.rule_status(rule_name)
         }
 
-        fn end_evaluation(&self, eval_type: EvaluationType, context: &str, msg: String, from: Option<PathAwareValue>, to: Option<PathAwareValue>, status: Option<Status>) {
+        fn end_evaluation(&self, eval_type: EvaluationType, context: &str, msg: String, from: Option<PathAwareValue>, to: Option<PathAwareValue>, status: Option<Status>, cmp: Option<(CmpOperator, bool)>) {
             if eval_type == EvaluationType::Clause {
                 match &status {
                     Some(Status::FAIL) => {
@@ -2177,7 +2177,7 @@ fn test_multiple_valued_clause_reporting_var_access() -> Result<()> {
                     _ => {}
                 }
             }
-            self.root.end_evaluation(eval_type, context, msg, from, to, status)
+            self.root.end_evaluation(eval_type, context, msg, from, to, status, cmp)
         }
 
         fn start_evaluation(&self, eval_type: EvaluationType, context: &str) {

--- a/guard/src/rules/mod.rs
+++ b/guard/src/rules/mod.rs
@@ -14,6 +14,7 @@ use crate::rules::path_value::PathAwareValue;
 use nom::lib::std::convert::TryFrom;
 use crate::rules::errors::ErrorKind;
 use serde::{Serialize};
+use crate::rules::values::CmpOperator;
 
 pub(crate) type Result<R> = std::result::Result<R, Error>;
 
@@ -87,7 +88,16 @@ pub(crate) trait EvaluationContext {
 
     fn rule_status(&self, rule_name: &str) -> Result<Status>;
 
-    fn end_evaluation(&self, eval_type: EvaluationType, context: &str, msg: String, from: Option<PathAwareValue>, to: Option<PathAwareValue>, status: Option<Status>);
+    fn end_evaluation(
+        &self,
+        eval_type: EvaluationType,
+        context: &str,
+        msg: String,
+        from: Option<PathAwareValue>,
+        to: Option<PathAwareValue>,
+        status: Option<Status>,
+        comparator: Option<(CmpOperator, bool)>
+    );
 
     fn start_evaluation(&self, eval_type: EvaluationType, context: &str);
 }

--- a/guard/src/rules/parser_tests.rs
+++ b/guard/src/rules/parser_tests.rs
@@ -3662,7 +3662,7 @@ impl EvaluationContext for DummyEval {
         unimplemented!()
     }
 
-    fn end_evaluation(&self, _eval_type: EvaluationType, _context: &str, _msg: String, _from: Option<PathAwareValue>, _to: Option<PathAwareValue>, _status: Option<Status>) {
+    fn end_evaluation(&self, _eval_type: EvaluationType, _context: &str, _msg: String, _from: Option<PathAwareValue>, _to: Option<PathAwareValue>, _status: Option<Status>, _cmp: Option<(CmpOperator, bool)>) {
     }
 
     fn start_evaluation(&self, _eval_type: EvaluationType, _context: &str) {

--- a/guard/src/rules/path_value_tests.rs
+++ b/guard/src/rules/path_value_tests.rs
@@ -121,7 +121,7 @@ impl EvaluationContext for DummyEval {
         unimplemented!()
     }
 
-    fn end_evaluation(&self, _eval_type: EvaluationType, _context: &str, _msg: String, _from: Option<PathAwareValue>, _to: Option<PathAwareValue>, _status: Option<Status>) {
+    fn end_evaluation(&self, _eval_type: EvaluationType, _context: &str, _msg: String, _from: Option<PathAwareValue>, _to: Option<PathAwareValue>, _status: Option<Status>, _cmp: Option<(CmpOperator, bool)>) {
     }
 
     fn start_evaluation(&self, _eval_type: EvaluationType, _context: &str) {

--- a/guard/src/rules/values.rs
+++ b/guard/src/rules/values.rs
@@ -27,6 +27,21 @@ pub enum CmpOperator {
     IsMap,
 }
 
+impl CmpOperator {
+    pub(crate) fn is_unary(&self) -> bool {
+        match self {
+            CmpOperator::Exists     |
+            CmpOperator::Empty      |
+            CmpOperator::IsString   |
+            CmpOperator::IsList     |
+            CmpOperator::IsMap          => true,
+            _                           => false
+        }
+    }
+
+    pub(crate) fn is_binary(&self) -> bool { !self.is_unary() }
+}
+
 impl std::fmt::Display for CmpOperator {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {

--- a/guard/src/rules/values_tests.rs
+++ b/guard/src/rules/values_tests.rs
@@ -135,7 +135,7 @@ fn test_query_on_value() -> Result<()> {
             unimplemented!()
         }
 
-        fn end_evaluation(&self, _eval_type: EvaluationType, _context: &str, _msg: String, _from: Option<PathAwareValue>, _to: Option<PathAwareValue>, _status: Option<Status>) {
+        fn end_evaluation(&self, _eval_type: EvaluationType, _context: &str, _msg: String, _from: Option<PathAwareValue>, _to: Option<PathAwareValue>, _status: Option<Status>, _cmp: Option<(CmpOperator, bool)>) {
         }
 
         fn start_evaluation(&self, _eval_type: EvaluationType, _context: &str) {
@@ -224,7 +224,7 @@ fn test_type_block_with_var_query_evaluation() -> Result<()> {
             unimplemented!()
         }
 
-        fn end_evaluation(&self, _eval_type: EvaluationType, _context: &str, _msg: String, _from: Option<PathAwareValue>, _to: Option<PathAwareValue>, _status: Option<Status>) {
+        fn end_evaluation(&self, _eval_type: EvaluationType, _context: &str, _msg: String, _from: Option<PathAwareValue>, _to: Option<PathAwareValue>, _status: Option<Status>, _cmp: Option<(CmpOperator, bool)>) {
         }
 
         fn start_evaluation(&self, _eval_type: EvaluationType, _context: &str) {

--- a/guard/tests/functional.rs
+++ b/guard/tests/functional.rs
@@ -22,7 +22,7 @@ mod tests {
             "#,
         );
         let rule = "AWS::ApiGateway::Method { Properties.AuthorizationType == \"NONE\"}";
-        let mut expected = String::from(
+        let expected =
             r#"
             [
               {
@@ -32,6 +32,7 @@ mod tests {
                 "from": null,
                 "to": null,
                 "status": "FAIL",
+                "comparator": null,
                 "children": [
                   {
                     "eval_type": "Type",
@@ -40,6 +41,7 @@ mod tests {
                     "from": null,
                     "to": null,
                     "status": "FAIL",
+                    "comparator": null,
                     "children": [
                       {
                         "eval_type": "Filter",
@@ -48,6 +50,7 @@ mod tests {
                         "from": null,
                         "to": null,
                         "status": "PASS",
+                        "comparator": null,
                         "children": [
                           {
                             "eval_type": "Conjunction",
@@ -56,6 +59,7 @@ mod tests {
                             "from": null,
                             "to": null,
                             "status": "PASS",
+                            "comparator": null,
                             "children": [
                               {
                                 "eval_type": "Clause",
@@ -64,6 +68,7 @@ mod tests {
                                 "from": null,
                                 "to": null,
                                 "status": "PASS",
+                                "comparator": ["Eq", false],
                                 "children": []
                               }
                             ]
@@ -77,6 +82,7 @@ mod tests {
                         "from": null,
                         "to": null,
                         "status": "FAIL",
+                        "comparator": null,
                         "children": [
                           {
                             "eval_type": "Conjunction",
@@ -85,6 +91,7 @@ mod tests {
                             "from": null,
                             "to": null,
                             "status": "FAIL",
+                            "comparator": null,
                             "children": [
                               {
                                 "eval_type": "Clause",
@@ -103,6 +110,7 @@ mod tests {
                                   ]
                                 },
                                 "status": "FAIL",
+                                "comparator": ["Eq", false],
                                 "children": []
                               }
                             ]
@@ -113,17 +121,11 @@ mod tests {
                   }
                 ]
               }
-            ]
-            "#,
-            );
-
-        // Remove white spaces from expected and calculated result for easy comparison.
-        let mut serialized =   cfn_guard::run_checks(&data, &rule).unwrap();
-        let expected = serde_json::from_str::<serde_json::Value>(&expected).ok().unwrap();
-        let serialized = serde_json::from_str::<serde_json::Value>(&serialized).ok().unwrap();
-        println!("{}", serde_yaml::to_string(&serialized).ok().unwrap());
-        println!("{}", serde_yaml::to_string(&expected).ok().unwrap());
-        assert_eq!(expected, serialized);
+            ]"#;
+        let serialized =   cfn_guard::run_checks(&data, &rule).unwrap();
+        let result = serde_json::from_str::<serde_json::Value>(&serialized).ok().unwrap();
+        let expected = serde_json::from_str::<serde_json::Value>(expected).ok().unwrap();
+        assert_eq!(expected, result);
     }
 
 }


### PR DESCRIPTION
- Adding support for custom reporters
- Support for "CFNTemplate" data type added with reporting that is similar to Guard 1.0 output format
- fixed unit/integ tests to test objects for equality over strings

*Description of changes:*

Adding the ability to provide the single-line-summary format from 1.0 with custom messages. This PR adds support for the CFN Templates. Will follow with additional PRs to support other formats 

Sample run 
```bash
$ cfn-guard validate -r migrated-3.guard -d sample-template.yaml --type CFNTemplate 
sample-template.yaml Status = FAIL
SKIP rules
migrated-3.guard/aws_apigateway_deployment_checks    SKIP
migrated-3.guard/aws_apigateway_stage_checks         SKIP
migrated-3.guard/aws_dynamodb_table_checks           SKIP
PASS rules
migrated-3.guard/aws_events_rule_checks              PASS
migrated-3.guard/aws_iam_role_checks                 PASS
FAILED rules
migrated-3.guard/aws_ec2_volume_checks               FAIL
migrated-3.guard/mixed_types_checks                  FAIL
---
Evaluation of rules migrated-3.guard for template sample-template.yaml, number of resource failures = 1
--
Resource [vol2] property [Properties.Encrypted] in template [sample-template.yaml] is not compliant with [migrated-3.guard/aws_ec2_volume_checks] because provided value [false] did not match with expected value [true]. Error message []
Resource [vol2] traversed until [Properties] for template [sample-template.yaml] wasn't compliant with [migrated-3.guard/aws_ec2_volume_checks] due to retrieval error. Error Message [Attempting to retrieve array index or key from map at path = /Resources/vol2/Properties , Type was not an array/object map, Remaining Query = Size]
Resource [vol2] property [Properties.Encrypted] in template [sample-template.yaml] is not compliant with [migrated-3.guard/mixed_types_checks] because provided value [false] did not match with expected value [true]. Error message []
--
Rule [migrated-3.guard/aws_iam_role_checks] is compliant for template [sample-template.yaml]
Rule [migrated-3.guard/aws_events_rule_checks] is compliant for template [sample-template.yaml]
--
Rule [migrated-3.guard/aws_apigateway_deployment_checks] is not applicable for template [sample-template.yaml]
Rule [migrated-3.guard/aws_apigateway_stage_checks] is not applicable for template [sample-template.yaml]
Rule [migrated-3.guard/aws_dynamodb_table_checks] is not applicable for template [sample-template.yaml]
--
```

Update on **2021-06-04**

Support for multiple output formats is now added along with Summary table display selection or no-display. Updating PR text to show-case these 

*By default, no options, single-line-summary*
```bash
$ cfn-guard validate -r migrated-3.guard -d sample-template.yaml 
sample-template.yaml Status = FAIL
SKIP rules
migrated-3.guard/aws_apigateway_deployment_checks    SKIP
migrated-3.guard/aws_apigateway_stage_checks         SKIP
migrated-3.guard/aws_dynamodb_table_checks           SKIP
PASS rules
migrated-3.guard/aws_events_rule_checks              PASS
migrated-3.guard/aws_iam_role_checks                 PASS
FAILED rules
migrated-3.guard/aws_ec2_volume_checks               FAIL
migrated-3.guard/mixed_types_checks                  FAIL
---
Evaluation of rules migrated-3.guard against data sample-template.yaml
--
Property [/Resources/vol2/Properties/Encrypted] in data [sample-template.yaml] is not compliant with [migrated-3.guard/aws_ec2_volume_checks] because provided value [false] did not match expected value [true]. Error Message []
Property traversed until [/Resources/vol2/Properties] in data [sample-template.yaml] is not compliant with [migrated-3.guard/aws_ec2_volume_checks] due to retrieval error. Error Message [Attempting to retrieve array index or key from map at path = /Resources/vol2/Properties , Type was not an array/object map, Remaining Query = Size]
Property [/Resources/vol2/Properties/Encrypted] in data [sample-template.yaml] is not compliant with [migrated-3.guard/mixed_types_checks] because provided value [false] did not match expected value [true]. Error Message []
--
Rule [migrated-3.guard/aws_iam_role_checks] is compliant for data [sample-template.yaml]
Rule [migrated-3.guard/aws_events_rule_checks] is compliant for data [sample-template.yaml]
--
Rule [migrated-3.guard/aws_apigateway_deployment_checks] is not applicable for data [sample-template.yaml]
Rule [migrated-3.guard/aws_apigateway_stage_checks] is not applicable for data [sample-template.yaml]
Rule [migrated-3.guard/aws_dynamodb_table_checks] is not applicable for data [sample-template.yaml]
--
```

*No summary table option, single-line-summary*
```bash
$ cfn-guard validate -r migrated-3.guard -d sample-template.yaml --show-summary none
Evaluation of rules migrated-3.guard against data sample-template.yaml
--
Property [/Resources/vol2/Properties/Encrypted] in data [sample-template.yaml] is not compliant with [migrated-3.guard/mixed_types_checks] because provided value [false] did not match expected value [true]. Error Message []
Property [/Resources/vol2/Properties/Encrypted] in data [sample-template.yaml] is not compliant with [migrated-3.guard/aws_ec2_volume_checks] because provided value [false] did not match expected value [true]. Error Message []
Property traversed until [/Resources/vol2/Properties] in data [sample-template.yaml] is not compliant with [migrated-3.guard/aws_ec2_volume_checks] due to retrieval error. Error Message [Attempting to retrieve array index or key from map at path = /Resources/vol2/Properties , Type was not an array/object map, Remaining Query = Size]
--
Rule [migrated-3.guard/aws_iam_role_checks] is compliant for data [sample-template.yaml]
Rule [migrated-3.guard/aws_events_rule_checks] is compliant for data [sample-template.yaml]
--
Rule [migrated-3.guard/aws_dynamodb_table_checks] is not applicable for data [sample-template.yaml]
Rule [migrated-3.guard/aws_apigateway_deployment_checks] is not applicable for data [sample-template.yaml]
Rule [migrated-3.guard/aws_apigateway_stage_checks] is not applicable for data [sample-template.yaml]
--
```

*Summary Table only PASS,FAIL rules, single-line-summary*
```bash
$ cfn-guard validate --rules migrated-3.guard --data sample-template.yaml --show-summary pass,fail
sample-template.yaml Status = FAIL
PASS rules
migrated-3.guard/aws_events_rule_checks              PASS
migrated-3.guard/aws_iam_role_checks                 PASS
FAILED rules
migrated-3.guard/aws_ec2_volume_checks               FAIL
migrated-3.guard/mixed_types_checks                  FAIL
---
Evaluation of rules migrated-3.guard against data sample-template.yaml
--
Property [/Resources/vol2/Properties/Encrypted] in data [sample-template.yaml] is not compliant with [migrated-3.guard/aws_ec2_volume_checks] because provided value [false] did not match expected value [true]. Error Message []
Property traversed until [/Resources/vol2/Properties] in data [sample-template.yaml] is not compliant with [migrated-3.guard/aws_ec2_volume_checks] due to retrieval error. Error Message [Attempting to retrieve array index or key from map at path = /Resources/vol2/Properties , Type was not an array/object map, Remaining Query = Size]
Property [/Resources/vol2/Properties/Encrypted] in data [sample-template.yaml] is not compliant with [migrated-3.guard/mixed_types_checks] because provided value [false] did not match expected value [true]. Error Message []
--
Rule [migrated-3.guard/aws_events_rule_checks] is compliant for data [sample-template.yaml]
Rule [migrated-3.guard/aws_iam_role_checks] is compliant for data [sample-template.yaml]
--
Rule [migrated-3.guard/aws_apigateway_deployment_checks] is not applicable for data [sample-template.yaml]
Rule [migrated-3.guard/aws_dynamodb_table_checks] is not applicable for data [sample-template.yaml]
Rule [migrated-3.guard/aws_apigateway_stage_checks] is not applicable for data [sample-template.yaml]
--
```

*Summary Table PASS, FAIL, output-format YAML*
```
$ cfn-guard validate --rules migrated-3.guard --data sample-template.yaml --show-summary pass,fail --output-format yaml
sample-template.yaml Status = FAIL
PASS rules
migrated-3.guard/aws_events_rule_checks              PASS
migrated-3.guard/aws_iam_role_checks                 PASS
FAILED rules
migrated-3.guard/aws_ec2_volume_checks               FAIL
migrated-3.guard/mixed_types_checks                  FAIL
---
---
data_from: sample-template.yaml
rules_from: migrated-3.guard
not_compliant:
  aws_ec2_volume_checks:
    - rule: aws_ec2_volume_checks
      path: /Resources/vol2/Properties/Encrypted
      provided: false
      expected: true
      comparison:
        operator: Eq
        not: false
      message: ""
    - rule: aws_ec2_volume_checks
      path: /Resources/vol2/Properties
      provided: ~
      expected: ~
      comparison: ~
      message: "Attempting to retrieve array index or key from map at path = /Resources/vol2/Properties , Type was not an array/object map, Remaining Query = Size"
  mixed_types_checks:
    - rule: mixed_types_checks
      path: /Resources/vol2/Properties/Encrypted
      provided: false
      expected: true
      comparison:
        operator: Eq
        not: false
      message: ""
not_applicable:
  - aws_apigateway_deployment_checks
  - aws_apigateway_stage_checks
  - aws_dynamodb_table_checks
compliant:
  - aws_iam_role_checks
  - aws_events_rule_checks
```

*No summary table, ouput-format yaml*
```
$ cfn-guard validate -r migrated-3.guard -d sample-template.yaml --show-summary none --output-format yaml
---
data_from: sample-template.yaml
rules_from: migrated-3.guard
not_compliant:
  mixed_types_checks:
    - rule: mixed_types_checks
      path: /Resources/vol2/Properties/Encrypted
      provided: false
      expected: true
      comparison:
        operator: Eq
        not: false
      message: ""
  aws_ec2_volume_checks:
    - rule: aws_ec2_volume_checks
      path: /Resources/vol2/Properties/Encrypted
      provided: false
      expected: true
      comparison:
        operator: Eq
        not: false
      message: ""
    - rule: aws_ec2_volume_checks
      path: /Resources/vol2/Properties
      provided: ~
      expected: ~
      comparison: ~
      message: "Attempting to retrieve array index or key from map at path = /Resources/vol2/Properties , Type was not an array/object map, Remaining Query = Size"
not_applicable:
  - aws_apigateway_deployment_checks
  - aws_apigateway_stage_checks
  - aws_dynamodb_table_checks
compliant:
  - aws_events_rule_checks
  - aws_iam_role_checks

```

*No summary table, outut-format yaml, multiple data files*
Output has a document per data file and rule combination for failed resources

```bash
$ cfn-guard validate -r migrated-3.guard -d /tmp/data/ --show-summary none --output-format yaml
---
data_from: /tmp/data/sample-template-2.yaml
rules_from: migrated-3.guard
failed:
  aws_ec2_volume_checks:
    - rule: aws_ec2_volume_checks
      path: /Resources/vol2/Properties/Encrypted
      provided: false
      expected: true
      comparison:
        - Eq
        - false
      message: ""
  mixed_types_checks:
    - rule: mixed_types_checks
      path: /Resources/vol2/Properties/Encrypted
      provided: false
      expected: true
      comparison:
        - Eq
        - false
      message: ""

---
data_from: /tmp/data/sample-template.yaml
rules_from: migrated-3.guard
failed:
  mixed_types_checks:
    - rule: mixed_types_checks
      path: /Resources/vol2/Properties/Encrypted
      provided: false
      expected: true
      comparison:
        - Eq
        - false
      message: ""
  aws_ec2_volume_checks:
    - rule: aws_ec2_volume_checks
      path: /Resources/vol2/Properties/Encrypted
      provided: false
      expected: true
      comparison:
        - Eq
        - false
      message: ""

```

*No Summary table, output-format json multiple data files*

Each line JSON document for each data-file/rule-file combination 

```bash
$ cfn-guard validate -r migrated-3.guard -d /tmp/data/ --show-summary none --output-format json
{"data_from":"/tmp/data/sample-template-2.yaml","rules_from":"migrated-3.guard","failed":{"aws_ec2_volume_checks":[{"rule":"aws_ec2_volume_checks","path":"/Resources/vol2/Properties/Encrypted","provided":false,"expected":true,"comparison":["Eq",false],"message":""}],"mixed_types_checks":[{"rule":"mixed_types_checks","path":"/Resources/vol2/Properties/Encrypted","provided":false,"expected":true,"comparison":["Eq",false],"message":""}]}}
{"data_from":"/tmp/data/sample-template.yaml","rules_from":"migrated-3.guard","failed":{"mixed_types_checks":[{"rule":"mixed_types_checks","path":"/Resources/vol2/Properties/Encrypted","provided":false,"expected":true,"comparison":["Eq",false],"message":""}],"aws_ec2_volume_checks":[{"rule":"aws_ec2_volume_checks","path":"/Resources/vol2/Properties/Encrypted","provided":false,"expected":true,"comparison":["Eq",false],"message":""}]}}
```

*No Summary, multiple rule files and multiple data files*
```bash
$ cfn-guard validate -r /tmp/rules/ -d /tmp/data/ --output-format yaml --show-summary none 
---
data_from: sample-template.yaml
rules_from: cluster.guard
not_compliant: {}
not_applicable:
  - test
compliant: []

---
data_from: sample-template.yaml
rules_from: migrated-3.guard
not_compliant:
  aws_ec2_volume_checks:
    - rule: aws_ec2_volume_checks
      path: /Resources/vol2/Properties/Encrypted
      provided: false
      expected: true
      comparison:
        operator: Eq
        not: false
      message: ""
    - rule: aws_ec2_volume_checks
      path: /Resources/vol2/Properties
      provided: ~
      expected: ~
      comparison: ~
      message: "Attempting to retrieve array index or key from map at path = /Resources/vol2/Properties , Type was not an array/object map, Remaining Query = Size"
  mixed_types_checks:
    - rule: mixed_types_checks
      path: /Resources/vol2/Properties/Encrypted
      provided: false
      expected: true
      comparison:
        operator: Eq
        not: false
      message: ""
not_applicable:
  - aws_apigateway_deployment_checks
  - aws_apigateway_stage_checks
  - aws_dynamodb_table_checks
compliant:
  - aws_events_rule_checks
  - aws_iam_role_checks
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
