### PR TITLE
Adding support for evaluating all values and not short-circuiting when encountering the first incorrect value from queries used directly in clauses

### DIFF
--- a/guard/src/rules/path_value.rs
+++ b/guard/src/rules/path_value.rs
@@ -166,6 +166,7 @@ impl PartialEq for PathAwareValue {
                     false
                 }
             },
+            (PathAwareValue::Regex((_, r)), PathAwareValue::Regex((_, s))) => r == s,
 
             //
             // Range checks

--- a/guard/tests/functional.rs
+++ b/guard/tests/functional.rs
@@ -89,7 +89,7 @@ mod tests {
                               {
                                 "eval_type": "Clause",
                                 "context": "Clause(Location[file:lambda, line:1, column:27], Check: Properties.AuthorizationType  EQUALS String(\"NONE\"))",
-                                "msg": "(DEFAULT: NO_MESSAGE)",
+                                "msg": "DEFAULT MESSAGE(FAIL)",
                                 "from": {
                                   "String": [
                                     "/Resources/VPC/Properties/AuthorizationType",
@@ -118,12 +118,11 @@ mod tests {
             );
 
         // Remove white spaces from expected and calculated result for easy comparison.
-        expected.retain(|c| !c.is_whitespace());
-
         let mut serialized =   cfn_guard::run_checks(&data, &rule).unwrap();
-        println!("{}", serialized);
-        serialized.retain(|c| !c.is_whitespace());
-
+        let expected = serde_json::from_str::<serde_json::Value>(&expected).ok().unwrap();
+        let serialized = serde_json::from_str::<serde_json::Value>(&serialized).ok().unwrap();
+        println!("{}", serde_yaml::to_string(&serialized).ok().unwrap());
+        println!("{}", serde_yaml::to_string(&expected).ok().unwrap());
         assert_eq!(expected, serialized);
     }
 


### PR DESCRIPTION
E.g.
```
rule check_names {
    Resources.*.Properties.Name == /NAME/
}
```

will check for all `Resources` in

```
Resources:
  second:
    Properties:
      Name: FAILEDMatch
  first:
    Properties:
      Name: MatchNAME
  matches:
    Properties:
      Name: MatchNAME
  failed:
    Properties:
      Name: FAILEDMatch

```
and would report both `second` and `failed`. Earlier we would only report `second` and stop.

The same is true when accessed via variables

```
let resources = Resources.*;
rule check_names {
    %resources.Properties.Name == /NAME/
}
```

Sample rule 
```
let aws_ec2_volume = Resources.*[ Type == "AWS::EC2::Volume" ]
let aws_ec2_securitygroupingress = Resources.*[ Type == "AWS::EC2::SecurityGroupIngress" ]
rule aws_ec2_volume_checks when %aws_ec2_volume !empty {
	#EC2-008
	%aws_ec2_volume.Properties.Encrypted == true <<[EC2-008] : EC2 volumes should be encrypted>>
}

rule aws_ec2_securitygroupingress_checks when %aws_ec2_securitygroupingress !empty {
	#EC2-001
	%aws_ec2_securitygroupingress.Properties.CidrIp != "0.0.0.0/0" <<EC2-001: EC2 instances must not be exposed directly to open traffic (0.0.0.0/0)>>
}
```

Sample template
```json
{
    "Resources": {
        "NewVolume" : {
            "Type" : "AWS::EC2::Volume",
            "Properties" : {
                "Size" : 200,
                "Encrypted": false,
                "AvailabilityZone" : "us-west-2b"
            }
        },
        "NewVolume2" : {
            "Type" : "AWS::EC2::Volume",
            "Properties" : {
                "Size" : 100,
                "Encrypted": false,
                "AvailabilityZone" : "us-west-2c"
            }
        }
    }
}
```

Sample run 
```
cfn-guard validate -r /tmp/migrated.guard -d /tmp/template.json 
/tmp/template.json Status = FAIL
PASS/SKIP rules
/tmp/migrated.guard/aws_ec2_securitygroupingress_checks    SKIP
FAILED rules
/tmp/migrated.guard/aws_ec2_volume_checks                  FAIL
---
```

Showing Failures
```
cfn-guard validate -r /tmp/migrated.guard -d /tmp/template.json --show-clause-failures 
/tmp/template.json Status = FAIL
PASS/SKIP rules
/tmp/migrated.guard/aws_ec2_securitygroupingress_checks    SKIP
FAILED rules
/tmp/migrated.guard/aws_ec2_volume_checks                  FAIL
Clause Failure Summary
/tmp/migrated.guard/aws_ec2_volume_checks                  Clause #1           FAIL(Clause(Location[file:/tmp/migrated.guard, line:5, column:2], Check: %aws_ec2_volume.Properties.Encrypted  EQUALS Bool(true)))
                                                                              Comparing Bool((Path("/Resources/NewVolume/Properties/Encrypted"), false)) with Bool((Path("/tmp/migrated.guard/5/2/Clause/"), true)) failed
                                                                              [EC2-008] : EC2 volumes should be encrypted
                                                          Clause #2           FAIL(Clause(Location[file:/tmp/migrated.guard, line:5, column:2], Check: %aws_ec2_volume.Properties.Encrypted  EQUALS Bool(true)))
                                                                              Comparing Bool((Path("/Resources/NewVolume2/Properties/Encrypted"), false)) with Bool((Path("/tmp/migrated.guard/5/2/Clause/"), true)) failed
                                                                              [EC2-008] : EC2 volumes should be encrypted
---
```


*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
