### PR TITLE
Add shellcheck and fix errors reported by shellcheck

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -20,3 +20,12 @@ jobs:
       run: cargo build --release --verbose
     - name: Run tests
       run: cargo test --verbose
+  
+  shellcheck:
+    
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Shellcheck
+      run: shellcheck install-guard.sh

--- a/install-guard.sh
+++ b/install-guard.sh
@@ -18,16 +18,16 @@ main() {
     get_os_type
     get_latest_release |
         while read -r MAJOR_VER; read -r VERSION; do
-            mkdir -p ~/".guard/$MAJOR_VER" ~/.guard/bin ||
+            mkdir -p ~/.guard/"$MAJOR_VER" ~/.guard/bin ||
                 err "unable to make directories ~/.guard/$MAJOR_VER, ~/.guard/bin"
             get_os_type
-            download "https://github.com/aws-cloudformation/cloudformation-guard/releases/download/$VERSION/cfn-guard-v$MAJOR_VER-$OS_TYPE-latest.tar.gz" > /tmp/guard.tar.gz ||
+            download https://github.com/aws-cloudformation/cloudformation-guard/releases/download/"$VERSION"/cfn-guard-v"$MAJOR_VER"-"$OS_TYPE"-latest.tar.gz > /tmp/guard.tar.gz ||
                 err "unable to download https://github.com/aws-cloudformation/cloudformation-guard/releases/download/$VERSION/cfn-guard-v$MAJOR_VER-$OS_TYPE-latest.tar.gz"
-            tar -C ~/".guard/$MAJOR_VER" -xzf /tmp/guard.tar.gz ||
+            tar -C ~/.guard/"$MAJOR_VER" -xzf /tmp/guard.tar.gz ||
                 err "unable to untar /tmp/guard.tar.gz"
-            ln -sf ~/".guard/$MAJOR_VER/cfn-guard-v$MAJOR_VER-$OS_TYPE-latest/cfn-guard" ~/.guard/bin ||
+            ln -sf ~/.guard/"$MAJOR_VER"/cfn-guard-v"$MAJOR_VER"-"$OS_TYPE"-latest/cfn-guard ~/.guard/bin ||
                 err "unable to symlink to ~/.guard/bin directory"
-            ~/".guard/bin/cfn-guard" help ||
+            ~/.guard/bin/cfn-guard help ||
                 err "cfn-guard was not installed properly"
             echo "Remember to SET PATH include PATH=\${PATH}:~/.guard/bin"
         done

--- a/install-guard.sh
+++ b/install-guard.sh
@@ -17,24 +17,24 @@ main() {
 
     get_os_type
     get_latest_release |
-        while read MAJOR_VER; read VERSION; do
-            mkdir -p ~/.guard/$MAJOR_VER ~/.guard/bin ||
+        while read -r MAJOR_VER; read -r VERSION; do
+            mkdir -p ~/".guard/$MAJOR_VER" ~/.guard/bin ||
                 err "unable to make directories ~/.guard/$MAJOR_VER, ~/.guard/bin"
             get_os_type
-            download https://github.com/aws-cloudformation/cloudformation-guard/releases/download/$VERSION/cfn-guard-v$MAJOR_VER-$OS_TYPE-latest.tar.gz > /tmp/guard.tar.gz ||
+            download "https://github.com/aws-cloudformation/cloudformation-guard/releases/download/$VERSION/cfn-guard-v$MAJOR_VER-$OS_TYPE-latest.tar.gz" > /tmp/guard.tar.gz ||
                 err "unable to download https://github.com/aws-cloudformation/cloudformation-guard/releases/download/$VERSION/cfn-guard-v$MAJOR_VER-$OS_TYPE-latest.tar.gz"
-            tar -C ~/.guard/$MAJOR_VER -xzf /tmp/guard.tar.gz ||
+            tar -C ~/".guard/$MAJOR_VER" -xzf /tmp/guard.tar.gz ||
                 err "unable to untar /tmp/guard.tar.gz"
-            ln -sf ~/.guard/$MAJOR_VER/cfn-guard-v$MAJOR_VER-$OS_TYPE-latest/cfn-guard ~/.guard/bin ||
+            ln -sf ~/".guard/$MAJOR_VER/cfn-guard-v$MAJOR_VER-$OS_TYPE-latest/cfn-guard" ~/.guard/bin ||
                 err "unable to symlink to ~/.guard/bin directory"
-            ~/.guard/bin/cfn-guard help ||
+            ~/".guard/bin/cfn-guard" help ||
                 err "cfn-guard was not installed properly"
             echo "Remember to SET PATH include PATH=\${PATH}:~/.guard/bin"
         done
 }
 
 get_os_type() {
-    local _ostype="$(uname -s)"
+    _ostype="$(uname -s)"
     case "$_ostype" in
         Darwin)
             OS_TYPE="macos"


### PR DESCRIPTION
`install-guard.sh` contains some so-called bashisms and may not work under some POSIX sh.
This PR will make this project detect bashisms and fix them.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
