### PR TITLE
Add test name capability for unit testing

### DIFF
--- a/docs/UNIT_TESTING.md
+++ b/docs/UNIT_TESTING.md
@@ -218,6 +218,7 @@ Name: "MyTest2"
     check_rest_api_is_private: Expected = SKIP, Evaluated = SKIP
 
 Test Case #3
+Name: "MyTest3"
   PASS Rules:
     check_rest_api_is_private: Expected = FAIL, Evaluated = FAIL
 

--- a/docs/UNIT_TESTING.md
+++ b/docs/UNIT_TESTING.md
@@ -14,7 +14,8 @@ All unit testing files are YAML/JSON formatted files. Each test file can contain
 
 ```yaml
 ---
-- input:
+- name: <TEST NAME>
+  input:
     <SAMPLE INPUT>
   expectations:
     rules:
@@ -112,7 +113,8 @@ First, you should test expectations starting from empty input and progressively 
 
 ```yaml
 ---
-- input: {}
+- name: MyTest  
+  input: {}
   expectations:
     rules:
       check_rest_api_is_private: SKIP
@@ -129,6 +131,7 @@ cfn-guard test                                 \
 The output you see is `PASS` for the test. 
 
 ```bash
+Test Case: "MyTest"
 PASS Expected Rule = check_rest_api_is_private, Status = SKIP, Got Status = SKIP
 ```
 
@@ -136,11 +139,13 @@ Now let us extend the testing to include empty resources:
 
 ```yaml
 ---
-- input: {}
+- name: MyTest1
+  input: {}
   expectations:
     rules:
       check_rest_api_is_private: SKIP
-- input:
+- name: MyTest2
+  input:
      Resources: {}
   expectations:
     rules:
@@ -150,7 +155,9 @@ Now let us extend the testing to include empty resources:
 Now you can re-run the test and should see:
 
 ```bash
+Test Case: "MyTest1"
 PASS Expected Rule = check_rest_api_is_private, Status = SKIP, Got Status = SKIP
+Test Case: "MyTest2"
 PASS Expected Rule = check_rest_api_is_private, Status = SKIP, Got Status = SKIP
 ```
 
@@ -158,23 +165,27 @@ You can now add an Amazon API Gateway resource type that was missing `Properties
 
 ```yaml
 ---
-- input: {}
+- name: MyTest1
+  input: {}
   expectations:
     rules:
       check_rest_api_is_private: SKIP
-- input:
+- name: MyTest2
+  input:
      Resources: {}
   expectations:
     rules:
       check_rest_api_is_private: SKIP
-- input:
+- name: MyTest3
+  input:
     Resources: 
       apiGw:
         Type: AWS::ApiGateway::RestApi
   expectations:
     rules:
       check_rest_api_is_private: FAIL
-- input:
+- name: MyTest4
+  input:
     Resources: 
       apiGw:
         Type: AWS::ApiGateway::RestApi
@@ -189,9 +200,13 @@ You can now add an Amazon API Gateway resource type that was missing `Properties
 and a sample run you should see:
 
 ```bash
+Test Case: "MyTest1"
 PASS Expected Rule = check_rest_api_is_private, Status = SKIP, Got Status = SKIP
+Test Case: "MyTest2"
 PASS Expected Rule = check_rest_api_is_private, Status = SKIP, Got Status = SKIP
+Test Case: "MyTest3"
 PASS Expected Rule = check_rest_api_is_private, Status = FAIL, Got Status = FAIL
+Test Case: "MyTest4"
 PASS Expected Rule = check_rest_api_is_private, Status = PASS, Got Status = PASS
 ```
 
@@ -201,24 +216,29 @@ When testing you can specify the `--verbose` flag that lets you inspect evaluati
 
 ```yaml
 ---
-#- input: {}
+---
+#- name: "MyTest1"
+#  input: {}
 #  expectations:
 #    rules:
-#      check_rest_api_is_private_and_has_access: SKIP
-#- input:
-#     Resources: {}
+#      check_rest_api_is_private: SKIP
+#- name: "MyTest2"
+#  input:
+#    Resources: {}
 #  expectations:
 #    rules:
-#      check_rest_api_is_private_and_has_access: SKIP
-#- input:
-#    Resources: 
+#      check_rest_api_is_private: SKIP
+#- name: "MyTest3"
+#  input:
+#    Resources:
 #      apiGw:
 #        Type: AWS::ApiGateway::RestApi
 #  expectations:
 #    rules:
-#      check_rest_api_is_private_and_has_access: FAIL
-- input:
-    Resources: 
+#      check_rest_api_is_private: FAIL
+- name: "MyTest4"
+  input:
+    Resources:
       apiGw:
         Type: AWS::ApiGateway::RestApi
         Properties:
@@ -241,6 +261,7 @@ cfn-guard test                                 \
 Here is the output from that run:
 
 ```bash
