### PR TITLE
fix: update guard-lambda to use new evaluation engine & add unit tests

### DIFF
--- a/guard-lambda/src/lib.rs
+++ b/guard-lambda/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod main;

--- a/guard-lambda/tests/lambda-handler.rs
+++ b/guard-lambda/tests/lambda-handler.rs
@@ -1,0 +1,49 @@
+#[cfg(test)]
+mod tests {
+    use cfn_guard_lambda;
+    use lambda_runtime::Context;
+    use cfn_guard_lambda::main::{CustomEvent, call_cfn_guard, CustomOutput};
+
+    const NON_COMPLIANT_DATA: &str = "{\"Resources\":{\"NewVolume\":{\"Type\":\"AWS::EC2::Volume\",\"Properties\":{\"Size\":500,\"Encrypted\":false,\"AvailabilityZone\":\"us-west-2b\"}},\"NewVolume2\":{\"Type\":\"AWS::EC2::Volume\",\"Properties\":{\"Size\":50,\"Encrypted\":true,\"AvailabilityZone\":\"us-west-2c\"}}}}";
+    const RULE: &str = "let ec2_volumes = Resources.*[ Type == /EC2::Volume/ ]\nrule EC2_ENCRYPTION_BY_DEFAULT when %ec2_volumes !empty {\n    %ec2_volumes.Properties.Encrypted == true \n      <<\n            Violation: All EBS Volumes should be encryped \n            Fix: Set Encrypted property to true\n       >>\n}";
+    const FAILURE_MESSAGE: &str = "Failed to handle event";
+
+    #[tokio::test]
+    async fn test_guard_lambda_handler_non_verbose() {
+        let context = Context::default();
+
+        let request = CustomEvent {
+            data: NON_COMPLIANT_DATA.parse().unwrap(),
+            rules: vec![
+                RULE.parse().unwrap()
+            ],
+            verbose: false,
+        };
+        println!("Request:\n{}", request);
+
+        let response: CustomOutput = call_cfn_guard(request, context)
+            .await
+            .expect(FAILURE_MESSAGE);
+        println!("Response:\n{}", response);
+    }
+
+
+    #[tokio::test]
+    async fn test_guard_lambda_handler_verbose() {
+        let context = Context::default();
+
+        let request = CustomEvent {
+            data: NON_COMPLIANT_DATA.parse().unwrap(),
+            rules: vec![
+                RULE.parse().unwrap()
+            ],
+            verbose: true,
+        };
+        println!("Request:\n{}", request);
+
+        let response: CustomOutput = call_cfn_guard(request, context)
+            .await
+            .expect(FAILURE_MESSAGE);
+        println!("Response:\n{}", response);
+    }
+}

--- a/guard/src/commands/helper.rs
+++ b/guard/src/commands/helper.rs
@@ -8,7 +8,11 @@ use crate::commands::tracker::StackTracker;
 use crate::commands::validate::{ConsoleReporter, OutputFormatType, Reporter};
 use crate::rules::{Evaluate, Result};
 use std::convert::TryFrom;
+use std::io::BufWriter;
 use crate::commands::validate::generic_summary::GenericSummary;
