### PR TITLE
feat: Support YAML data input in CFN Guard Lambda

### DIFF
--- a/guard/src/commands/helper.rs
+++ b/guard/src/commands/helper.rs
@@ -15,7 +15,10 @@ pub fn validate_and_return_json(
 ) -> Result<String> {
     let input_data = match serde_json::from_str::<serde_json::Value>(&data) {
        Ok(value) => PathAwareValue::try_from(value),
-       Err(e) => return Err(Error::new(ErrorKind::ParseError(e.to_string()))),
+       Err(e) => {
+           let value = serde_yaml::from_str::<serde_json::Value>(&data)?;
+           PathAwareValue::try_from(value)
+       }
     };
 
     let span = crate::rules::parser::Span::new_extra(&rules, "lambda");


### PR DESCRIPTION
- Remove redundant code in validate.rs that is not called

*Issue #, if available:*


*Description of changes:*
Try to parse input as YAML before returning failure. Tested using personal AWS account.


---
*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