+Test Case: "MyTest4"
 PASS Expected Rule = check_rest_api_is_private, Status = PASS, Got Status = PASS
 Rule(check_rest_api_is_private, PASS)
     |  Message: DEFAULT MESSAGE(PASS)
@@ -260,7 +281,8 @@ This is bit dense, but the key observation is the line that says `Clause(Locatio
 that states that the check did PASS. The example also showed the case where `Types` was expected to be an array, but a single value was given. Guard will still evaluate and still provide a correct result. Now you should add a test case for `FAIL`ure.  You can add this to the end of the test file.
 
 ```yaml
-- input:
+- name: "MyTest"
+  input:
     Resources: 
       apiGw:
         Type: AWS::ApiGateway::RestApi
@@ -275,21 +297,24 @@ that states that the check did PASS. The example also showed the case where `Typ
 Now let us run the `test` command again:
 
 ```bash
+Test Case: "MyTest"
+PASS Expected Rule = check_rest_api_is_private, Status = FAIL, Got Status = FAIL
 Rule(check_rest_api_is_private, FAIL)
     |  Message: DEFAULT MESSAGE(FAIL)
     Condition(check_rest_api_is_private, PASS)
         |  Message: DEFAULT MESSAGE(PASS)
-        Clause(Clause(Location[file:api_gateway_private.guard, line:20, column:37], Check: %api_gws NOT EMPTY ), PASS)
+        Clause(Clause(Location[file:../../../Guard tests/rules.guard, line:3, column:37], Check: %api_gws NOT EMPTY ), PASS)
             |  From: Map((Path("/Resources/apiGw"), MapValue { keys: [String((Path("/Resources/apiGw/Type"), "Type")), String((Path("/Resources/apiGw/Properties"), "Properties"))], values: {"Type": String((Path("/Resources/apiGw/Type"), "AWS::ApiGateway::RestApi")), "Properties": Map((Path("/Resources/apiGw/Properties"), MapValue { keys: [String((Path("/Resources/apiGw/Properties/EndpointConfiguration"), "EndpointConfiguration"))], values: {"EndpointConfiguration": Map((Path("/Resources/apiGw/Properties/EndpointConfiguration"), MapValue { keys: [String((Path("/Resources/apiGw/Properties/EndpointConfiguration/Types"), "Types"))], values: {"Types": List((Path("/Resources/apiGw/Properties/EndpointConfiguration/Types"), [String((Path("/Resources/apiGw/Properties/EndpointConfiguration/Types/0"), "PRIVATE")), String((Path("/Resources/apiGw/Properties/EndpointConfiguration/Types/1"), "REGIONAL"))]))} }))} }))} }))
             |  Message: DEFAULT MESSAGE(PASS)
-    BlockClause(Block[Location[file:api_gateway_private.guard, line:21, column:3]], FAIL)
+    BlockClause(Block[Location[file:../../../Guard tests/rules.guard, line:4, column:3]], FAIL)
         |  Message: DEFAULT MESSAGE(FAIL)
         Conjunction(cfn_guard::rules::exprs::GuardClause, FAIL)
             |  Message: DEFAULT MESSAGE(FAIL)
-            Clause(Clause(Location[file:api_gateway_private.guard, line:22, column:5], Check: Properties.EndpointConfiguration.Types[*]  EQUALS String("PRIVATE")), FAIL)
+            Clause(Clause(Location[file:../../../Guard tests/rules.guard, line:5, column:5], Check: Properties.EndpointConfiguration.Types[*]  EQUALS String("PRIVATE")), FAIL)
                 |  From: String((Path("/Resources/apiGw/Properties/EndpointConfiguration/Types/1"), "REGIONAL"))
-                |  To: String((Path("api_gateway_private.guard/22/5/Clause/"), "PRIVATE"))
+                |  To: String((Path("../../../Guard tests/rules.guard/5/5/Clause/"), "PRIVATE"))
                 |  Message: (DEFAULT: NO_MESSAGE)
