### PR TITLE
fix: Added logic for evaluation of boolean values for is_empty

### DIFF
--- a/guard/src/rules/eval.rs
+++ b/guard/src/rules/eval.rs
@@ -24,6 +24,7 @@ fn element_empty_operation(value: &QueryResult<'_>) -> Result<bool>
                 PathAwareValue::List((_, list)) => list.is_empty(),
                 PathAwareValue::Map((_, map)) => map.is_empty(),
                 PathAwareValue::String((_, string)) => string.is_empty(),
+                PathAwareValue::Bool((_, boolean)) => (*boolean).to_string().is_empty(),
                 _ => return Err(Error::new(ErrorKind::IncompatibleError(
                     format!("Attempting EMPTY operation on type {} that does not support it at {}",
                             value.type_info(), value.self_path())


### PR DESCRIPTION
*Issue #, if available:*
#266 

*Description of changes:*
Added logic for evaluation of `is_empty` on top of a boolean value

---
*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
