### PR TITLE
add version for ffi function

### DIFF
--- a/guard-ffi/example/cfn_guard.h
+++ b/guard-ffi/example/cfn_guard.h
@@ -12,6 +12,7 @@ typedef struct {
 } validate_input_t;
 
 char* cfn_guard_run_checks(validate_input_t template, validate_input_t rules, _Bool verbose, extern_err_t * err);
+char* cfn_guard_version(extern_err_t * err);
 void cfn_guard_free_string(char *);
 
 #endif

--- a/guard-ffi/example/cfn_guard_test.c
+++ b/guard-ffi/example/cfn_guard_test.c
@@ -2,7 +2,7 @@
 #include <stdlib.h>
 #include "cfn_guard.h"
 
-int main() {
+void run_rule() {
   extern_err_t err;
   validate_input_t data, rules;
   data.content = "foo:\n  bar: true";
@@ -11,7 +11,7 @@ int main() {
   rules.file_name = "check.rule";
   char* result = cfn_guard_run_checks(data, rules, 0, &err);
   if (err.code == 0) {
-    printf(result);
+    printf("%s\n", result);
     cfn_guard_free_string(result);
     cfn_guard_free_string(err.message);
   } else {
@@ -19,5 +19,18 @@ int main() {
     cfn_guard_free_string(err.message);
     cfn_guard_free_string(result);
   }
+}
+
+void print_version() {
+  extern_err_t err;
+  char *result = cfn_guard_version(&err);
+  printf("%s\n", result);
+  cfn_guard_free_string(result);
+  cfn_guard_free_string(err.message);
+}
+
+int main() {
+  run_rule();
+  print_version();
   return 0;
 }

--- a/guard-ffi/src/lib.rs
+++ b/guard-ffi/src/lib.rs
@@ -8,6 +8,8 @@ mod errors;
 use types::FfiValidateInput;
 use errors::FfiError;
 
+const LIB_VERSION : &str = env!("CARGO_PKG_VERSION");
+
 /**
  * C prototype for this function:
  * typedef struct {
@@ -36,6 +38,29 @@ pub extern "C" fn cfn_guard_run_checks<'a>(data: FfiValidateInput<'a>, rules: Ff
             Err(e) => Err(FfiError(e)),
             Ok(r) => Ok(r)
         }
+    })
+}
+
+/**
+ * C prototype for this function:
+ * typedef struct {
+ *   int32_t code;
+ *   char *message;
+ * } extern_err_t;
+ *
+ * char* cfn_guard_version(extern_err_t * err);
+ * void cfn_guard_free_string(char *);
+ *
+ * if an error is returned, it will be populated in `err`. `cfn_guard_free_string` must be called
+ * for the `message` field in `err`.
+ *
+ * if `err.code` == 0, then the result will be a json string. This `*char` must be passed to
+ * `cfn_guard_free_string` to return the memory allocated by rust.
+ */
+#[no_mangle]
+pub extern "C" fn cfn_guard_version(err : &mut ExternError) -> *mut c_char {
+    ffi_support::call_with_output(err, || {
+        format!("{}", LIB_VERSION)
     })
 }
 


### PR DESCRIPTION
*Issue #, if available:*


*Description of changes:*
Adds ability to get the version of cfn-guard when invoked via ffi

---
*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