+
 ```
 
 The check fails as `REGIONAL` was not expected. 

--- a/docs/UNIT_TESTING.md
+++ b/docs/UNIT_TESTING.md
@@ -131,8 +131,10 @@ cfn-guard test                                 \
 The output you see is `PASS` for the test. 
 
 ```bash
-Test Case: "MyTest"
-PASS Expected Rule = check_rest_api_is_private, Status = SKIP, Got Status = SKIP
+Test Case #1
+Name: "MyTest"
+  PASS Rules:
+    check_rest_api_is_private: Expected = SKIP, Evaluated = SKIP
 ```
 
 Now let us extend the testing to include empty resources:
@@ -155,10 +157,15 @@ Now let us extend the testing to include empty resources:
 Now you can re-run the test and should see:
 
 ```bash
-Test Case: "MyTest1"
-PASS Expected Rule = check_rest_api_is_private, Status = SKIP, Got Status = SKIP
-Test Case: "MyTest2"
-PASS Expected Rule = check_rest_api_is_private, Status = SKIP, Got Status = SKIP
+Test Case #1
+Name: "MyTest1"
+  PASS Rules:
+    check_rest_api_is_private: Expected = SKIP, Evaluated = SKIP
+
+Test Case #2
+Name: "MyTest2"
+  PASS Rules:
+    check_rest_api_is_private: Expected = SKIP, Evaluated = SKIP
 ```
 
 You can now add an Amazon API Gateway resource type that was missing `Properties` (This isn’t a valid CFN template, but nonetheless testing that the rule works correctly even for these malformed inputs is useful.), and one that satisfies only `EndpointConfiguration` attribute and has no policy statements defined. You should expect this to `FAIL`. Here is the testing you should have: 
@@ -200,14 +207,24 @@ You can now add an Amazon API Gateway resource type that was missing `Properties
 and a sample run you should see:
 
 ```bash
-Test Case: "MyTest1"
-PASS Expected Rule = check_rest_api_is_private, Status = SKIP, Got Status = SKIP
-Test Case: "MyTest2"
-PASS Expected Rule = check_rest_api_is_private, Status = SKIP, Got Status = SKIP
-Test Case: "MyTest3"
-PASS Expected Rule = check_rest_api_is_private, Status = FAIL, Got Status = FAIL
-Test Case: "MyTest4"
-PASS Expected Rule = check_rest_api_is_private, Status = PASS, Got Status = PASS
+Test Case #1
+Name: "MyTest1"
+  PASS Rules:
+    check_rest_api_is_private: Expected = SKIP, Evaluated = SKIP
+
+Test Case #2
+Name: "MyTest2"
+  PASS Rules:
+    check_rest_api_is_private: Expected = SKIP, Evaluated = SKIP
+
+Test Case #3
+  PASS Rules:
+    check_rest_api_is_private: Expected = FAIL, Evaluated = FAIL
+
+Test Case #4
+Name: "MyTest4"
+  PASS Rules:
+    check_rest_api_is_private: Expected = PASS, Evaluated = PASS
 ```
 
 ### How do I know that `EndpointConfiguration` check did indeed succeed for PASS case?
