### PR TITLE
fix: Added verbose flag for Lambda to emit shorter version of output

### DIFF
--- a/guard-lambda/src/main.rs
+++ b/guard-lambda/src/main.rs
@@ -7,12 +7,18 @@ use log::{self, LevelFilter, info};
 use serde_derive::{Deserialize, Serialize};
 use simple_logger::SimpleLogger;
 
+fn default_as_true() -> bool {
+    true
+}
+
 #[derive(Deserialize, Debug)]
 struct CustomEvent {
     #[serde(rename = "data")]
     data: String,
     #[serde(rename = "rules")]
     rules: Vec<String>,
+    #[serde(rename = "verbose", default="default_as_true")] // for backward compatibility
+    verbose: bool,
 }
 
 #[derive(Serialize)]
@@ -34,7 +40,7 @@ pub(crate) async fn call_cfn_guard(e: CustomEvent, _c: Context) -> Result<Custom
     info!("Rules are: [{:?}]", &e.rules);
     let mut results_vec = Vec::new();
     for rule in e.rules.iter() {
-        let result = match cfn_guard::run_checks(&e.data, &rule) {
+        let result = match cfn_guard::run_checks(&e.data, &rule, e.verbose) {
             Ok(t) => t,
             Err(e) => (e.to_string()),
         };

--- a/guard/src/commands/helper.rs
+++ b/guard/src/commands/helper.rs
@@ -5,13 +5,15 @@ use crate::rules::errors::{Error, ErrorKind};
 use crate::rules::evaluate::RootScope;
 use crate::rules::path_value::PathAwareValue;
 use crate::commands::tracker::StackTracker;
-use crate::commands::validate::ConsoleReporter;
+use crate::commands::validate::{ConsoleReporter, OutputFormatType, Reporter};
 use crate::rules::{Evaluate, Result};
 use std::convert::TryFrom;
+use crate::commands::validate::generic_summary::GenericSummary;
 
 pub fn validate_and_return_json(
     data: &str,
     rules: &str,
+    verbose: bool
 ) -> Result<String> {
     let input_data = match serde_json::from_str::<serde_json::Value>(&data) {
        Ok(value) => PathAwareValue::try_from(value),
@@ -30,10 +32,14 @@ pub fn validate_and_return_json(
                 Ok(root) => {
                     let root_context = RootScope::new(&rules, &root);
                     let stacker = StackTracker::new(&root_context);
-                    let reporters = vec![];
-                    let reporter = ConsoleReporter::new(stacker, &reporters, "lambda-run","lambda-payload", true, true, false);
+                    let data_file_name: &str = "lambda-payload";
+                    let rules_file_name: &str = "lambda-run";
+                    let reporters = vec![
+                        Box::new(GenericSummary::new(&data_file_name, &rules_file_name, OutputFormatType::JSON)) as Box<dyn Reporter>
+                    ];
+                    let reporter = ConsoleReporter::new(stacker, &reporters, &rules_file_name, &data_file_name, verbose, true, false);
                     rules.evaluate(&root, &reporter)?;
-                    let json_result = reporter.get_result_json();
+                    let json_result = reporter.get_result_json()?;
                     return Ok(json_result);
                 }
                 Err(e) => return Err(e),

--- a/guard/src/lib.rs
+++ b/guard/src/lib.rs
@@ -9,6 +9,7 @@ mod migrate;
 pub extern "C" fn run_checks(
     data: &str,
     rules: &str,
+    verbose: bool
 ) -> crate::rules::Result<String> {
-    return  crate::commands::helper::validate_and_return_json(&data, &rules);
+    return  crate::commands::helper::validate_and_return_json(&data, &rules, verbose);
 }

--- a/guard/tests/functional.rs
+++ b/guard/tests/functional.rs
@@ -122,7 +122,8 @@ mod tests {
                 ]
               }
             ]"#;
-        let serialized =   cfn_guard::run_checks(&data, &rule).unwrap();
+        let verbose = true;
+        let serialized =   cfn_guard::run_checks(&data, &rule, verbose).unwrap();
         let result = serde_json::from_str::<serde_json::Value>(&serialized).ok().unwrap();
         let expected = serde_json::from_str::<serde_json::Value>(expected).ok().unwrap();
         assert_eq!(expected, result);


### PR DESCRIPTION
*Issue #, if available:* #236 


*Description of changes:*
Added an optional flag `verbose` to the Lambda input set to `true` by default to support backward compatibility with current behavior. To shorten the output, we must add `"verbose": false` to the event passed as input. 

This reduces the size of output as it emits the short version of the evaluated rules similar to the CLI output.

*Sample event:*

```
{
   "data": "<data>", 
   "rules": [
      "<rule1>", 
      "<rule2>", 
      ...],
   "verbose": false
}
``` 


---
*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
