### PR TITLE
chore: version bump to 2.0.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,7 +90,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "cfn-guard"
-version = "2.0.3"
+version = "2.0.4"
 dependencies = [
  "clap",
  "colored 2.0.0",
@@ -113,7 +113,7 @@ dependencies = [
 
 [[package]]
 name = "cfn-guard-lambda"
-version = "2.0.3"
+version = "2.0.4"
 dependencies = [
  "cfn-guard",
  "lambda_runtime",

--- a/guard-lambda/Cargo.toml
+++ b/guard-lambda/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cfn-guard-lambda"
-version = "2.0.3"
+version = "2.0.4"
 authors = ["Diwakar Chakravarthy", "John Tompkins", "Omkar Hegde", "Priya Padmanaban", "aws-cloudformation-developers <aws-cloudformation-developers@amazon.com>"]
 description = "Lambda version of cfn-guard. Checks JSON- or YAML- formatted structured data for policy compliance using a simple, policy-as-code, declarative syntax"
 license = "Apache-2.0"
@@ -16,4 +16,4 @@ serde_derive = "1.0.92"
 simple_logger = "1.3.0"
 log = "0.4.6"
 tokio = "1.6.1"
-cfn-guard = { version = "2.0.3", path = "../guard" }
+cfn-guard = { version = "2.0.4", path = "../guard" }

--- a/guard/Cargo.toml
+++ b/guard/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cfn-guard"
-version = "2.0.3"
+version = "2.0.4"
 edition = "2018"
 authors = ["Diwakar Chakravarthy", "John Tompkins", "Omkar Hegde", "Priya Padmanaban", "aws-cloudformation-developers <aws-cloudformation-developers@amazon.com>"]
 description = "AWS CloudFormation Guard is an open-source general-purpose policy-as-code evaluation tool. It provides developers with a simple-to-use, yet powerful and expressive domain-specific language (DSL) to define policies and enables developers to validate JSON- or YAML- formatted structured data with those policies."


### PR DESCRIPTION
*Description of changes:*
- Patch version bump to `2.0.4`
- includes payload flag feature which allows user to pass a JSON containing data content and rules content
- Changes from `2.0.3` to `2.0.4`: https://github.com/aws-cloudformation/cloudformation-guard/compare/2.0.3...HEAD  


---
*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
