### PR TITLE
Fixed #252

### DIFF
--- a/guard/src/commands/validate/common.rs
+++ b/guard/src/commands/validate/common.rs
@@ -740,7 +740,7 @@ fn emit_messages(
         else {
             writeln!(
                 writer,
-                "{prefix}{mh:<width$}= {message}",
+                "{prefix}{mh:<width$} = {message}",
                 prefix=prefix,
                 message=message[0],
                 mh="Message",
@@ -752,7 +752,7 @@ fn emit_messages(
     if !error.is_empty() {
         writeln!(
             writer,
-            "{prefix}{eh:<width$}= {error}",
+            "{prefix}{eh:<width$} = {error}",
             prefix=prefix,
             error=error,
             eh="Error",


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-cloudformation/cloudformation-guard/issues/252

*Description of changes:*
Added one space between `Message` and `=`. Also did the same for when `Error` should be emitted. 

```
$ cargo run --package cfn-guard --bin cfn-guard -- validate -d template.json -r rules.guard
template.json Status = FAIL
FAILED rules
rules.guard/aws_s3_bucket_versioning_defined    FAIL
---
Evaluating data template.json against rules rules.guard
Number of non-compliant resources 1
Resource = WebsiteBucket4326D7C2 {
  Type      = AWS::S3::Bucket
  CDK-Path  = LandingPageFrontend/Website/Bucket/Resource
  Rule = aws_s3_bucket_versioning_defined {
    ALL {
      Check =  VersioningConfiguration EXISTS   {
        Message = VersioningConfiguration is not defined
        RequiredPropertyError {
          PropertyPath = /Resources/WebsiteBucket4326D7C2/Properties[L:5,C:20]
          MissingProperty = VersioningConfiguration
          Reason = Could not find key VersioningConfiguration inside struct at path /Resources/WebsiteBucket4326D7C2/Properties[L:5,C:20]
          Code:
                3.    "WebsiteBucket4326D7C2": {
                4.      "Type": "AWS::S3::Bucket",
                5.      "Properties": {
                6.      },
                7.      "Metadata": {
                8.        "aws:cdk:path": "LandingPageFrontend/Website/Bucket/Resource"
        }
      }
    }
  }
}
```

---
*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
