### PR TITLE
Removing try_exists from validate_path since it has only recently bee…

### DIFF
--- a/guard-lambda/Cargo.toml
+++ b/guard-lambda/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cfn-guard-lambda"
 version = "2.1.0"
 authors = ["Diwakar Chakravarthy", "John Tompkins", "Omkar Hegde", "Priya Padmanaban",
-    "Bryan Ayala", "Kexiang Wang", "Akshay Rane", "aws-cloudformation-developers <aws-cloudformation-developers@amazon.com>"]
+    "Bryan Ayala", "Kexiang Wang", "Akshay Rane", "Josh Fried", "aws-cloudformation-developers <aws-cloudformation-developers@amazon.com>"]
 description = "Lambda version of cfn-guard. Checks JSON- or YAML- formatted structured data for policy compliance using a simple, policy-as-code, declarative syntax"
 license = "Apache-2.0"
 edition = "2018"

--- a/guard/src/commands/validate.rs
+++ b/guard/src/commands/validate.rs
@@ -475,16 +475,10 @@ or rules files.
 }
 
 pub(crate) fn validate_path(base: &str) -> Result<()> {
-    match Path::new(base).try_exists() {
-        Ok(exists) => {
-            if !exists {
-                return Err(Error::new(ErrorKind::FileNotFoundError(base.to_string())));
-            }
-        }
-        Err(e) => return Err(Error::new(ErrorKind::IoError(e))),
+    match Path::new(base).exists() {
+        true => Ok(()),
+        false => Err(Error::new(ErrorKind::FileNotFoundError(base.to_string()))),
     }
-
-    Ok(())
 }
 
 pub fn validate_and_return_json(data: &str, rules: &str) -> Result<String> {


### PR DESCRIPTION
…n stabilized

*Issue #, if available:*


*Description of changes:*
Changed the method in validate_path to use exists() instead of try_exists() due to backwards compatibility issues

---
*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
