### PR TITLE
Add new validate command flags to README.md

### DIFF
--- a/guard/README.md
+++ b/guard/README.md
@@ -99,8 +99,12 @@ FLAGS:
     -v, --verbose                 Verbose logging
 
 OPTIONS:
-    -d, --data <data>      Provide a file or dir for data files in JSON or YAML
-    -r, --rules <rules>    Provide a rules file or a directory of rules files
+    -d, --data <data>             Provide a file or dir for data files in JSON or YAML
+    -r, --rules <rules>           Provide a rules file or a directory of rules files
+    --show-summary <show-summary> --show-summary all(default) or --show-summary pass, fail (only show rules that did 
+                                  pass/fail) or --show-summary none (to turn it off) [default : all]
+                                  [possible values: none, all, pass, fail, skip]
+    -t, --type <type>             Specify the type of data file used to improved messaging [possible values: CFNTemplate]
 
 ```
 


### PR DESCRIPTION
*Description of changes:* Update README.md for cfn-guard CLI to have new flags which are --show-summary and --type


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