@@ -261,8 +278,10 @@ cfn-guard test                                 \
 Here is the output from that run:
 
 ```bash
-Test Case: "MyTest4"
-PASS Expected Rule = check_rest_api_is_private, Status = PASS, Got Status = PASS
+Test Case #1
+Name: "MyTest4"
+  PASS Rules:
+    check_rest_api_is_private: Expected = PASS, Evaluated = PASS
 Rule(check_rest_api_is_private, PASS)
     |  Message: DEFAULT MESSAGE(PASS)
     Condition(check_rest_api_is_private, PASS)
@@ -297,22 +316,24 @@ that states that the check did PASS. The example also showed the case where `Typ
 Now let us run the `test` command again:
 
 ```bash
-Test Case: "MyTest"
-PASS Expected Rule = check_rest_api_is_private, Status = FAIL, Got Status = FAIL
+Test Case #1
+Name: "MyTest"
+  PASS Rules:
+    check_rest_api_is_private: Expected = FAIL, Evaluated = FAIL
 Rule(check_rest_api_is_private, FAIL)
     |  Message: DEFAULT MESSAGE(FAIL)
     Condition(check_rest_api_is_private, PASS)
         |  Message: DEFAULT MESSAGE(PASS)
-        Clause(Clause(Location[file:../../../Guard tests/rules.guard, line:3, column:37], Check: %api_gws NOT EMPTY ), PASS)
+        Clause(Clause(Location[file:api_gateway_private.guard, line:3, column:37], Check: %api_gws NOT EMPTY ), PASS)
             |  From: Map((Path("/Resources/apiGw"), MapValue { keys: [String((Path("/Resources/apiGw/Type"), "Type")), String((Path("/Resources/apiGw/Properties"), "Properties"))], values: {"Type": String((Path("/Resources/apiGw/Type"), "AWS::ApiGateway::RestApi")), "Properties": Map((Path("/Resources/apiGw/Properties"), MapValue { keys: [String((Path("/Resources/apiGw/Properties/EndpointConfiguration"), "EndpointConfiguration"))], values: {"EndpointConfiguration": Map((Path("/Resources/apiGw/Properties/EndpointConfiguration"), MapValue { keys: [String((Path("/Resources/apiGw/Properties/EndpointConfiguration/Types"), "Types"))], values: {"Types": List((Path("/Resources/apiGw/Properties/EndpointConfiguration/Types"), [String((Path("/Resources/apiGw/Properties/EndpointConfiguration/Types/0"), "PRIVATE")), String((Path("/Resources/apiGw/Properties/EndpointConfiguration/Types/1"), "REGIONAL"))]))} }))} }))} }))
             |  Message: DEFAULT MESSAGE(PASS)
-    BlockClause(Block[Location[file:../../../Guard tests/rules.guard, line:4, column:3]], FAIL)
+    BlockClause(Block[Location[file:api_gateway_private.guard, line:4, column:3]], FAIL)
         |  Message: DEFAULT MESSAGE(FAIL)
         Conjunction(cfn_guard::rules::exprs::GuardClause, FAIL)
             |  Message: DEFAULT MESSAGE(FAIL)
-            Clause(Clause(Location[file:../../../Guard tests/rules.guard, line:5, column:5], Check: Properties.EndpointConfiguration.Types[*]  EQUALS String("PRIVATE")), FAIL)
+            Clause(Clause(Location[file:api_gateway_private.guard, line:5, column:5], Check: Properties.EndpointConfiguration.Types[*]  EQUALS String("PRIVATE")), FAIL)
                 |  From: String((Path("/Resources/apiGw/Properties/EndpointConfiguration/Types/1"), "REGIONAL"))
-                |  To: String((Path("../../../Guard tests/rules.guard/5/5/Clause/"), "PRIVATE"))
+                |  To: String((Path("api_gateway_private.guard/5/5/Clause/"), "PRIVATE"))
                 |  Message: (DEFAULT: NO_MESSAGE)
 
 ```

--- a/guard/src/commands/test.rs
+++ b/guard/src/commands/test.rs
@@ -176,7 +176,7 @@ fn test_with_data(test_data_files: &[PathBuf], rules: &RulesFile<'_>, verbose: b
                             }
                         }
                     }
-                    print_test_report(&by_result);
+                    print_test_case_report(&by_result);
                     test_counter += 1;
                 }
             }
@@ -185,7 +185,7 @@ fn test_with_data(test_data_files: &[PathBuf], rules: &RulesFile<'_>, verbose: b
     Ok(exit_code)
 }
 
-pub (crate) fn print_test_report(by_result: &HashMap<String, indexmap::IndexSet<String>>) {
+pub (crate) fn print_test_case_report(by_result: &HashMap<String, indexmap::IndexSet<String>>) {
 
     let mut results = by_result.keys().map(|elem| elem.clone()).collect_vec();
     results.sort(); // Deterministic order of results
@@ -196,4 +196,5 @@ pub (crate) fn print_test_report(by_result: &HashMap<String, indexmap::IndexSet<
             println!("    {}", *each_case);
         }
     }
+    println!();
 }

