### PR TITLE
bugfix for slashes in resource names

### DIFF
--- a/guard/src/commands/validate/cfn.rs
+++ b/guard/src/commands/validate/cfn.rs
@@ -1,25 +1,38 @@
-use crate::commands::validate::{OutputFormatType, Reporter};
-use crate::rules::path_value::traversal::{Traversal, TraversalResult};
-use crate::rules::eval_context::{ClauseReport, EventRecord, simplifed_json_from_root, UnaryComparison, BinaryComparison, RuleReport, FileReport, InComparison};
-use std::io::Write;
-use crate::rules::Status;
-use crate::commands::tracker::StatusContext;
-use std::collections::{HashMap, HashSet, BTreeSet};
+use std::{
+    io::Write,
+    collections::{
+        HashMap,
+        HashSet,
+        BTreeSet,
+    },
+    cmp::max,
+    rc::Rc,
+};
 use lazy_static::lazy_static;
-use crate::rules::UnResolved;
 use regex::Regex;
-use crate::rules::path_value::PathAwareValue;
 
-use std::cmp::max;
 use colored::*;
-use crate::rules::display::ValueOnlyDisplay;
-
-use super::common::{
-    LocalResourceAggr,
-    IdentityHash,
-    RuleHierarchy,
-    PathTree,
-    populate_hierarchy_path_trees
+use crate::{
+    commands::{
+        validate::{
+            common::{PathTree, populate_hierarchy_path_trees, RuleHierarchy, LocalResourceAggr, IdentityHash},
+            OutputFormatType,
+            Reporter,
+        },
+        tracker::StatusContext,
+    },
+    rules::{
+        UnResolved,
+        Status,
+        eval_context::{ClauseReport, EventRecord, simplifed_json_from_root, UnaryComparison, BinaryComparison, RuleReport, FileReport, InComparison},
+        path_value::{
+            traversal::{Traversal, TraversalResult, Node},
+            PathAwareValue,
+        },
+        display::ValueOnlyDisplay,
+        self,
+    },
+    utils::ReadCursor,
 };
 
 
@@ -43,7 +56,6 @@ impl<'reporter> CfnAware<'reporter> {
 }
 
 impl<'reporter> Reporter for CfnAware<'reporter> {
-
     fn report(
         &self,
         _writer: &mut dyn Write,
@@ -54,7 +66,7 @@ impl<'reporter> Reporter for CfnAware<'reporter> {
         _rules_file: &str,
         _data_file: &str,
         _data: &Traversal<'_>,
-        _output_format_type: OutputFormatType) -> crate::rules::Result<()> {
+        _output_format_type: OutputFormatType) -> rules::Result<()> {
         Ok(())
     }
 
@@ -67,8 +79,7 @@ impl<'reporter> Reporter for CfnAware<'reporter> {
         data_file: &str,
         data_file_bytes: &str,
         data: &Traversal<'value>,
-        output_type: OutputFormatType) -> crate::rules::Result<()> {
-
+        output_type: OutputFormatType) -> rules::Result<()> {
         let root = data.root().unwrap();
         if let Ok(_) = data.at("/Resources", root) {
             let failure_report = simplifed_json_from_root(root_record)?;
@@ -82,16 +93,16 @@ impl<'reporter> Reporter for CfnAware<'reporter> {
         else {
             self.next.map_or(
                 Ok(()), |next|
-                next.report_eval(
-                    write,
-                    status,
-                    root_record,
-                    rules_file,
-                    data_file,
-                    data_file_bytes,
-                    data,
-                    output_type)
-                )
+                    next.report_eval(
+                        write,
+                        status,
+                        root_record,
+                        rules_file,
+                        data_file,
+                        data_file_bytes,
+                        data,
+                        output_type)
+            )
         }
     }
 }
@@ -100,21 +111,21 @@ fn binary_err_msg(
     writer: &mut dyn Write,
     _clause: &ClauseReport<'_>,
     bc: &BinaryComparison<'_>,
-    prefix: &str) -> crate::rules::Result<usize> {
+    prefix: &str) -> rules::Result<usize> {
     let width = "PropertyPath".len() + 4;
     writeln!(
         writer,
         "{prefix}{pp:<width$}= {path}\n{prefix}{op:<width$}= {cmp}\n{prefix}{val:<width$}= {value}\n{prefix}{cw:<width$}= {with}",
-        width=width,
-        pp="PropertyPath",
-        op="Operator",
-        val="Value",
-        cw="ComparedWith",
-        prefix=prefix,
-        path=bc.from.self_path(),
-        value=ValueOnlyDisplay(bc.from),
-        cmp=crate::rules::eval_context::cmp_str(bc.comparison),
-        with=ValueOnlyDisplay(bc.to)
+        width = width,
+        pp = "PropertyPath",
+        op = "Operator",
+        val = "Value",
+        cw = "ComparedWith",
+        prefix = prefix,
+        path = bc.from.self_path(),
+        value = ValueOnlyDisplay(bc.from),
+        cmp = rules::eval_context::cmp_str(bc.comparison),
+        with = ValueOnlyDisplay(bc.to)
     )?;
     Ok(width)
 }
@@ -123,105 +134,92 @@ fn unary_err_msg(
     writer: &mut dyn Write,
     _clause: &ClauseReport<'_>,
     re: &UnaryComparison<'_>,
-    prefix: &str) -> crate::rules::Result<usize> {
+    prefix: &str) -> rules::Result<usize> {
     let width = "PropertyPath".len() + 4;
     writeln!(
         writer,
         "{prefix}{pp:<width$}= {path}\n{prefix}{op:<width$}= {cmp}",
-        width=width,
-        pp="PropertyPath",
-        op="Operator",
-        prefix=prefix,
-        path=re.value.self_path(),
-        cmp=crate::rules::eval_context::cmp_str(re.comparison),
+        width = width,
+        pp = "PropertyPath",
+        op = "Operator",
+        prefix = prefix,
+        path = re.value.self_path(),
+        cmp = rules::eval_context::cmp_str(re.comparison),
     )?;
     Ok(width)
 }
 
-
-use crate::utils;
 
 fn single_line(writer: &mut dyn Write,
                data_file: &str,
                data_content: &str,
                rules_file: &str,
                data: &Traversal<'_>,
-               failure_report: FileReport<'_>) -> crate::rules::Result<()> {
-
+               failure_report: FileReport<'_>) -> rules::Result<()> {
     if failure_report.not_compliant.is_empty() {
         return Ok(())
     }
 
-    let mut code_segment = utils::ReadCursor::new(data_content);
+    let mut code_segment = ReadCursor::new(data_content);
     let mut path_tree = PathTree::new();
     let mut hierarchy = RuleHierarchy::new();
-    let root_node = std::rc::Rc::new(String::from(""));
+    let root_node = Rc::new(String::from(""));
+
     for each_rule in &failure_report.not_compliant {
         populate_hierarchy_path_trees(
             each_rule,
             root_node.clone(),
             &mut path_tree,
-            &mut hierarchy
+            &mut hierarchy,
         );
     }
 
     let root = data.root().unwrap();
     let mut by_resources = HashMap::new();
     for (key, value) in path_tree.range("/Resources"..) {
-        let resource_name = match CFN_RESOURCES.captures(*key) {
-            Some(cap) => {
-                cap.get(1).unwrap().as_str()
-            },
-            _ => unreachable!()
-        };
-        let resource_aggr = by_resources.entry(resource_name).or_insert_with(|| {
-            let path = format!("/Resources/{}", resource_name);
-            let resource = match data.at(&path, root) {
-                Ok(TraversalResult::Value(val)) => val,
-                _ => unreachable!()
-            };
-            let resource_type = match data.at("0/Type", resource) {
-                Ok(TraversalResult::Value(val)) => match val.value() {
-                    PathAwareValue::String((_, v)) => v.as_str(),
-                    _ => unreachable!()
-                }
-                _ => unreachable!()
-            };
-            let cdk_path = match data.at("0/Metadata/aws:cdk:path", resource) {
-                Ok(TraversalResult::Value(val)) => match val.value() {
-                    PathAwareValue::String((_, v)) => Some(v.as_str()),
-                    _ => unreachable!()
-                },
-                _ => None
-            };
-            LocalResourceAggr {
-                name: resource_name,
-                resource_type,
-                cdk_path,
-                clauses: HashSet::new(),
-                paths: BTreeSet::new(),
-            }
-        });
+        let matches = key.matches("/").count();
+        let mut count = 1;
 
-        for node in value.iter() {
-            resource_aggr.clauses.insert(IdentityHash{key: node.clause});
-            resource_aggr.paths.insert(node.path.as_ref().clone());
-        }
+        if matches > 2 {
+            loop {
+                if matches - count == 0 {
+                    unreachable!()
+                }
+                let resource_name = get_resource_name(key, count, matches);
+
+                match handle_resource_aggr(data, root, resource_name, &mut by_resources, value) {
+                    Some(_) =>  break,
+                    None => count += 1,
+                };
+            }
+        } else {
+            let resource_name = match CFN_RESOURCES.captures(*key) {
+                Some(cap) => {
+                    cap.get(1).unwrap().as_str()
+                },
+                _ => unreachable!()
+            };
+
+            match handle_resource_aggr(data, root, resource_name.to_string(), &mut by_resources, value) {
+                Some(_) => {},
+                None => unreachable!(),
+            }
+        };
     }
 
     writeln!(writer, "Evaluating data {} against rules {}", data_file, rules_file)?;
     let num_of_resources = format!("{}", by_resources.len()).bold();
     writeln!(writer, "Number of non-compliant resources {}", num_of_resources)?;
-    for (resource_name, resource) in by_resources {
+    for (_resource_name, resource) in by_resources {
         writeln!(writer, "Resource = {} {{", resource.name.yellow().bold())?;
         let prefix = String::from("  ");
         writeln!(
             writer,
             "{prefix}{0:<width$}= {rt}",
             "Type",
-            prefix=prefix,
-            width=10,
-            rt=resource.resource_type,
+            prefix = prefix,
+            width = 10,
+            rt = resource.resource_type,
         )?;
         let cdk_path = resource.cdk_path.as_ref().map_or("", |p| *p);
         if !cdk_path.is_empty() {
@@ -229,33 +227,35 @@ fn single_line(writer: &mut dyn Write,
                 writer,
                 "{prefix}{0:<width$}= {cdk}",
                 "CDK-Path",
-                prefix=prefix,
-                width=10,
-                cdk=cdk_path
+                prefix = prefix,
+                width = 10,
+                cdk = cdk_path
             )?;
         }
         for each_rule in &failure_report.not_compliant {
             let rule_name = match each_rule {
-                ClauseReport::Rule(RuleReport{name, ..}) => format!("/{}", name),
+                ClauseReport::Rule(RuleReport { name, .. }) => format!("/{}", name),
                 _ => unreachable!()
             };
 
             let range = resource.paths.range(rule_name.clone()..)
                 .take_while(|p| p.starts_with(&rule_name)).count();
             if range > 0 {
-                struct ErrWriter<'w, 'b>{code_segment: &'w mut utils::ReadCursor<'b>}
+                struct ErrWriter<'w, 'b> {
+                    code_segment: &'w mut ReadCursor<'b>,
+                }
                 impl<'w, 'b> super::common::ComparisonErrorWriter for ErrWriter<'w, 'b> {
                     fn missing_property_msg(
                         &mut self,
                         writer: &mut dyn Write,
                         _cr: &ClauseReport<'_>,
                         bc: Option<&UnResolved<'_>>,
-                        prefix: &str) -> crate::rules::Result<usize> {
+                        prefix: &str) -> rules::Result<usize> {
                         if let Some(bc) = bc {
                             self.emit_code(
                                 writer,
                                 bc.traversed_to.self_path().1.line,
-                                prefix
+                                prefix,
                             )?;
                         }
                         Ok(0)
@@ -266,21 +266,21 @@ fn single_line(writer: &mut dyn Write,
                         writer: &mut dyn Write,
                         cr: &ClauseReport<'_>,
                         bc: &BinaryComparison<'_>,
-                        prefix: &str) -> crate::rules::Result<usize> {
+                        prefix: &str) -> rules::Result<usize> {
                         let width = "PropertyPath".len() + 4;
                         writeln!(
                             writer,
                             "{prefix}{pp:<width$}= {path}\n{prefix}{op:<width$}= {cmp}\n{prefix}{val:<width$}= {value}\n{prefix}{cw:<width$}= {with}",
-                            width=width,
-                            pp="PropertyPath",
-                            op="Operator",
-                            val="Value",
-                            cw="ComparedWith",
-                            prefix=prefix,
-                            path=bc.from.self_path(),
-                            value=ValueOnlyDisplay(bc.from),
-                            cmp=crate::rules::eval_context::cmp_str(bc.comparison),
-                            with=ValueOnlyDisplay(bc.to)
+                            width = width,
+                            pp = "PropertyPath",
+                            op = "Operator",
+                            val = "Value",
+                            cw = "ComparedWith",
+                            prefix = prefix,
+                            path = bc.from.self_path(),
+                            value = ValueOnlyDisplay(bc.from),
+                            cmp = rules::eval_context::cmp_str(bc.comparison),
+                            with = ValueOnlyDisplay(bc.to)
                         )?;
                         self.emit_code(writer, bc.from.self_path().1.line, prefix)?;
                         Ok(width)
@@ -291,7 +291,7 @@ fn single_line(writer: &mut dyn Write,
                         writer: &mut dyn Write,
                         cr: &ClauseReport<'_>,
                         bc: &InComparison<'_>,
-                        prefix: &str) -> crate::rules::Result<usize> {
+                        prefix: &str) -> rules::Result<usize> {
                         let cut_off = max(bc.to.len(), 5);
                         let mut collected = Vec::with_capacity(10);
                         for (idx, each) in bc.to.iter().enumerate() {
@@ -306,38 +306,37 @@ fn single_line(writer: &mut dyn Write,
                             writeln!(
                                 writer,
                                 "{prefix}{pp:<width$}= {path}\n{prefix}{op:<width$}= {cmp}\n{prefix}{val:<width$}= {value}\n{prefix}{cw:<width$}= {with}",
-                                width=width,
-                                pp="PropertyPath",
-                                op="Operator",
-                                val="Value",
-                                cw="ComparedWith",
-                                prefix=prefix,
-                                path=bc.from.self_path(),
-                                value=ValueOnlyDisplay(bc.from),
-                                cmp=crate::rules::eval_context::cmp_str(bc.comparison),
-                                with=collected
+                                width = width,
+                                pp = "PropertyPath",
+                                op = "Operator",
+                                val = "Value",
+                                cw = "ComparedWith",
+                                prefix = prefix,
+                                path = bc.from.self_path(),
+                                value = ValueOnlyDisplay(bc.from),
+                                cmp = rules::eval_context::cmp_str(bc.comparison),
+                                with = collected
                             )?;
                         } else {
                             writeln!(
                                 writer,
                                 "{prefix}{pp:<width$}= {path}\n{prefix}{op:<width$}= {cmp}\n{prefix}{total_name:<width$}= {total}\n{prefix}{val:<width$}= {value}\n{prefix}{cw:<width$}= {with}",
-                                width=width,
-                                pp="PropertyPath",
-                                op="Operator",
-                                val="Value",
-                                total_name="Total",
-                                cw="ComparedWith",
-                                prefix=prefix,
-                                path=bc.from.self_path(),
-                                value=ValueOnlyDisplay(bc.from),
-                                cmp=crate::rules::eval_context::cmp_str(bc.comparison),
-                                total=bc.to.len(),
-                                with=collected
+                                width = width,
+                                pp = "PropertyPath",
+                                op = "Operator",
+                                val = "Value",
+                                total_name = "Total",
+                                cw = "ComparedWith",
+                                prefix = prefix,
+                                path = bc.from.self_path(),
+                                value = ValueOnlyDisplay(bc.from),
+                                cmp = rules::eval_context::cmp_str(bc.comparison),
+                                total = bc.to.len(),
+                                with = collected
                             )?;
                         }
                         self.emit_code(writer, bc.from.self_path().1.line, prefix)?;
                         Ok(width)
-
                     }
 
 
@@ -346,26 +345,24 @@ fn single_line(writer: &mut dyn Write,
                         writer: &mut dyn Write,
                         cr: &ClauseReport<'_>,
                         re: &UnaryComparison<'_>,
-                        prefix: &str) -> crate::rules::Result<usize> {
+                        prefix: &str) -> rules::Result<usize> {
                         let width = unary_err_msg(
                             writer,
                             cr,
                             re,
-                            prefix
+                            prefix,
                         )?;
                         self.emit_code(writer, re.value.self_path().1.line, prefix)?;
                         Ok(width)
                     }
-
-
                 }
-                let mut err_writer = ErrWriter{code_segment: &mut code_segment};
+                let mut err_writer = ErrWriter { code_segment: &mut code_segment };
                 super::common::pprint_clauses(
                     writer,
                     each_rule,
                     &resource,
                     prefix.clone(),
-                    &mut err_writer
+                    &mut err_writer,
                 )?;
 
                 impl<'w, 'b> ErrWriter<'w, 'b> {
@@ -373,32 +370,32 @@ fn single_line(writer: &mut dyn Write,
                         &mut self,
                         writer: &mut dyn Write,
                         line: usize,
-                        prefix: &str) -> crate::rules::Result<()> {
+                        prefix: &str) -> rules::Result<()> {
                         writeln!(
                             writer,
                             "{prefix}Code:",
-                            prefix=prefix
+                            prefix = prefix
                         )?;
                         let new_prefix = format!("{}  ", prefix);
-                        if let Some((num, line)) = self.code_segment.seek_line(std::cmp::max(1, line-2)) {
-                            let line = format!("{num:>5}.{line}", num=num, line=line).bright_green();
+                        if let Some((num, line)) = self.code_segment.seek_line(max(1, line - 2)) {
+                            let line = format!("{num:>5}.{line}", num = num, line = line).bright_green();
                             writeln!(
                                 writer,
                                 "{prefix}{line}",
                                 prefix = new_prefix,
-                                line=line
+                                line = line
                             )?;
                         }
                         let mut context = 5;
                         loop {
                             match self.code_segment.next() {
                                 Some((num, line)) => {
-                                    let line = format!("{num:>5}.{line}", num=num, line=line).bright_green();
+                                    let line = format!("{num:>5}.{line}", num = num, line = line).bright_green();
                                     writeln!(
                                         writer,
                                         "{prefix}{line}",
                                         prefix = new_prefix,
-                                        line=line
+                                        line = line
                                     )?;
                                 }
                                 None => break,
@@ -411,11 +408,84 @@ fn single_line(writer: &mut dyn Write,
                         Ok(())
                     }
                 }
-
             }
         }
         writeln!(writer, "}}")?;
     }
 
     Ok(())
+}
+
+
+///
+/// takes a key that contains > 2 `/`, and strips all characters to the right of i = matches-count
+///
+/// # Arguments
+///
+/// * `key`: str
+/// * `count`: usize
+/// * `matches`: usize
+///
+/// returns: String
+/// ```
+fn get_resource_name(key: &&str, count: usize, matches: usize) -> String {
+    let c = &char::from_u32(0xC).unwrap().to_string();
+    // count = 2; key = "/Resources/foo/bar/baz -> placeholder = "\fResources\ffoo\fbar/baz"
+    let mut placeholder = str::replacen(key, "/", c, matches - count);
+
+    // placeholder = "\fResources\ffoo\fbar/baz" -> placeholder = "/Resources/foo\fbar/baz"
+    placeholder = str::replacen(&placeholder, c, "/", 2); // count = 2 -> because always need to replace the Slashes for /Resources/
+
+    // placeholder = "/Resources/foo\fbar/baz"
+    match CFN_RESOURCES.captures(&placeholder) {
+        Some(cap) => {
+            // resource_name = "foo/bar"
+            str::replace(cap.get(1).unwrap().as_str(), c, "/")
+        }
+        _ => unreachable!()
+    }
+}
+
+fn handle_resource_aggr<'record, 'value: 'record>(
+    data: &'value Traversal<'_>,
+    root: &'value Node<'_>,
+    name: String,
+    by_resources: &mut HashMap<String, LocalResourceAggr<'record, 'value>>,
+    value: &Vec<Rc<crate::commands::validate::common::Node<'record, 'value>>>,
+) -> Option<()> {
+    let path = format!("/Resources/{}", name);
+    let resource = match data.at(&path, root) {
+        Ok(TraversalResult::Value(val)) => val,
+        _ => return None
+    };
+
+    let resource_type = match data.at("0/Type", resource) {
+        Ok(TraversalResult::Value(val)) => match val.value() {
+            PathAwareValue::String((_, v)) => v.as_str(),
+            _ => unreachable!()
+        }
+        _ => return None
+    };
+    let cdk_path = match data.at("0/Metadata/aws:cdk:path", resource) {
+        Ok(TraversalResult::Value(val)) => match val.value() {
+            PathAwareValue::String((_, v)) => Some(v.as_str()),
+            _ => unreachable!()
+        },
+        _ => None
+    };
+
+    let resource_aggr = (*by_resources).entry(name.to_string()).or_insert_with(|| LocalResourceAggr {
+        name,
+        resource_type,
+        cdk_path,
+        clauses: HashSet::new(),
+        paths: BTreeSet::new(),
+    });
+
+    for node in value.iter() {
+        resource_aggr.clauses.insert(IdentityHash { key: node.clause });
+        resource_aggr.paths.insert(node.path.as_ref().clone());
+    };
+
+    Some(())
 }

--- a/guard/src/commands/validate/common.rs
+++ b/guard/src/commands/validate/common.rs
@@ -287,7 +287,7 @@ pub(super) fn extract_name_info_from_record<'record, 'value>(
                 provided,
                 expected: Some(serde_json::Value::Array(to)),
                 message: String::from(incomp.message.as_ref().map_or("", |s| s.as_str())),
-                    ..Default::default()
+                ..Default::default()
             }
         },
 
@@ -296,7 +296,7 @@ pub(super) fn extract_name_info_from_record<'record, 'value>(
 }
 
 pub(crate) fn extract_event_records<'value>(root_record: EventRecord<'value>)
-    -> (Vec<EventRecord<'value>>, Vec<EventRecord<'value>>, Vec<EventRecord<'value>>)
+                                            -> (Vec<EventRecord<'value>>, Vec<EventRecord<'value>>, Vec<EventRecord<'value>>)
 {
     let mut failed = Vec::with_capacity(root_record.children.len());
     let mut skipped = Vec::with_capacity(root_record.children.len());
@@ -515,40 +515,40 @@ pub(super) fn print_name_info<R, U, B>(
                     Some(cmp) => (cmp.operator, cmp.not_operator_exists),
                     None => {
                         writeln!(writer, "Parameterized Rule {rules}/{rule_name} failed for {data}. Reason {msg}",
-                            rules=rules_file_name,
-                            data=data_file_name,
-                            rule_name=each.rule,
-                            msg=each.message.replace('\n', "; ")
+                                 rules=rules_file_name,
+                                 data=data_file_name,
+                                 rule_name=each.rule,
+                                 msg=each.message.replace('\n', "; ")
                         );
                         continue;
                     }
                 };
                 if cmp.is_unary() {
                     writeln!(writer, "{}",
-                         unary_message(
-                             rules_file_name,
-                             data_file_name,
-                             match cmp {
-                                 CmpOperator::Exists => if !not { "did not exist" } else { "existed" },
-                                 CmpOperator::Empty => if !not { "was not empty"} else { "was empty" },
-                                 CmpOperator::IsList => if !not { "was not a list " } else { "was list" },
-                                 CmpOperator::IsMap => if !not { "was not a struct" } else { "was struct" },
-                                 CmpOperator::IsString => if !not { "was not a string " } else { "was string" },
-                                 _ => unreachable!()
-                             },
-                             each)?,
+                             unary_message(
+                                 rules_file_name,
+                                 data_file_name,
+                                 match cmp {
+                                     CmpOperator::Exists => if !not { "did not exist" } else { "existed" },
+                                     CmpOperator::Empty => if !not { "was not empty"} else { "was empty" },
+                                     CmpOperator::IsList => if !not { "was not a list " } else { "was list" },
+                                     CmpOperator::IsMap => if !not { "was not a struct" } else { "was struct" },
+                                     CmpOperator::IsString => if !not { "was not a string " } else { "was string" },
+                                     _ => unreachable!()
+                                 },
+                                 each)?,
                     )?;
 
                 }
                 else {
                     // EQUALS failed at property path Properties.Encrypted because provided value [false] did not match with expected value [true].
                     writeln!(writer, "{}",
-                        binary_message(
-                            rules_file_name,
-                            data_file_name,
-                            if not { "did" } else { "did not" },
-                            each
-                        )?,
+                             binary_message(
+                                 rules_file_name,
+                                 data_file_name,
+                                 if not { "did" } else { "did not" },
+                                 each
+                             )?,
                     )?;
                 }
             }
@@ -583,7 +583,7 @@ pub(super) fn report_structured<'value>(root: &EventRecord<'value>,
 
 #[derive(Clone, Debug)]
 pub(super) struct LocalResourceAggr<'record, 'value: 'record> {
-    pub(super) name: &'value str,
+    pub(super) name: String,
     pub(super) resource_type: &'value str,
     pub(super) cdk_path: Option<&'value str>,
     pub(super) clauses: HashSet<IdentityHash<'record, ClauseReport<'value>>>,
@@ -713,16 +713,16 @@ pub(super) fn populate_hierarchy_path_trees<'report, 'value: 'report>(
 
 pub(super) type BinaryComparisonErrorFn =
 dyn Fn
-    (&mut dyn Write,
-     &ClauseReport<'_>,
-     &BinaryComparison<'_>,
-     String) -> crate::rules::Result<()>;
+(&mut dyn Write,
+    &ClauseReport<'_>,
+    &BinaryComparison<'_>,
+    String) -> crate::rules::Result<()>;
 
 pub(super) type UnaryComparisonErrorFn = dyn Fn
-    (&mut dyn Write,
-     &ClauseReport<'_>,
-     &UnaryComparison<'_>,
-     String) -> crate::rules::Result<()>;
+(&mut dyn Write,
+    &ClauseReport<'_>,
+    &UnaryComparison<'_>,
+    String) -> crate::rules::Result<()>;
 
 
 fn emit_messages(
@@ -1151,5 +1151,3 @@ pub(super) fn pprint_clauses<'report, 'value: 'report>(
 
     Ok(())
 }
-
-

--- a/guard/src/commands/validate/tf.rs
+++ b/guard/src/commands/validate/tf.rs
@@ -157,7 +157,7 @@ fn single_line(writer: &mut dyn Write,
         let (resource_type, resource_name) = (addr.slice(0..dot_sep), addr.slice(dot_sep+1..));
         let resource_aggr = by_resources.entry(resource_name).or_insert(
             LocalResourceAggr {
-                name: resource_name,
+                name: String::from(resource_name),
                 resource_type,
                 cdk_path: None,
                 clauses: HashSet::new(),
@@ -300,4 +300,3 @@ fn single_line(writer: &mut dyn Write,
     }
     Ok(())
 }
-


### PR DESCRIPTION
*Issue #, if available:*
fix for #256 

*Description of changes:*
To fix this bug, we check the number of / in a key. If the key has > 2 matches, we assume its possibly a resource name that contains a slash in it. In this case, we try different combinations to include keys with / in them until we find a valid key, or else we return an error.

---
*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
