### PR TITLE
[#228]: bugfix for comment at eof

### DIFF
--- a/guard/src/rules/parser.rs
+++ b/guard/src/rules/parser.rs
@@ -105,7 +105,7 @@ impl<'a> std::fmt::Display for ParserError<'a> {
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
 pub(in crate::rules) fn comment2(input: Span) -> IResult<Span, Span> {
-    delimited(char('#'), take_till(|c| c == '\n'), char('\n'))(input)
+    delimited(char('#'), take_till(|c| c == '\n'), multispace0)(input)
 }
 //
 // This function extracts either white-space-CRLF or a comment


### PR DESCRIPTION
*Issue #, if available:*
#228 

*Description of changes:*
Changed our logic for parsing comments to use the crate nom's function `multispace0` which does 

```Recognizes zero or more spaces, tabs, carriage returns and line feeds.
complete version: will return the whole input if no terminating token is found (a non space character)``` 
---
*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