+use crate::rules::eval::eval_rules_file;
+use crate::rules::eval_context::root_scope;
+use crate::rules::path_value::traversal::Traversal;
 
 pub fn validate_and_return_json(
     data: &str,
@@ -30,17 +34,37 @@ pub fn validate_and_return_json(
         Ok(rules) => {
             match input_data {
                 Ok(root) => {
-                    let root_context = RootScope::new(&rules, &root);
-                    let stacker = StackTracker::new(&root_context);
                     let data_file_name: &str = "lambda-payload";
                     let rules_file_name: &str = "lambda-run";
-                    let renderer = &GenericSummary::new() as &dyn Reporter;
-                    let renderers = vec![renderer];
-                    let reporter = ConsoleReporter::new(stacker, &renderers, &rules_file_name, &data_file_name, verbose, true, false);
-                    rules.evaluate(&root, &reporter)?;
-                    let json_result = reporter.get_result_json(
-                        &root, OutputFormatType::JSON)?;
-                    return Ok(json_result);
+
+                    let mut write_output = BufWriter::new(Vec::new());
+
+                    let traversal = Traversal::from(&root);
+                    let mut root_scope = root_scope(&rules, &root)?;
+                    let status = eval_rules_file(&rules, &mut root_scope)?;
+                    let root_record = root_scope.reset_recorder().extract();
+
+                    if verbose {
+                        return Ok(serde_json::to_string_pretty(&root_record)?);
+                    }
+
+                    let reporter = &GenericSummary::new() as &dyn Reporter;
+
+                    reporter.report_eval(
+                        &mut write_output,
+                        status,
+                        &root_record,
+                        rules_file_name,
+                        data_file_name,
+                        data,
+                        &traversal,
+                        OutputFormatType::JSON
+                    )?;
+
+                    match String::from_utf8(write_output.buffer().to_vec()) {
+                        Ok(val) => return Ok(val),
+                        Err(e) => return Err(Error::new(ErrorKind::ParseError(e.to_string()))),
+                    }
                 }
                 Err(e) => return Err(e),
             }

--- a/guard/tests/functional.rs
+++ b/guard/tests/functional.rs
@@ -27,105 +27,121 @@ mod tests {
         );
         let rule = "AWS::ApiGateway::Method { Properties.AuthorizationType == \"NONE\"}";
         let expected =
-            r#"[{
-                "eval_type": "Rule",
-                "context": "default",
-                "msg": "DEFAULT MESSAGE(FAIL)",
-                "from": null,
-                "to": null,
-                "status": "FAIL",
-                "comparator": null,
-                "children": [
-                  {
-                    "eval_type": "Type",
-                    "context": "AWS::ApiGateway::Method",
-                    "msg": "DEFAULT MESSAGE(FAIL)",
-                    "from": null,
-                    "to": null,
-                    "status": "FAIL",
-                    "comparator": null,
-                    "children": [
-                      {
-                        "eval_type": "Filter",
-                        "context": "Path=/Resources/VPC[L:0,C:0],Type=MapElement",
-                        "msg": "DEFAULT MESSAGE(PASS)",
-                        "from": null,
-                        "to": null,
-                        "status": "PASS",
-                        "comparator": null,
-                        "children": [
-                          {
-                            "eval_type": "Conjunction",
-                            "context": "cfn_guard::rules::exprs::GuardClause",
-                            "msg": "DEFAULT MESSAGE(PASS)",
-                            "from": null,
-                            "to": null,
-                            "status": "PASS",
-                            "comparator": null,
-                            "children": [
-                              {
-                                "eval_type": "Clause",
-                                "context": " Type EQUALS  \"AWS::ApiGateway::Method\"",
-                                "msg": "DEFAULT MESSAGE(PASS)",
-                                "from": null,
-                                "to": null,
-                                "status": "PASS",
-                                "comparator": [
-                                  "Eq",
-                                  false
-                                ],
-                                "children": []
-                              }
-                            ]
-                          }
-                        ]
+            r#"{
+                  "context": "File(rules=1)",
+                  "container": {
+                    "FileCheck": {
+                      "name": "",
+                      "status": "FAIL",
+                      "message": null
+                    }
+                  },
+                  "children": [
+                    {
+                      "context": "default",
+                      "container": {
+                        "RuleCheck": {
+                          "name": "default",
+                          "status": "FAIL",
+                          "message": null
+                        }
                       },
-                      {
-                        "eval_type": "Type",
-                        "context": "AWS::ApiGateway::Method#0(/Resources/VPC[L:0,C:0])",
-                        "msg": "DEFAULT MESSAGE(FAIL)",
-                        "from": null,
-                        "to": null,
-                        "status": "FAIL",
-                        "comparator": null,
-                        "children": [
-                          {
-                            "eval_type": "Conjunction",
-                            "context": "cfn_guard::rules::exprs::GuardClause",
-                            "msg": "DEFAULT MESSAGE(FAIL)",
-                            "from": null,
-                            "to": null,
-                            "status": "FAIL",
-                            "comparator": null,
-                            "children": [
-                              {
-                                "eval_type": "Clause",
-                                "context": " Properties.AuthorizationType EQUALS  \"NONE\"",
-                                "msg": "DEFAULT MESSAGE(FAIL)",
-                                "from": {
-                                  "path": "/Resources/VPC/Properties/AuthorizationType",
-                                  "value": "10.0.0.0/24"
-                                },
-                                "to": {
-                                  "path": "",
-                                  "value": "NONE"
-                                },
+                      "children": [
+                        {
+                          "context": "TypeBlock#AWS::ApiGateway::Method",
+                          "container": {
+                            "TypeCheck": {
+                              "type_name": "AWS::ApiGateway::Method",
+                              "block": {
+                                "at_least_one_matches": false,
                                 "status": "FAIL",
-                                "comparator": [
-                                  "Eq",
-                                  false
-                                ],
-                                "children": []
+                                "message": null
                               }
-                            ]
-                          }
-                        ]
-                      }
-                    ]
-                  }
-                ]
-              }
-            ]"#;
+                            }
+                          },
+                          "children": [
+                            {
+                              "context": "Filter/Map#1",
+                              "container": {
+                                "Filter": "PASS"
+                              },
+                              "children": [
+                                {
+                                  "context": "GuardAccessClause#block Type EQUALS  \"AWS::ApiGateway::Method\"",
+                                  "container": {
+                                    "GuardClauseBlockCheck": {
+                                      "at_least_one_matches": false,
+                                      "status": "PASS",
+                                      "message": null
+                                    }
+                                  },
+                                  "children": [
+                                    {
+                                      "context": " Type EQUALS  \"AWS::ApiGateway::Method\"",
+                                      "container": {
+                                        "ClauseValueCheck": "Success"
+                                      },
+                                      "children": []
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "context": "TypeBlock#AWS::ApiGateway::Method/0",
+                              "container": {
+                                "TypeBlock": "FAIL"
+                              },
+                              "children": [
+                                {
+                                  "context": "GuardAccessClause#block Properties.AuthorizationType EQUALS  \"NONE\"",
+                                  "container": {
+                                    "GuardClauseBlockCheck": {
+                                      "at_least_one_matches": false,
+                                      "status": "FAIL",
+                                      "message": null
+                                    }
+                                  },
+                                  "children": [
+                                    {
+                                      "context": " Properties.AuthorizationType EQUALS  \"NONE\"",
+                                      "container": {
+                                        "ClauseValueCheck": {
+                                          "Comparison": {
+                                            "comparison": [
+                                              "Eq",
+                                              false
+                                            ],
+                                            "from": {
+                                              "Resolved": {
+                                                "path": "/Resources/VPC/Properties/AuthorizationType",
+                                                "value": "10.0.0.0/24"
+                                              }
+                                            },
+                                            "to": {
+                                              "Resolved": {
+                                                "path": "",
+                                                "value": "NONE"
+                                              }
+                                            },
+                                            "message": null,
+                                            "custom_message": null,
+                                            "status": "FAIL"
+                                          }
+                                        }
+                                      },
+                                      "children": []
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }"#;
         let verbose = true;
         let serialized =   cfn_guard::run_checks(&data, &rule, verbose).unwrap();
         let result = serde_json::from_str::<serde_json::Value>(&serialized).ok().unwrap();


### PR DESCRIPTION
*Issue #, if available:*
Incorporated changes included in [PR#255](https://github.com/aws-cloudformation/cloudformation-guard/pull/255)

*Description of changes:*
* Update lambda to emit output from new evaluation engine
* Add unit tests for lambda handler

---
*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
