### PR TITLE
Add Homebrew to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ Alternatively, you can install the latest version with [Homebrew](https://brew.s
 $ brew install cloudformation-guard
 ```
 
-In this way, you need not to modify your `$PATH`.
+You would not need to modify `$PATH` this way.
 
 ##### Ubuntu
 

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ $ curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/aws-clo
 ```
 Remember to add `~/.guard/bin/` to your `$PATH`.
 
-Altenatively, you can install the latest version with [Homebrew](https://brew.sh/).
+Alternatively, you can install the latest version with [Homebrew](https://brew.sh/).
 
 ```bash
 $ brew install cloudformation-guard

--- a/README.md
+++ b/README.md
@@ -162,6 +162,14 @@ $ curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/aws-clo
 ```
 Remember to add `~/.guard/bin/` to your `$PATH`.
 
+Altenatively, you can install the latest version with [Homebrew](https://brew.sh/).
+
+```bash
+$ brew install cloudformation-guard
+```
+
+In this way, you need not to modify your `$PATH`.
+
 ##### Ubuntu
 
 1. Open any terminal of your choice


### PR DESCRIPTION
There is already a formula in Homebrew.
https://formulae.brew.sh/formula/cloudformation-guard
macOS users can install cloudformation-guard with brew in a handy way.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
