### PR TITLE
Retrieve version number dynamically from environment variable in code

### DIFF
--- a/guard/src/main.rs
+++ b/guard/src/main.rs
@@ -11,10 +11,12 @@ use crate::command::Command;
 use rules::errors::Error;
 use std::process::exit;
 
+const VERSION: &'static str = env!("CARGO_PKG_VERSION");
+
 fn main() -> Result<(), Error>{
     let mut app =
         App::new("cfn-guard")
-            .version("2.0")
+            .version(VERSION)
             .about(r#"
   Guard is a general-purpose tool that provides a simple declarative syntax to define 
   policy-as-code as rules to validate against any structured hierarchical data (like JSON/YAML).


### PR DESCRIPTION
*Description of changes:*
Made change to retrieve version number dynamically from the `CARGO_PKG_VERSION` environment variable.

Tested locally:
```
$ target/release/cfn-guard --version
cfn-guard 2.0.3
```
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