--- a/guard/src/commands/test.rs
+++ b/guard/src/commands/test.rs
@@ -109,6 +109,7 @@ struct TestExpectations {
 
 #[derive(Serialize, Deserialize, Debug)]
 struct TestSpec {
+    name: Option<serde_json::Value>,
     input: serde_json::Value,
     expectations: TestExpectations,
 }
@@ -137,6 +138,9 @@ fn test_with_data(test_data_files: &[PathBuf], rules: &RulesFile<'_>, verbose: b
                     rules.evaluate(&root, &stacker)?;
                     let expectations = each.expectations.rules;
                     let stack = stacker.stack();
+                    if !each.name.is_none() {
+                        println!("Test Case: {}", each.name.unwrap());
+                    }
                     for each in &stack[0].children {
                         match expectations.get(&each.context) {
                             Some(value) => {

--- a/guard/src/commands/test.rs
+++ b/guard/src/commands/test.rs
@@ -117,6 +117,7 @@ struct TestSpec {
 
 fn test_with_data(test_data_files: &[PathBuf], rules: &RulesFile<'_>, verbose: bool) -> Result<i32> {
     let mut exit_code = 0;
+    let mut test_counter = 1;
     for specs in iterate_over(test_data_files, |data, path| {
         match serde_yaml::from_str::<Vec<TestSpec>>(&data) {
             Ok(spec) => {
@@ -139,9 +140,12 @@ fn test_with_data(test_data_files: &[PathBuf], rules: &RulesFile<'_>, verbose: b
                     rules.evaluate(&root, &stacker)?;
                     let expectations = each.expectations.rules;
                     let stack = stacker.stack();
+
+                    println!("Test Case #{}", test_counter);
                     if !each.name.is_none() {
-                        println!("Test Case: {}", each.name.unwrap());
+                        println!("Name: {}", each.name.unwrap());
                     }
+
                     let mut by_result = HashMap::new();
                     for each in &stack[0].children {
                         match expectations.get(&each.context) {
@@ -168,11 +172,12 @@ fn test_with_data(test_data_files: &[PathBuf], rules: &RulesFile<'_>, verbose: b
                                 }
                             },
                             None => {
-                                println!("  No Test expectations was set for Rule {}", each.context)
+                                println!("  No Test expectation was set for Rule {}", each.context)
                             }
                         }
                     }
                     print_test_report(&by_result);
+                    test_counter += 1;
                 }
             }
         }


### PR DESCRIPTION
*Issue #, if available:*
#133 

*Description of changes:*
Adding test name to the test YAML and displaying the name on the console after test execution.

In order to not break existing tests created without a name, this change introduces an Optional parameter for test name.
The docs are updated to reflect this feature so that all users create tests with meaningful names in the future.

Sample run:

rules.guard
```
let api_gws = Resources.*[ Type == 'AWS::ApiGateway::RestApi' ]                             

rule check_rest_api_is_private when %api_gws !empty {                                       
  %api_gws {
    Properties.EndpointConfiguration.Types[*] == "PRIVATE"                                    
  }   
}

rule check_rest_api_is_encrypted when %api_gws !empty {                                       
  %api_gws {
    Properties.Encrypted == "true"                                    
  }   
} 
```

api_gateway_private_tests.yaml

```
---
- name: "MyTest1"
  input: {}
  expectations:
    rules:
      check_rest_api_is_private: SKIP
- name: "MyTest2"
  input:
     Resources: {}
  expectations:
    rules:
      check_rest_api_is_private: SKIP
- input:
    Resources: 
      apiGw:
        Type: AWS::ApiGateway::RestApi
  expectations:
    rules:
      check_rest_api_is_private: FAIL
- name: "MyTest4"
  input:
    Resources: 
      apiGw:
        Type: AWS::ApiGateway::RestApi
        Properties:
          EndpointConfiguration:
            Types: "PRIVATE"
          Encrypted: "true"
  expectations:
    rules:
      check_rest_api_is_private: PASS
      check_rest_api_is_encrypted: FAIL
```
*Note that the third test case does not have a name associated

Console output:

```
Test Case #1
Name: "MyTest1"
  No Test expectation was set for Rule check_rest_api_is_encrypted
  PASS Rules:
    check_rest_api_is_private: Expected = SKIP, Evaluated = SKIP

Test Case #2
Name: "MyTest2"
  No Test expectation was set for Rule check_rest_api_is_encrypted
  PASS Rules:
    check_rest_api_is_private: Expected = SKIP, Evaluated = SKIP

Test Case #3
  No Test expectation was set for Rule check_rest_api_is_encrypted
  PASS Rules:
    check_rest_api_is_private: Expected = FAIL, Evaluated = FAIL

Test Case #4
Name: "MyTest4"
  FAILED Rules:
    check_rest_api_is_encrypted: Expected = FAIL, Evaluated = PASS
  PASS Rules:
    check_rest_api_is_private: Expected = PASS, Evaluated = PASS

```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
