### PR TITLE
fix: update guard-lambda for new engine

### DIFF
--- a/guard/src/commands/validate.rs
+++ b/guard/src/commands/validate.rs
@@ -30,12 +30,12 @@ use crate::rules::path_value::traversal::Traversal;
 use crate::commands::validate::tf::TfAware;
 
 pub(crate) mod generic_summary;
+pub(crate) mod tf;
+pub(crate) mod cfn;
 mod common;
 mod summary_table;
 mod cfn_reporter;
-mod cfn;
 mod console_reporter;
-mod tf;
 
 #[derive(Eq, Clone, Debug, PartialEq)]
 pub(crate) struct DataFile {


### PR DESCRIPTION
*Description of changes:*

This updates the helper function used by guard-lambda to use the new engine rather than the old ConsoleReporter.

---
*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
