### PR TITLE
Bumping up clap-rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,15 +22,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "arrayvec"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -115,6 +106,7 @@ version = "2.1.0"
 dependencies = [
  "Inflector",
  "clap",
+ "clap_complete",
  "colored 2.0.0",
  "enumflags2",
  "enumflags2_derive",
@@ -163,17 +155,35 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "2.34.0"
+version = "3.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+checksum = "71655c45cb9845d3270c9d6df84ebe72b4dad3c2ba3f7023ad47c144e4e473a5"
 dependencies = [
- "ansi_term",
  "atty",
  "bitflags",
+ "clap_lex",
+ "indexmap",
  "strsim",
+ "termcolor",
  "textwrap",
- "unicode-width",
- "vec_map",
+]
+
+[[package]]
+name = "clap_complete"
+version = "3.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f7a2e0a962c45ce25afce14220bc24f9dade0a1787f185cecf96bfba7847cd8"
+dependencies = [
+ "clap",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+dependencies = [
+ "os_str_bytes",
 ]
 
 [[package]]
@@ -619,6 +629,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e82dad04139b71a90c080c8463fe0dc7902db5192d939bd0950f074d014339e1"
 
 [[package]]
+name = "os_str_bytes"
+version = "6.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ff7415e9ae3fff1225851df9e0d9e4e5479f947619774677a63572e55e80eff"
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -826,9 +842,9 @@ checksum = "2bd10a070fb1f2796a288abec42695db4682a82b6f12ffacd60fb8d5ad3a4a12"
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
@@ -842,13 +858,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "textwrap"
-version = "0.11.0"
+name = "termcolor"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
 dependencies = [
- "unicode-width",
+ "winapi-util",
 ]
+
+[[package]]
+name = "textwrap"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 
 [[package]]
 name = "thread_local"
@@ -997,12 +1019,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fdbf052a0783de01e944a6ce7a8cb939e295b1e7be835a1112c3b9a7f047a5a"
 
 [[package]]
-name = "unicode-width"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
-
-[[package]]
 name = "unsafe-libyaml"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1019,12 +1035,6 @@ name = "valuable"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,33 +155,31 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.23"
+version = "4.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71655c45cb9845d3270c9d6df84ebe72b4dad3c2ba3f7023ad47c144e4e473a5"
+checksum = "335867764ed2de42325fafe6d18b8af74ba97ee0c590fa016f157535b42ab04b"
 dependencies = [
  "atty",
  "bitflags",
  "clap_lex",
- "indexmap",
  "strsim",
  "termcolor",
- "textwrap",
 ]
 
 [[package]]
 name = "clap_complete"
-version = "3.2.5"
+version = "4.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f7a2e0a962c45ce25afce14220bc24f9dade0a1787f185cecf96bfba7847cd8"
+checksum = "dfe581a2035db4174cdbdc91265e1aba50f381577f0510d0ad36c7bc59cc84a3"
 dependencies = [
  "clap",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.2.4"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+checksum = "0d4198f73e42b4936b35b5bb248d81d2b595ecb170da0bac7655c54eedfa8da8"
 dependencies = [
  "os_str_bytes",
 ]
@@ -865,12 +863,6 @@ checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
 dependencies = [
  "winapi-util",
 ]
-
-[[package]]
-name = "textwrap"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 
 [[package]]
 name = "thread_local"

--- a/guard/Cargo.toml
+++ b/guard/Cargo.toml
@@ -22,7 +22,8 @@ nom_locate = "2.0.0"
 indexmap = { version = "1.6.0", features = ["serde-1"] }
 regex = "1.5.5"
 simple_logger = "1.3.0"
-clap = "2.29.0"
+clap = "3.0.0"
+clap_complete = "3.0.0"
 serde = { version = "1.0", features = ["derive"] }
 #serde_json = "1.0.57"
 serde_yaml = "0.9.10"

--- a/guard/Cargo.toml
+++ b/guard/Cargo.toml
@@ -22,8 +22,8 @@ nom_locate = "2.0.0"
 indexmap = { version = "1.6.0", features = ["serde-1"] }
 regex = "1.5.5"
 simple_logger = "1.3.0"
-clap = "3.0.0"
-clap_complete = "3.0.0"
+clap = "4.0.18"
+clap_complete = "4.0.3"
 serde = { version = "1.0", features = ["derive"] }
 #serde_json = "1.0.57"
 serde_yaml = "0.9.10"

--- a/guard/src/command.rs
+++ b/guard/src/command.rs
@@ -4,6 +4,6 @@ use crate::rules::errors::Error;
 
 pub trait Command {
     fn name(&self) -> &'static str;
-    fn command(&self) -> App<'static, 'static>;
+    fn command(&self) -> App<'static>;
     fn execute(&self, args: &ArgMatches) -> Result<i32, Error>;
 }

--- a/guard/src/command.rs
+++ b/guard/src/command.rs
@@ -1,4 +1,4 @@
-use clap::{ArgMatches};
+use clap::ArgMatches;
 
 use crate::rules::errors::Error;
 

--- a/guard/src/command.rs
+++ b/guard/src/command.rs
@@ -1,9 +1,9 @@
-use clap::{App, ArgMatches};
+use clap::{ArgMatches};
 
 use crate::rules::errors::Error;
 
 pub trait Command {
     fn name(&self) -> &'static str;
-    fn command(&self) -> App<'static>;
+    fn command(&self) -> clap::Command;
     fn execute(&self, args: &ArgMatches) -> Result<i32, Error>;
 }

--- a/guard/src/commands/migrate.rs
+++ b/guard/src/commands/migrate.rs
@@ -36,7 +36,7 @@ impl Command for Migrate {
     }
 
 
-    fn command(&self) -> App<'static, 'static> {
+    fn command(&self) -> App<'static> {
         App::new(MIGRATE)
             .about(r#"Migrates 1.0 rules to 2.0 compatible rules.
 "#)
@@ -44,7 +44,7 @@ impl Command for Migrate {
             .arg(Arg::with_name(OUTPUT.0).long(OUTPUT.0).short(OUTPUT.1).takes_value(true).help("Write migrated rules to output file").required(false))
     }
 
-    fn execute(&self, app: &ArgMatches<'_>) -> Result<i32> {
+    fn execute(&self, app: &ArgMatches) -> Result<i32> {
         let file_input = app.value_of(RULES.0).unwrap();
         let path = PathBuf::from_str(file_input).unwrap();
         let file_name = path.to_str().unwrap_or("").to_string();

--- a/guard/src/commands/migrate.rs
+++ b/guard/src/commands/migrate.rs
@@ -20,13 +20,12 @@ use crate::rules::Result;
 mod migrate_tests;
 
 
-
 #[derive(Clone, Copy, Eq, PartialEq)]
 pub(crate) struct Migrate {}
 
 impl Migrate {
     pub(crate) fn new() -> Self {
-        Migrate{}
+        Migrate {}
     }
 }
 
@@ -59,21 +58,21 @@ impl Command for Migrate {
             Err(e) => {
                 println!("Unable read content from file {}", e);
                 Err(Error::new(ErrorKind::IoError(e)))
-            },
+            }
             Ok(file_content) => {
                 match parse_rules_file(&file_content, &file_name) {
                     Err(e) => {
                         println!("Could not parse 1.0 rule file: {}. Please ensure the file is valid with the old version of the tool and try again.", file_name);
                         Err(e)
-                    },
+                    }
                     Ok(rules) => {
                         let migrated_rules = migrate_rules(rules)?;
                         let span = crate::rules::parser::Span::new_extra(&migrated_rules, "");
                         match crate::rules::parser::rules_file(span) {
                             Ok(_rules) => {
-                                write!(out,"{}", migrated_rules)?;
+                                write!(out, "{}", migrated_rules)?;
                                 Ok(0_i32)
-                            },
+                            }
                             Err(e) => {
                                 println!("Could not parse migrated ruleset for file: '{}': {}", &file_name, e);
                                 Err(e)
@@ -99,7 +98,7 @@ pub(crate) fn migrated_rules_by_type(rules: &[RuleLineType],
     types.sort();
     for each_type in &types {
         writeln!(&mut migrated, "let {} = Resources.*[ Type == \"{}\" ]", each_type, each_type.type_name)?;
-        writeln!(&mut migrated, "rule {name}_checks WHEN %{name} NOT EMPTY {{", name=each_type)?;
+        writeln!(&mut migrated, "rule {name}_checks WHEN %{name} NOT EMPTY {{", name = each_type)?;
         writeln!(&mut migrated, "    %{} {{", each_type)?;
         for each_clause in by_type.get(each_type).unwrap() {
             writeln!(&mut migrated, "        {}", *each_clause)?;
@@ -118,26 +117,25 @@ pub(crate) fn aggregate_by_type(rules: &Vec<RuleLineType>) -> HashMap<TypeName, 
                     Rule::Basic(br) => {
                         by_type.entry(br.type_name.clone()).or_insert_with(indexmap::IndexSet::new)
                             .insert(clause);
-                    },
+                    }
                     Rule::Conditional(br) => {
                         by_type.entry(br.type_name.clone()).or_insert_with(indexmap::IndexSet::new)
                             .insert(clause);
                     }
                 }
-
             }
         }
     }
     by_type
 }
 
-pub (crate) fn get_resource_types_in_ruleset(rules: &Vec<RuleLineType>) -> Result<Vec<TypeName>> {
+pub(crate) fn get_resource_types_in_ruleset(rules: &Vec<RuleLineType>) -> Result<Vec<TypeName>> {
     let mut resource_types = HashSet::new();
     for rule in rules {
         if let RuleLineType::Clause(clause) = rule.clone() {
             clause.rules.into_iter().for_each(|rule|
                 match rule {
-                    Rule::Basic(basic_rule) => { resource_types.insert(basic_rule.type_name); },
+                    Rule::Basic(basic_rule) => { resource_types.insert(basic_rule.type_name); }
                     Rule::Conditional(conditional_rule) => { resource_types.insert(conditional_rule.type_name); }
                 }
             );
@@ -148,7 +146,7 @@ pub (crate) fn get_resource_types_in_ruleset(rules: &Vec<RuleLineType>) -> Resul
     Ok(resource_types_list)
 }
 
-pub (crate) fn migrate_rules(rules: Vec<RuleLineType>) -> Result<String> {
+pub(crate) fn migrate_rules(rules: Vec<RuleLineType>) -> Result<String> {
     let aggr_by_type = aggregate_by_type(&rules);
     let migrated_rules = migrated_rules_by_type(&rules, &aggr_by_type)?;
 

--- a/guard/src/commands/mod.rs
+++ b/guard/src/commands/mod.rs
@@ -15,7 +15,7 @@ mod common_test_helpers;
 //
 // Application metadata
 pub const APP_NAME: &str = "cfn-guard";
-pub const APP_VERSION: &'static str = env!("CARGO_PKG_VERSION");
+pub const APP_VERSION: &str = env!("CARGO_PKG_VERSION");
 // Commands
 pub(crate)  const MIGRATE: &str = "migrate";
 pub(crate)  const PARSE_TREE: &str = "parse-tree";
@@ -23,30 +23,30 @@ pub(crate) const RULEGEN: &str = "rulegen";
 pub(crate)  const TEST: &str = "test";
 pub const VALIDATE: &str = "validate";
 // Arguments for validate
-pub(crate) const ALPHABETICAL: (&str, &str) = ("alphabetical", "a");
-pub const DATA: (&str, &str) = ("data", "d");
-pub(crate) const LAST_MODIFIED: (&str, &str) = ("last-modified", "m");
-pub(crate) const OUTPUT_FORMAT: (&str, &str) = ("output-format", "o");
-pub const INPUT_PARAMETERS: (&str, &str) = ("input-parameters", "i");
-pub(crate) const PAYLOAD: (&str, &str) = ("payload", "P");
-pub(crate) const PREVIOUS_ENGINE: (&str, &str) = ("previous-engine","E");
-pub(crate) const PRINT_JSON: (&str, &str) = ("print-json", "p");
-pub(crate) const SHOW_CLAUSE_FAILURES: (&str, &str) = ("show-clause-failures", "s");
-pub(crate) const SHOW_SUMMARY: (&str, &str) = ("show-summary", "S");
-pub(crate) const TYPE: (&str, &str) = ("type", "t");
-pub(crate) const VERBOSE: (&str, &str) = ("verbose", "v");
+pub(crate) const ALPHABETICAL: (&str,char) = ("alphabetical", 'a');
+pub const DATA: (&str,char) = ("data", 'd');
+pub(crate) const LAST_MODIFIED: (&str,char) = ("last-modified", 'm');
+pub(crate) const OUTPUT_FORMAT: (&str,char) = ("output-format", 'o');
+pub const INPUT_PARAMETERS: (&str,char) = ("input-parameters", 'i');
+pub(crate) const PAYLOAD: (&str,char) = ("payload", 'P');
+pub(crate) const PREVIOUS_ENGINE: (&str,char) = ("previous-engine",'E');
+pub(crate) const PRINT_JSON: (&str,char) = ("print-json", 'p');
+pub(crate) const SHOW_CLAUSE_FAILURES: (&str,char) = ("show-clause-failures", 's');
+pub(crate) const SHOW_SUMMARY: (&str,char) = ("show-summary", 'S');
+pub(crate) const TYPE: (&str,char) = ("type", 't');
+pub(crate) const VERBOSE: (&str,char) = ("verbose", 'v');
 // Arguments for validate, migrate, parse tree
-pub const RULES: (&str, &str) = ("rules", "r");
+pub const RULES: (&str, char) = ("rules", 'r');
 // Arguments for migrate, parse-tree, rulegen
-pub(crate) const OUTPUT: (&str, &str) = ("output", "o");
+pub(crate) const OUTPUT: (&str,char) = ("output", 'o');
 // Arguments for parse-tree
-pub(crate) const PRINT_YAML: (&str, &str) = ("print-yaml", "y");
+pub(crate) const PRINT_YAML: (&str,char) = ("print-yaml", 'y');
 // Arguments for test
-pub(crate) const RULES_FILE: (&str, &str) = ("rules-file", "r");
-pub(crate) const TEST_DATA: (&str, &str) = ("test-data", "t");
-pub(crate) const DIRECTORY: (&str, &str) = ("dir", "d");
+pub(crate) const RULES_FILE: (&str,char) = ("rules-file", 'r');
+pub(crate) const TEST_DATA: (&str,char) = ("test-data", 't');
+pub(crate) const DIRECTORY: (&str,char) = ("dir", 'd');
 // Arguments for rulegen
-pub(crate) const TEMPLATE: (&str, &str) = ("template", "t");
+pub(crate) const TEMPLATE: (&str,char) = ("template", 'a');
 // Arg group for validate
 pub(crate)  const REQUIRED_FLAGS: &str = "required_flags";
 // Arg group for test
@@ -54,10 +54,10 @@ pub(crate)  const RULES_AND_TEST_FILE: &str = "rules-and-test-file";
 pub(crate)  const DIRECTORY_ONLY: &str =  "directory-only";
 
 
-pub(crate) const  DATA_FILE_SUPPORTED_EXTENSIONS: [&'static str; 5] = [".yaml",
+pub(crate) const  DATA_FILE_SUPPORTED_EXTENSIONS: [&str; 5] = [".yaml",
                                                                       ".yml",
                                                                       ".json",
                                                                       ".jsn",
                                                                       ".template"];
-pub(crate) const  RULE_FILE_SUPPORTED_EXTENSIONS: [&'static str; 2] = [".guard",
+pub(crate) const  RULE_FILE_SUPPORTED_EXTENSIONS: [&str; 2] = [".guard",
                                                                      ".ruleset"];

--- a/guard/src/commands/mod.rs
+++ b/guard/src/commands/mod.rs
@@ -17,47 +17,49 @@ mod common_test_helpers;
 pub const APP_NAME: &str = "cfn-guard";
 pub const APP_VERSION: &str = env!("CARGO_PKG_VERSION");
 // Commands
-pub(crate)  const MIGRATE: &str = "migrate";
-pub(crate)  const PARSE_TREE: &str = "parse-tree";
+pub(crate) const MIGRATE: &str = "migrate";
+pub(crate) const PARSE_TREE: &str = "parse-tree";
 pub(crate) const RULEGEN: &str = "rulegen";
-pub(crate)  const TEST: &str = "test";
+pub(crate) const TEST: &str = "test";
 pub const VALIDATE: &str = "validate";
 // Arguments for validate
-pub(crate) const ALPHABETICAL: (&str,char) = ("alphabetical", 'a');
-pub const DATA: (&str,char) = ("data", 'd');
-pub(crate) const LAST_MODIFIED: (&str,char) = ("last-modified", 'm');
-pub(crate) const OUTPUT_FORMAT: (&str,char) = ("output-format", 'o');
-pub const INPUT_PARAMETERS: (&str,char) = ("input-parameters", 'i');
-pub(crate) const PAYLOAD: (&str,char) = ("payload", 'P');
-pub(crate) const PREVIOUS_ENGINE: (&str,char) = ("previous-engine",'E');
-pub(crate) const PRINT_JSON: (&str,char) = ("print-json", 'p');
-pub(crate) const SHOW_CLAUSE_FAILURES: (&str,char) = ("show-clause-failures", 's');
-pub(crate) const SHOW_SUMMARY: (&str,char) = ("show-summary", 'S');
-pub(crate) const TYPE: (&str,char) = ("type", 't');
-pub(crate) const VERBOSE: (&str,char) = ("verbose", 'v');
+pub(crate) const ALPHABETICAL: (&str, char) = ("alphabetical", 'a');
+pub const DATA: (&str, char) = ("data", 'd');
+pub(crate) const LAST_MODIFIED: (&str, char) = ("last-modified", 'm');
+pub(crate) const OUTPUT_FORMAT: (&str, char) = ("output-format", 'o');
+pub const INPUT_PARAMETERS: (&str, char) = ("input-parameters", 'i');
+pub(crate) const PAYLOAD: (&str, char) = ("payload", 'P');
+pub(crate) const PREVIOUS_ENGINE: (&str, char) = ("previous-engine", 'E');
+pub(crate) const PRINT_JSON: (&str, char) = ("print-json", 'p');
+pub(crate) const SHOW_CLAUSE_FAILURES: (&str, char) = ("show-clause-failures", 's');
+pub(crate) const SHOW_SUMMARY: (&str, char) = ("show-summary", 'S');
+pub(crate) const TYPE: (&str, char) = ("type", 't');
+pub(crate) const VERBOSE: (&str, char) = ("verbose", 'v');
 // Arguments for validate, migrate, parse tree
 pub const RULES: (&str, char) = ("rules", 'r');
 // Arguments for migrate, parse-tree, rulegen
-pub(crate) const OUTPUT: (&str,char) = ("output", 'o');
+pub(crate) const OUTPUT: (&str, char) = ("output", 'o');
 // Arguments for parse-tree
-pub(crate) const PRINT_YAML: (&str,char) = ("print-yaml", 'y');
+pub(crate) const PRINT_YAML: (&str, char) = ("print-yaml", 'y');
 // Arguments for test
-pub(crate) const RULES_FILE: (&str,char) = ("rules-file", 'r');
-pub(crate) const TEST_DATA: (&str,char) = ("test-data", 't');
-pub(crate) const DIRECTORY: (&str,char) = ("dir", 'd');
+pub(crate) const RULES_FILE: (&str, char) = ("rules-file", 'r');
+pub(crate) const TEST_DATA: (&str, char) = ("test-data", 't');
+pub(crate) const DIRECTORY: (&str, char) = ("dir", 'd');
 // Arguments for rulegen
-pub(crate) const TEMPLATE: (&str,char) = ("template", 'a');
+pub(crate) const TEMPLATE: (&str, char) = ("template", 'a');
 // Arg group for validate
-pub(crate)  const REQUIRED_FLAGS: &str = "required_flags";
+pub(crate) const REQUIRED_FLAGS: &str = "required_flags";
 // Arg group for test
-pub(crate)  const RULES_AND_TEST_FILE: &str = "rules-and-test-file";
-pub(crate)  const DIRECTORY_ONLY: &str =  "directory-only";
+pub(crate) const RULES_AND_TEST_FILE: &str = "rules-and-test-file";
+pub(crate) const DIRECTORY_ONLY: &str = "directory-only";
 
 
-pub(crate) const  DATA_FILE_SUPPORTED_EXTENSIONS: [&str; 5] = [".yaml",
-                                                                      ".yml",
-                                                                      ".json",
-                                                                      ".jsn",
-                                                                      ".template"];
-pub(crate) const  RULE_FILE_SUPPORTED_EXTENSIONS: [&str; 2] = [".guard",
-                                                                     ".ruleset"];
+pub(crate) const DATA_FILE_SUPPORTED_EXTENSIONS: [&str; 5] = [
+    ".yaml",
+    ".yml",
+    ".json",
+    ".jsn",
+    ".template"
+];
+pub(crate) const RULE_FILE_SUPPORTED_EXTENSIONS: [&str; 2] = [".guard",
+    ".ruleset"];

--- a/guard/src/commands/parse_tree.rs
+++ b/guard/src/commands/parse_tree.rs
@@ -1,5 +1,7 @@
-use std::fs::{File};
-use clap::{App, Arg, ArgMatches};
+use std::fs::File;
+
+use clap::{Arg, ArgMatches};
+
 use crate::command::Command;
 use crate::commands::{OUTPUT, PARSE_TREE, PRINT_JSON, PRINT_YAML, RULES};
 use crate::rules:: Result;
@@ -19,33 +21,32 @@ impl Command for ParseTree {
     }
 
 
-    fn command(&self) -> App<'static> {
-        App::new(PARSE_TREE)
+    fn command(&self) -> clap::Command {
+        clap::Command::new(PARSE_TREE)
             .about(r#"Prints out the parse tree for the rules defined in the file.
 "#)
-            .arg(Arg::with_name(RULES.0).long(RULES.0).short(RULES.1).takes_value(true).help("Provide a rules file").required(false))
-            .arg(Arg::with_name(OUTPUT.0).long(OUTPUT.0).short(OUTPUT.1).takes_value(true).help("Write to output file").required(false))
-            .arg(Arg::with_name(PRINT_JSON.0).long(PRINT_JSON.0).short(PRINT_JSON.1).required(false)
+            .arg(Arg::new(RULES.0).long(RULES.0).short(RULES.1).help("Provide a rules file").required(false))
+            .arg(Arg::new(OUTPUT.0).long(OUTPUT.0).short(OUTPUT.1).help("Write to output file").required(false))
+            .arg(Arg::new(PRINT_JSON.0).long(PRINT_JSON.0).short(PRINT_JSON.1).required(false)
                 .help("Print output in JSON format"))
-            .arg(Arg::with_name(PRINT_YAML.0).long(PRINT_YAML.0).short(PRINT_YAML.1).required(false)
+            .arg(Arg::new(PRINT_YAML.0).long(PRINT_YAML.0).short(PRINT_YAML.1).required(false)
                 .help("Print output in YAML format"))
     }
 
     fn execute(&self, app: &ArgMatches) -> Result<i32> {
-
-        let mut file: Box<dyn std::io::Read> = match app.value_of(RULES.0) {
+        let mut file: Box<dyn std::io::Read> = match app.get_one::<String>(RULES.0) {
             Some(file) => Box::new(std::io::BufReader::new(File::open(file)?)),
             None => {
                 Box::new(std::io::stdin())
             }
         };
 
-        let out= match app.value_of(OUTPUT.0) {
-                Some(file) => Box::new(File::create(file)?) as Box<dyn std::io::Write>,
+        let out = match app.get_one::<String>(OUTPUT.0) {
+            Some(file) => Box::new(File::create(file)?) as Box<dyn std::io::Write>,
             None => Box::new(std::io::stdout()) as Box<dyn std::io::Write>
         };
 
-        let yaml = !app.is_present(PRINT_JSON.0);
+        let yaml = !app.contains_id(PRINT_JSON.0);
         let mut content = String::new();
         file.read_to_string(&mut content)?;
         let span = crate::rules::parser::Span::new_extra(&content, "");
@@ -65,6 +66,6 @@ impl Command for ParseTree {
             }
         }
 
-        Ok(0 as i32)
+        Ok(0_i32)
     }
 }

--- a/guard/src/commands/parse_tree.rs
+++ b/guard/src/commands/parse_tree.rs
@@ -19,7 +19,7 @@ impl Command for ParseTree {
     }
 
 
-    fn command(&self) -> App<'static, 'static> {
+    fn command(&self) -> App<'static> {
         App::new(PARSE_TREE)
             .about(r#"Prints out the parse tree for the rules defined in the file.
 "#)
@@ -31,7 +31,7 @@ impl Command for ParseTree {
                 .help("Print output in YAML format"))
     }
 
-    fn execute(&self, app: &ArgMatches<'_>) -> Result<i32> {
+    fn execute(&self, app: &ArgMatches) -> Result<i32> {
 
         let mut file: Box<dyn std::io::Read> = match app.value_of(RULES.0) {
             Some(file) => Box::new(std::io::BufReader::new(File::open(file)?)),

--- a/guard/src/commands/parse_tree.rs
+++ b/guard/src/commands/parse_tree.rs
@@ -4,14 +4,14 @@ use clap::{Arg, ArgMatches};
 
 use crate::command::Command;
 use crate::commands::{OUTPUT, PARSE_TREE, PRINT_JSON, PRINT_YAML, RULES};
-use crate::rules:: Result;
+use crate::rules::Result;
 
 #[derive(Clone, Copy, Eq, PartialEq)]
 pub(crate) struct ParseTree {}
 
 impl ParseTree {
     pub(crate) fn new() -> Self {
-        ParseTree{}
+        ParseTree {}
     }
 }
 
@@ -54,13 +54,12 @@ impl Command for ParseTree {
             Err(e) => {
                 println!("Parsing error handling rule, Error = {}", e);
                 return Err(e);
-            },
+            }
 
             Ok(rules) => {
                 if yaml {
                     serde_yaml::to_writer(out, &rules)?;
-                }
-                else {
+                } else {
                     serde_json::to_writer(out, &rules)?;
                 }
             }

--- a/guard/src/commands/rulegen.rs
+++ b/guard/src/commands/rulegen.rs
@@ -24,7 +24,7 @@ impl Command for Rulegen {
     fn name(&self) -> &'static str { RULEGEN }
 
 
-    fn command(&self) -> App<'static, 'static> {
+    fn command(&self) -> App<'static> {
         App::new(RULEGEN)
             .about(r#"Autogenerate rules from an existing JSON- or YAML- formatted data. (Currently works with only CloudFormation templates)
 "#)
@@ -32,7 +32,7 @@ impl Command for Rulegen {
             .arg(Arg::with_name(OUTPUT.0).long(OUTPUT.0).short(OUTPUT.1).takes_value(true).help("Write to output file").required(false))
     }
 
-    fn execute(&self, app: &ArgMatches<'_>) -> Result<i32> {
+    fn execute(&self, app: &ArgMatches) -> Result<i32> {
         let file = app.value_of(TEMPLATE.0).unwrap();
         let template_contents = fs::read_to_string(file)?;
 

--- a/guard/src/commands/rulegen.rs
+++ b/guard/src/commands/rulegen.rs
@@ -50,13 +50,13 @@ impl Command for Rulegen {
     }
 }
 
-pub fn parse_template_and_call_gen(template_contents: &str) -> HashMap<String, HashMap<String, HashSet<String>>>{
+pub fn parse_template_and_call_gen(template_contents: &str) -> HashMap<String, HashMap<String, HashSet<String>>> {
     let cfn_template: HashMap<String, Value> = match serde_yaml::from_str(template_contents) {
         Ok(s) => s,
         Err(e) => {
             println!("Parsing error handling template file, Error = {}", e);
             process::exit(1);
-        },
+        }
     };
 
     let cfn_resources_clone = match cfn_template.get("Resources") {
@@ -130,7 +130,7 @@ fn gen_rules(cfn_resources: HashMap<String, Value>) -> HashMap<String, HashMap<S
 
             // Preserve double quotes for strings.
             if prop_val.is_string() {
-                let test_str = format!("{}{}{}", "\"" , no_newline_stripped_val, "\"");
+                let test_str = format!("{}{}{}", "\"", no_newline_stripped_val, "\"");
                 no_newline_stripped_val = test_str;
             }
             let resource_name = (&cfn_resource["Type"].as_str().unwrap()).to_string();
@@ -170,7 +170,7 @@ fn gen_rules(cfn_resources: HashMap<String, Value>) -> HashMap<String, HashMap<S
 //          %aws_ec2_volume_resources.Properties.AvailabilityZone IN ["us-west-2b", "us-west-2c"]
 //          %aws_ec2_volume_resources.Properties.Encrypted == false
 //     }
-fn print_rules(rule_map : HashMap<String, HashMap<String, HashSet<String>>>, mut writer : Box<dyn std::io::Write>) -> Result<()> {
+fn print_rules(rule_map: HashMap<String, HashMap<String, HashSet<String>>>, mut writer: Box<dyn std::io::Write>) -> Result<()> {
     let mut str = Builder::default();
 
     for (resource, properties) in &rule_map {
@@ -200,11 +200,11 @@ fn print_rules(rule_map : HashMap<String, HashMap<String, HashSet<String>>>, mut
             //
             // TODO fix with Error return
             //
-            write!(writer,"{}", generated_rules)?;
-        },
+            write!(writer, "{}", generated_rules)?;
+        }
         Err(e) => {
             println!("Parsing error with generated rules file, Error = {}", e);
-        },
+        }
     }
     Ok(())
 }

--- a/guard/src/commands/test.rs
+++ b/guard/src/commands/test.rs
@@ -10,22 +10,22 @@ use walkdir::DirEntry;
 use validate::validate_path;
 
 use crate::command::Command;
+use crate::commands::{
+    ALPHABETICAL, DIRECTORY, DIRECTORY_ONLY, LAST_MODIFIED, PREVIOUS_ENGINE, RULES_AND_TEST_FILE,
+    RULES_FILE, TEST, TEST_DATA, validate, VERBOSE,
+};
 use crate::commands::files::{
     alpabetical, get_files_with_filter, iterate_over, last_modified, read_file_content,
     regular_ordering,
 };
 use crate::commands::tracker::StackTracker;
-use crate::commands::{
-    validate, ALPHABETICAL, DIRECTORY, DIRECTORY_ONLY, LAST_MODIFIED, PREVIOUS_ENGINE,
-    RULES_AND_TEST_FILE, RULES_FILE, TEST, TEST_DATA, VERBOSE,
-};
+use crate::rules::{Evaluate, NamedStatus, RecordType, Result, Status};
 use crate::rules::errors::{Error, ErrorKind};
 use crate::rules::eval::eval_rules_file;
 use crate::rules::evaluate::RootScope;
 use crate::rules::exprs::RulesFile;
 use crate::rules::path_value::PathAwareValue;
 use crate::rules::Status::SKIP;
-use crate::rules::{Evaluate, NamedStatus, RecordType, Result, Status};
 
 #[derive(Clone, Copy, Eq, PartialEq)]
 pub(crate) struct Test {}
@@ -41,7 +41,7 @@ impl Command for Test {
         TEST
     }
 
-    fn command(&self) -> App<'static, 'static> {
+    fn command(&self) -> App<'static> {
         App::new(TEST)
             .about(r#"Built in unit testing capability to validate a Guard rules file against
 unit tests specified in YAML format to determine each individual rule's success
@@ -77,7 +77,7 @@ or failure testing.
                 .help("Verbose logging"))
     }
 
-    fn execute(&self, app: &ArgMatches<'_>) -> Result<i32> {
+    fn execute(&self, app: &ArgMatches) -> Result<i32> {
         let mut exit_code = 0;
         let cmp = if let Some(_ignored) = app.value_of(ALPHABETICAL.0) {
             alpabetical

--- a/guard/src/commands/test.rs
+++ b/guard/src/commands/test.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{btree_map::BTreeMap, HashMap};
 use std::convert::TryFrom;
 use std::fs::File;
 use std::path::PathBuf;
@@ -181,7 +181,7 @@ or failure testing.
                         Err(e) => {
                             eprintln!("Parse Error on ruleset file {}", e);
                             exit_code = 1;
-                        },
+                        }
                         Ok(rules) => {
                             let data_test_files = each_rule_file
                                 .test_files
@@ -238,14 +238,14 @@ or failure testing.
                     Err(e) => {
                         eprintln!("Unable to read rule file content {}", e);
                         exit_code = 1;
-                    },
+                    }
                     Ok((context, path)) => {
                         let span = crate::rules::parser::Span::new_extra(&context, &path);
                         match crate::rules::parser::rules_file(span) {
                             Err(e) => {
                                 eprintln!("Parse Error on ruleset file {}", e);
                                 exit_code = 1;
-                            },
+                            }
                             Ok(rules) => {
                                 let curr_exit_code =
                                     test_with_data(&data_test_files, &rules, verbose, new_engine)?;
@@ -301,7 +301,7 @@ fn test_with_data(
             Err(e) => {
                 eprintln!("Error processing {}", e);
                 exit_code = 1;
-            },
+            }
             Ok(specs) => {
                 for each in specs {
                     println!("Test Case #{}", test_counter);
@@ -318,7 +318,7 @@ fn test_with_data(
 
                         let by_rules = top.children.iter().fold(HashMap::new(), |mut acc, rule| {
                             if let Some(RecordType::RuleCheck(NamedStatus { name, .. })) =
-                                rule.container
+                            rule.container
                             {
                                 acc.entry(name).or_insert(vec![]).push(&rule.container)
                             }
@@ -343,9 +343,9 @@ fn test_with_data(
 
                                 for each in rule.iter().copied().flatten() {
                                     if let RecordType::RuleCheck(NamedStatus {
-                                        status: got_status,
-                                        ..
-                                    }) = each
+                                                                     status: got_status,
+                                                                     ..
+                                                                 }) = each
                                     {
                                         match expected {
                                             SKIP => {
@@ -409,7 +409,7 @@ fn test_with_data(
                                     Err(e) => {
                                         eprintln!("Incorrect STATUS provided {}", e);
                                         exit_code = 1;
-                                    },
+                                    }
                                     Ok(status) => {
                                         let got = each.status.unwrap();
                                         if status != got {

--- a/guard/src/commands/validate.rs
+++ b/guard/src/commands/validate.rs
@@ -14,25 +14,25 @@ use serde::Deserialize;
 use Type::CFNTemplate;
 
 use crate::command::Command;
+use crate::commands::{
+    ALPHABETICAL, DATA, DATA_FILE_SUPPORTED_EXTENSIONS, INPUT_PARAMETERS, LAST_MODIFIED,
+    OUTPUT_FORMAT, PAYLOAD, PREVIOUS_ENGINE, PRINT_JSON, REQUIRED_FLAGS, RULE_FILE_SUPPORTED_EXTENSIONS,
+    RULES, SHOW_CLAUSE_FAILURES, SHOW_SUMMARY, TYPE, VALIDATE, VERBOSE,
+};
 use crate::commands::aws_meta_appender::MetadataAppender;
 use crate::commands::files::{alpabetical, iterate_over, last_modified};
 use crate::commands::tracker::{StackTracker, StatusContext};
 use crate::commands::validate::summary_table::SummaryType;
 use crate::commands::validate::tf::TfAware;
-use crate::commands::{
-    ALPHABETICAL, DATA, DATA_FILE_SUPPORTED_EXTENSIONS, INPUT_PARAMETERS, LAST_MODIFIED,
-    OUTPUT_FORMAT, PAYLOAD, PREVIOUS_ENGINE, PRINT_JSON, REQUIRED_FLAGS, RULES,
-    RULE_FILE_SUPPORTED_EXTENSIONS, SHOW_CLAUSE_FAILURES, SHOW_SUMMARY, TYPE, VALIDATE, VERBOSE,
-};
+use crate::rules::{Evaluate, EvaluationContext, EvaluationType, Result, Status};
 use crate::rules::errors::{Error, ErrorKind};
 use crate::rules::eval::eval_rules_file;
-use crate::rules::eval_context::{root_scope, simplifed_json_from_root, EventRecord};
+use crate::rules::eval_context::{EventRecord, root_scope, simplifed_json_from_root};
 use crate::rules::evaluate::RootScope;
 use crate::rules::exprs::RulesFile;
-use crate::rules::path_value::traversal::Traversal;
 use crate::rules::path_value::PathAwareValue;
+use crate::rules::path_value::traversal::Traversal;
 use crate::rules::values::CmpOperator;
-use crate::rules::{Evaluate, EvaluationContext, EvaluationType, Result, Status};
 
 mod cfn;
 mod cfn_reporter;
@@ -115,7 +115,7 @@ impl Command for Validate {
         VALIDATE
     }
 
-    fn command(&self) -> App<'static, 'static> {
+    fn command(&self) -> App<'static> {
         App::new(VALIDATE)
             .about(r#"Evaluates rules against the data files to determine success or failure.
 You can point rules flag to a rules directory and point data flag to a data directory.
@@ -172,7 +172,7 @@ or rules files.
                 .required(true))
     }
 
-    fn execute(&self, app: &ArgMatches<'_>) -> Result<i32> {
+    fn execute(&self, app: &ArgMatches) -> Result<i32> {
         let cmp = if app.is_present(LAST_MODIFIED.0) {
             last_modified
         } else {

--- a/guard/src/commands/validate.rs
+++ b/guard/src/commands/validate.rs
@@ -6,7 +6,7 @@ use std::io::{BufReader, Read, Write};
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
-use clap::{App, Arg, ArgGroup, ArgMatches};
+use clap::{Arg, ArgAction, ArgGroup, ArgMatches};
 use colored::*;
 use enumflags2::BitFlags;
 use serde::Deserialize;
@@ -41,6 +41,7 @@ mod console_reporter;
 pub(crate) mod generic_summary;
 mod summary_table;
 mod tf;
+
 
 #[derive(Eq, Clone, Debug, PartialEq)]
 pub(crate) struct DataFile {
@@ -115,8 +116,8 @@ impl Command for Validate {
         VALIDATE
     }
 
-    fn command(&self) -> App<'static> {
-        App::new(VALIDATE)
+    fn command(&self) -> clap::Command {
+        clap::Command::new(VALIDATE)
             .about(r#"Evaluates rules against the data files to determine success or failure.
 You can point rules flag to a rules directory and point data flag to a data directory.
 When pointed to a directory it will read all rules in the directory file and evaluate
@@ -125,55 +126,95 @@ single file and it would work as well.
 Note - When pointing the command to a directory, the directory may not contain a mix of
 rules and data files. The directory being pointed to must contain only data files,
 or rules files.
-"#)
-            .arg(Arg::with_name(RULES.0).long(RULES.0).short(RULES.1).takes_value(true)
-                .help("Provide a rules file or a directory of rules files. Supports passing multiple values by using this option repeatedly.\
+"#).arg(Arg::new(RULES.0)
+            .long(RULES.0)
+            .short(RULES.1)
+            .action(ArgAction::Append)
+            .help("Provide a rules file or a directory of rules files. Supports passing multiple values by using this option repeatedly.\
                           \nExample:\n --rules rule1.guard --rules ./rules-dir1 --rules rule2.guard\
                           \nFor directory arguments such as `rules-dir1` above, scanning is only supported for files with following extensions: .guard, .ruleset")
-                .multiple(true).conflicts_with("payload"))
-            .arg(Arg::with_name(DATA.0).long(DATA.0).short(DATA.1).takes_value(true)
+            .conflicts_with("payload"))
+            .arg(Arg::new(DATA.0)
+                .long(DATA.0)
+                .short(DATA.1)
+                .action(ArgAction::Append)
                 .help("Provide a data file or directory of data files in JSON or YAML. Supports passing multiple values by using this option repeatedly.\
                           \nExample:\n --data template1.yaml --data ./data-dir1 --data template2.yaml\
                           \nFor directory arguments such as `data-dir1` above, scanning is only supported for files with following extensions: .yaml, .yml, .json, .jsn, .template")
-                .multiple(true).conflicts_with("payload"))
-            .arg(Arg::with_name(INPUT_PARAMETERS.0).long(INPUT_PARAMETERS.0).short(INPUT_PARAMETERS.1).takes_value(true)
-                     .help("Provide a data file or directory of data files in JSON or YAML that specifies any additional parameters to use along with data files to be used as a combined context. \
+                .conflicts_with("payload"))
+            .arg(Arg::new(INPUT_PARAMETERS.0)
+                .long(INPUT_PARAMETERS.0)
+                .short(INPUT_PARAMETERS.1)
+                .action(ArgAction::Append)
+                .help("Provide a data file or directory of data files in JSON or YAML that specifies any additional parameters to use along with data files to be used as a combined context. \
                            All the parameter files passed as input get merged and this combined context is again merged with each file passed as an argument for `data`. Due to this, every file is \
                            expected to contain mutually exclusive properties, without any overlap. Supports passing multiple values by using this option repeatedly.\
                           \nExample:\n --input-parameters param1.yaml --input-parameters ./param-dir1 --input-parameters param2.yaml\
-                          \nFor directory arguments such as `param-dir1` above, scanning is only supported for files with following extensions: .yaml, .yml, .json, .jsn, .template")
-                     .multiple(true))
-            .arg(Arg::with_name(TYPE.0).long(TYPE.0).short(TYPE.1).takes_value(true).possible_values(&["CFNTemplate"])
+                          \nFor directory arguments such as `param-dir1` above, scanning is only supported for files with following extensions: .yaml, .yml, .json, .jsn, .template"))
+            .arg(Arg::new(TYPE.0)
+                .long(TYPE.0)
+                .short(TYPE.1)
+                .value_parser(["CFNTemplate"])
                 .help("Specify the type of data file used for improved messaging"))
-            .arg(Arg::with_name(OUTPUT_FORMAT.0).long(OUTPUT_FORMAT.0).short(OUTPUT_FORMAT.1).takes_value(true)
-                .possible_values(&["json","yaml","single-line-summary"])
+            .arg(Arg::new(OUTPUT_FORMAT.0)
+                .long(OUTPUT_FORMAT.0)
+                .short(OUTPUT_FORMAT.1)
+                .value_parser(["json", "yaml", "single-line-summary"])
                 .default_value("single-line-summary")
                 .help("Specify the format in which the output should be displayed"))
-            .arg(Arg::with_name(PREVIOUS_ENGINE.0).long(PREVIOUS_ENGINE.0).short(PREVIOUS_ENGINE.1).takes_value(false)
-                .help("Uses the old engine for evaluation. This parameter will allow customers to evaluate old changes before migrating"))
-            .arg(Arg::with_name(SHOW_SUMMARY.0).long(SHOW_SUMMARY.0).short(SHOW_SUMMARY.1).takes_value(true).use_delimiter(true).multiple(true)
-                .possible_values(&["none", "all", "pass", "fail", "skip"])
+            .arg(Arg::new(PREVIOUS_ENGINE.0)
+                .long(PREVIOUS_ENGINE.0)
+                .short(PREVIOUS_ENGINE.1)
+                .help("Uses the old engine for evaluation. This parameter will allow customers to evaluate old changes before migrating")
+                .action(ArgAction::Append))
+            .arg(Arg::new(SHOW_SUMMARY.0)
+                .long(SHOW_SUMMARY.0)
+                .short(SHOW_SUMMARY.1)
+                .value_parser(["none", "all", "pass", "fail", "skip"])
                 .default_value("fail")
+                .action(ArgAction::Append)
                 .help("Controls if the summary table needs to be displayed. --show-summary fail (default) or --show-summary pass,fail (only show rules that did pass/fail) or --show-summary none (to turn it off) or --show-summary all (to show all the rules that pass, fail or skip)"))
-            .arg(Arg::with_name(SHOW_CLAUSE_FAILURES.0).long(SHOW_CLAUSE_FAILURES.0).short(SHOW_CLAUSE_FAILURES.1).takes_value(false).required(false)
+            .arg(Arg::new(SHOW_CLAUSE_FAILURES.0)
+                .long(SHOW_CLAUSE_FAILURES.0)
+                .short(SHOW_CLAUSE_FAILURES.1)
+                .required(false)
+                .num_args(0)
                 .help("Show clause failure along with summary"))
-            .arg(Arg::with_name(ALPHABETICAL.0).long(ALPHABETICAL.0).short(ALPHABETICAL.1).required(false).help("Validate files in a directory ordered alphabetically"))
-            .arg(Arg::with_name(LAST_MODIFIED.0).long(LAST_MODIFIED.0).short(LAST_MODIFIED.1).required(false).conflicts_with(ALPHABETICAL.0)
+            .arg(Arg::new(ALPHABETICAL.0)
+                .long(ALPHABETICAL.0)
+                .short(ALPHABETICAL.1)
+                .num_args(0)
+                .required(false)
+                .help("Validate files in a directory ordered alphabetically"))
+            .arg(Arg::new(LAST_MODIFIED.0)
+                .long(LAST_MODIFIED.0)
+                .short(LAST_MODIFIED.1)
+                .num_args(0)
+                .required(false)
+                .conflicts_with(ALPHABETICAL.0)
                 .help("Validate files in a directory ordered by last modified times"))
-            .arg(Arg::with_name(VERBOSE.0).long(VERBOSE.0).short(VERBOSE.1).required(false)
+            .arg(Arg::new(VERBOSE.0)
+                .long(VERBOSE.0)
+                .short(VERBOSE.1)
+                .num_args(0)
+                .required(false)
                 .help("Verbose logging"))
-            .arg(Arg::with_name(PRINT_JSON.0).long(PRINT_JSON.0).short(PRINT_JSON.1).required(false)
+            .arg(Arg::new(PRINT_JSON.0)
+                .long(PRINT_JSON.0)
+                .short(PRINT_JSON.1)
+                .num_args(0)
+                .required(false)
                 .help("Print output in json format"))
-            .arg(Arg::with_name(PAYLOAD.0).long(PAYLOAD.0).short(PAYLOAD.1)
+            .arg(Arg::new(PAYLOAD.0)
+                .long(PAYLOAD.0)
+                .short(PAYLOAD.1)
                 .help("Provide rules and data in the following JSON format via STDIN,\n{\"rules\":[\"<rules 1>\", \"<rules 2>\", ...], \"data\":[\"<data 1>\", \"<data 2>\", ...]}, where,\n- \"rules\" takes a list of string \
                 version of rules files as its value and\n- \"data\" takes a list of string version of data files as it value.\nWhen --payload is specified --rules and --data cannot be specified."))
-            .group(ArgGroup::with_name(REQUIRED_FLAGS)
-                .args(&[RULES.0, PAYLOAD.0])
-                .required(true))
+            .group(ArgGroup::new(REQUIRED_FLAGS).args([RULES.0, PAYLOAD.0]).required(true))
     }
 
     fn execute(&self, app: &ArgMatches) -> Result<i32> {
-        let cmp = if app.is_present(LAST_MODIFIED.0) {
+        let cmp = if app.contains_id(LAST_MODIFIED.0) {
             last_modified
         } else {
             alpabetical
@@ -181,7 +222,7 @@ or rules files.
 
         let empty_path = Path::new("");
         let mut streams: Vec<DataFile> = Vec::new();
-        let data_files: Vec<DataFile> = match app.values_of(DATA.0) {
+        let data_files: Vec<DataFile> = match app.get_many::<String>(DATA.0) {
             Some(list_of_file_or_dir) => {
                 for file_or_dir in list_of_file_or_dir {
                     validate_path(file_or_dir)?;
@@ -223,7 +264,7 @@ or rules files.
                 streams
             }
             None => {
-                if app.is_present(RULES.0) {
+                if app.contains_id(RULES.0) {
                     let mut content = String::new();
                     let mut reader = BufReader::new(std::io::stdin());
                     reader.read_to_string(&mut content)?;
@@ -243,7 +284,7 @@ or rules files.
             }
         };
 
-        let extra_data = match app.values_of(INPUT_PARAMETERS.0) {
+        let extra_data = match app.get_many::<String>(INPUT_PARAMETERS.0) {
             Some(list_of_file_or_dir) => {
                 let mut primary_path_value: Option<PathAwareValue> = None;
                 for file_or_dir in list_of_file_or_dir {
@@ -276,11 +317,11 @@ or rules files.
             None => None,
         };
 
-        let verbose = app.is_present(VERBOSE.0);
+        let verbose = app.contains_id(VERBOSE.0);
 
-        let data_type = match app.value_of(TYPE.0) {
+        let data_type = match app.get_one::<&str>(TYPE.0) {
             Some(t) => {
-                if t == "CFNTemplate" {
+                if *t == "CFNTemplate" {
                     CFNTemplate
                 } else {
                     Type::Generic
@@ -289,11 +330,11 @@ or rules files.
             None => Type::Generic,
         };
 
-        let output_type = match app.value_of(OUTPUT_FORMAT.0) {
+        let output_type = match app.get_one::<String>(OUTPUT_FORMAT.0) {
             Some(o) => {
-                if o == "single-line-summary" {
+                if *o == "single-line-summary" {
                     OutputFormatType::SingleLineSummary
-                } else if o == "json" {
+                } else if *o == "json" {
                     OutputFormatType::JSON
                 } else {
                     OutputFormatType::YAML
@@ -303,10 +344,10 @@ or rules files.
         };
 
         let summary_type: BitFlags<SummaryType> =
-            app.values_of(SHOW_SUMMARY.0)
+            app.get_many::<String>(SHOW_SUMMARY.0)
                 .map_or(SummaryType::FAIL.into(), |v| {
                     v.fold(BitFlags::empty(), |mut st, elem| {
-                        match elem {
+                        match elem.as_str() {
                             "pass" => st.insert(SummaryType::PASS),
                             "fail" => st.insert(SummaryType::FAIL),
                             "skip" => st.insert(SummaryType::SKIP),
@@ -320,13 +361,13 @@ or rules files.
                     })
                 });
 
-        let print_json = app.is_present(PRINT_JSON.0);
-        let show_clause_failures = app.is_present(SHOW_CLAUSE_FAILURES.0);
-        let new_version_eval_engine = !app.is_present(PREVIOUS_ENGINE.0);
+        let print_json = app.contains_id(PRINT_JSON.0);
+        let show_clause_failures = app.contains_id(SHOW_CLAUSE_FAILURES.0);
+        let new_version_eval_engine = !app.contains_id(PREVIOUS_ENGINE.0);
 
         let mut exit_code = 0;
-        if app.is_present(RULES.0) {
-            let list_of_file_or_dir = app.values_of(RULES.0).unwrap();
+        if app.contains_id(RULES.0) {
+            let list_of_file_or_dir = app.get_many::<String>(RULES.0).unwrap();
             let mut rules = Vec::new();
             for file_or_dir in list_of_file_or_dir {
                 validate_path(file_or_dir)?;

--- a/guard/src/commands/validate.rs
+++ b/guard/src/commands/validate.rs
@@ -382,12 +382,12 @@ or rules files.
                     {
                         if entry.path().is_file()
                             && entry
-                                .path()
-                                .file_name()
-                                .and_then(|s| s.to_str())
-                                .map_or(false, |s| {
-                                    has_a_supported_extension(s, &RULE_FILE_SUPPORTED_EXTENSIONS)
-                                })
+                            .path()
+                            .file_name()
+                            .and_then(|s| s.to_str())
+                            .map_or(false, |s| {
+                                has_a_supported_extension(s, &RULE_FILE_SUPPORTED_EXTENSIONS)
+                            })
                         {
                             rules.push(entry.path().to_path_buf());
                         }
@@ -603,7 +603,7 @@ pub(super) fn print_context(cxt: &StatusContext, depth: usize) {
         cxt.context,
         common::colored_string(cxt.status)
     )
-    .underline();
+        .underline();
     //let depth = cxt.indent;
     let _sub_indent = depth + 1;
     indent_spaces(depth - 1);
@@ -654,7 +654,7 @@ fn print_failing_clause(rules_file_name: &str, rule: &StatusContext, longest: us
             common::colored_string(matched.status),
             matched.context
         )
-        .underline();
+            .underline();
         if !first {
             print!("{space:>longest$}", space = " ", longest = longest + 4)
         }

--- a/guard/src/main.rs
+++ b/guard/src/main.rs
@@ -1,75 +1,71 @@
-use clap::App;
 use std::collections::HashMap;
+use std::process::exit;
 
+use clap::{App, AppFlags, ArgGroup, ArgMatches};
+use clap::error::ContextKind::Usage;
+use nom::combinator::map;
 
-mod rules;
-mod commands;
-mod command;
-mod migrate;
-mod utils;
+use rules::errors::Error;
 
 use crate::command::Command;
-use rules::errors::Error;
-use std::process::exit;
 use crate::commands::{APP_NAME, APP_VERSION};
 
+mod command;
+mod commands;
+mod migrate;
+mod rules;
+mod utils;
 
-
-fn main() -> Result<(), Error>{
-    let mut app =
-        App::new(APP_NAME)
-            .version(APP_VERSION)
-            .about(r#"
+fn main() -> Result<(), Error> {
+    let mut app = App::new(APP_NAME).version(APP_VERSION).about(
+        r#"
   Guard is a general-purpose tool that provides a simple declarative syntax to define 
   policy-as-code as rules to validate against any structured hierarchical data (like JSON/YAML).
   Rules are composed of clauses expressed using Conjunctive Normal Form
   (fancy way of saying it is a logical AND of OR clauses). Guard has deep
   integration with CloudFormation templates for evaluation but is a general tool
-  that equally works for any JSON- and YAML- data."#);
+  that equally works for any JSON- and YAML- data."#,
+    );
 
     let mut commands: Vec<Box<dyn Command>> = Vec::with_capacity(2);
-    commands.push(Box::new(crate::commands::parse_tree::ParseTree::new()));
-    commands.push(Box::new(crate::commands::test::Test::new()));
-    commands.push(Box::new(crate::commands::validate::Validate::new()));
-    commands.push(Box::new(crate::commands::rulegen::Rulegen::new()));
-    commands.push(Box::new(crate::commands::migrate::Migrate::new()));
+    commands.push(Box::new(commands::parse_tree::ParseTree::new()));
+    commands.push(Box::new(commands::test::Test::new()));
+    commands.push(Box::new(commands::validate::Validate::new()));
+    commands.push(Box::new(commands::rulegen::Rulegen::new()));
+    commands.push(Box::new(commands::migrate::Migrate::new()));
 
-    let mappings = commands.iter()
-        .map(|s| (s.name(), s)).fold(
+    let mappings = commands.iter().map(|s| (s.name(), s)).fold(
         HashMap::with_capacity(commands.len()),
         |mut map, entry| {
             map.insert(entry.0, entry.1.as_ref());
             map
-        }
+        },
     );
 
     for each in &commands {
         app = app.subcommand(each.command());
     }
 
+    let usage = app.render_usage();
     let app = app.get_matches();
+
     match app.subcommand() {
-        (name, Some(value)) => {
+        Some((name, value)) => {
             if let Some(command) = mappings.get(name) {
                 match (*command).execute(value) {
                     Err(e) => {
                         println!("Error occurred {}", e);
                         exit(-1);
-                    },
-                    Ok(code) => {
-                        exit(code)
                     }
+                    Ok(code) => exit(code),
                 }
+            } else {
+                println!("{}", &usage);
             }
-            else {
-                println!("{}", app.usage());
-            }
-        },
-
-        (_, None) => {
-            println!("{}", app.usage());
+        }
+        None => {
+            println!("{}", &usage);
         }
     }
     Ok(())
 }
-

--- a/guard/src/main.rs
+++ b/guard/src/main.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::process::exit;
 
-use clap::{App, AppFlags, ArgGroup, ArgMatches};
+use clap::{ArgGroup, ArgMatches};
 use clap::error::ContextKind::Usage;
 use nom::combinator::map;
 
@@ -17,7 +17,7 @@ mod rules;
 mod utils;
 
 fn main() -> Result<(), Error> {
-    let mut app = App::new(APP_NAME).version(APP_VERSION).about(
+    let mut app = clap::Command::new(APP_NAME).version(APP_VERSION).about(
         r#"
   Guard is a general-purpose tool that provides a simple declarative syntax to define 
   policy-as-code as rules to validate against any structured hierarchical data (like JSON/YAML).

--- a/guard/tests/utils.rs
+++ b/guard/tests/utils.rs
@@ -1,14 +1,16 @@
 // Copyright Amazon Web Services, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::collections::HashMap;
 use std::fs::File;
 use std::io::{BufReader, Read};
 use std::path::PathBuf;
-use cfn_guard::commands::validate::Validate;
-use std::collections::HashMap;
+
 use clap::App;
+
 use cfn_guard::command::Command;
 use cfn_guard::commands::{DATA, RULES};
+use cfn_guard::commands::validate::Validate;
 
 pub fn get_data_option() -> String {
     format!("-{}", DATA.1)
@@ -62,26 +64,19 @@ pub fn cfn_guard_test_command(args: Vec<&str>) -> i32 {
     let app = app.get_matches_from(command_options);
 
     match app.subcommand() {
-        (name, Some(value)) => {
+        Some((name, value)) => {
             if let Some(command) = mappings.get(name) {
                 match (*command).execute(value) {
                     Err(e) => {
                         println!("Error occurred {}", e);
-                        return -1;
+                        -1
                     },
-                    Ok(code) => {
-                        return code;
-                    }
+                    Ok(code) => code
                 }
-            }
-            else {
-                return -2;
+            } else {
+                -2
             }
         },
-
-        (_, None) => {
-            return -3;
-        }
+        None => -3
     }
-
 }

--- a/guard/tests/utils.rs
+++ b/guard/tests/utils.rs
@@ -6,8 +6,6 @@ use std::fs::File;
 use std::io::{BufReader, Read};
 use std::path::PathBuf;
 
-use clap::App;
-
 use cfn_guard::command::Command;
 use cfn_guard::commands::{DATA, RULES};
 use cfn_guard::commands::validate::Validate;
@@ -38,11 +36,10 @@ pub fn get_full_path_for_resource_file(path: &str) -> String {
 
 pub fn cfn_guard_test_command(args: Vec<&str>) -> i32 {
     let TEST_APP_NAME = "cfn-guard-test";
-    let mut app =
-        App::new(TEST_APP_NAME);
+    let mut app = clap::Command::new(TEST_APP_NAME);
     let mut command_options = Vec::new();
     command_options.push(TEST_APP_NAME);
-    command_options.append( args.clone().as_mut());
+    command_options.append(args.clone().as_mut());
 
     let mut commands: Vec<Box<dyn Command>> = Vec::with_capacity(2);
     commands.push(Box::new(Validate::new()));

--- a/guard/tests/utils.rs
+++ b/guard/tests/utils.rs
@@ -51,7 +51,7 @@ pub fn cfn_guard_test_command(args: Vec<&str>) -> i32 {
         |mut map, entry| {
             map.insert(entry.0, entry.1.as_ref());
             map
-        }
+        },
     );
 
     for each in &commands {
@@ -67,13 +67,13 @@ pub fn cfn_guard_test_command(args: Vec<&str>) -> i32 {
                     Err(e) => {
                         println!("Error occurred {}", e);
                         -1
-                    },
+                    }
                     Ok(code) => code
                 }
             } else {
                 -2
             }
-        },
+        }
         None => -3
     }
 }


### PR DESCRIPTION
*Issue #, if available:*
This is the start of #269. In order to add autocompletions we needed to update our version of clap-rs. Previously we were on 2.x, this PR brings us up to 4.0.18. 

This came with many breaking changes. The most obvious one is that App<'a, 'b> struct was replaced with Command. 

For a more detailed write up on the breaking changes please refer to the following 

[4.0](https://github.com/clap-rs/clap/releases/tag/v4.0.0-rc.1)
[3.0](https://github.com/clap-rs/clap/releases/tag/v3.0.0)


**NOTE: First 2 commits contain changes for 3.0, and 4.0 respectively, commit 3 contains changes strictly related to running rustfmt**

*Description of changes:*


---
*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
