### PR TITLE
Improve installer

### DIFF
--- a/install-guard.sh
+++ b/install-guard.sh
@@ -60,7 +60,7 @@ get_latest_release() {
 }
 
 err() {
-    say "$1" >&2
+    echo "$1" >&2
     exit 1
 }
 

--- a/install-guard.sh
+++ b/install-guard.sh
@@ -29,7 +29,7 @@ main() {
                 err "unable to symlink to ~/.guard/bin directory"
             ~/.guard/bin/cfn-guard help ||
                 err "cfn-guard was not installed properly"
-            echo "Remember to SET PATH include PATH=${PATH}:~/.guard/bin"
+            echo "Remember to SET PATH include PATH=\${PATH}:~/.guard/bin"
         done
 }
 

--- a/install-guard.sh
+++ b/install-guard.sh
@@ -53,9 +53,8 @@ get_os_type() {
 
 
 get_latest_release() {
-    curl -fsSLI -o /dev/null -w %{url_effective} \
-        https://github.com/aws-cloudformation/cloudformation-guard/releases/latest |
-    awk -F '/' '{print $NF}' |
+    curl -fsSL https://api.github.com/repos/aws-cloudformation/cloudformation-guard/releases/latest |
+    awk -F '"' '/tag_name/ { print $4 }' |
     awk -F '.' '{ print $1 "\n" $0 }'
 }
 

--- a/install-guard.sh
+++ b/install-guard.sh
@@ -5,8 +5,9 @@
 # to the latest one
 
 main() {
-    need_cmd curl
-    need_cmd wget
+    if ! ( check_cmd curl || check_cmd wget ); then
+        err "need 'curl' or 'wget' (command not found)"
+    fi
     need_cmd awk
     need_cmd mkdir
     need_cmd rm
@@ -20,7 +21,7 @@ main() {
             mkdir -p ~/.guard/$MAJOR_VER ~/.guard/bin ||
                 err "unable to make directories ~/.guard/$MAJOR_VER, ~/.guard/bin"
             get_os_type
-            wget https://github.com/aws-cloudformation/cloudformation-guard/releases/download/$VERSION/cfn-guard-v$MAJOR_VER-$OS_TYPE-latest.tar.gz -O /tmp/guard.tar.gz ||
+            download https://github.com/aws-cloudformation/cloudformation-guard/releases/download/$VERSION/cfn-guard-v$MAJOR_VER-$OS_TYPE-latest.tar.gz > /tmp/guard.tar.gz ||
                 err "unable to download https://github.com/aws-cloudformation/cloudformation-guard/releases/download/$VERSION/cfn-guard-v$MAJOR_VER-$OS_TYPE-latest.tar.gz"
             tar -C ~/.guard/$MAJOR_VER -xzf /tmp/guard.tar.gz ||
                 err "unable to untar /tmp/guard.tar.gz"
@@ -53,7 +54,7 @@ get_os_type() {
 
 
 get_latest_release() {
-    curl -fsSL https://api.github.com/repos/aws-cloudformation/cloudformation-guard/releases/latest |
+    download https://api.github.com/repos/aws-cloudformation/cloudformation-guard/releases/latest |
     awk -F '"' '/tag_name/ { print $4 }' |
     awk -F '.' '{ print $1 "\n" $0 }'
 }
@@ -72,5 +73,15 @@ need_cmd() {
 check_cmd() {
     command -v "$1" > /dev/null 2>&1
 }
+
+download()
+{
+    if check_cmd curl; then
+        curl -fsSL "$1"
+    else
+        wget -qO- "$1"
+    fi
+}
+
 
 main


### PR DESCRIPTION
I have confused that the error message was suddenly spoken out from my PC's speaker during the installation of cloudformation-guard.
It may be fancy and useful where the mother tongue is English but simply annoying in the other countries like my country Japan and on CI.

In addition, macOS does not ship with wget so that I rewrite the installer script to work even if only one of wget or curl is present
Lightweight images like [busybox](https://hub.docker.com/_/busybox) provide the only wget, and thus this change is useful to run this command in containers. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
