### PR TITLE
Added support for advanced regular expressions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,6 +66,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -110,6 +125,7 @@ dependencies = [
  "colored 2.0.0",
  "enumflags2",
  "enumflags2_derive",
+ "fancy-regex",
  "grep-matcher",
  "grep-regex",
  "grep-searcher",
@@ -119,7 +135,6 @@ dependencies = [
  "lazy_static",
  "nom",
  "nom_locate",
- "regex",
  "rstest",
  "serde",
  "serde_json",
@@ -242,6 +257,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "fancy-regex"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0678ab2d46fa5195aaf59ad034c083d351377d4af57f3e073c074d0da3e3c766"
+dependencies = [
+ "bit-set",
+ "regex",
 ]
 
 [[package]]

--- a/guard/Cargo.toml
+++ b/guard/Cargo.toml
@@ -20,7 +20,6 @@ crate-type = ["rlib"]
 nom = "5.1.2"
 nom_locate = "2.0.0"
 indexmap = { version = "1.6.0", features = ["serde-1"] }
-regex = "1.5.5"
 simple_logger = "1.3.0"
 clap = "4.0.18"
 clap_complete = "4.0.3"
@@ -42,6 +41,7 @@ grep-matcher = "0.1.5"
 grep-regex = "0.1.9"
 unsafe-libyaml = "0.2.2"
 rstest = "0.15.0"
+fancy-regex = "0.10.0"
 
 [dependencies.serde_json]
 version = "1.0.85"

--- a/guard/src/commands/validate/cfn.rs
+++ b/guard/src/commands/validate/cfn.rs
@@ -9,7 +9,7 @@ use std::{
     rc::Rc,
 };
 use lazy_static::lazy_static;
-use regex::Regex;
+use fancy_regex::Regex;
 
 use colored::*;
 use crate::{
@@ -193,7 +193,7 @@ fn single_line(writer: &mut dyn Write,
                 };
             }
         } else {
-            let resource_name = match CFN_RESOURCES.captures(*key) {
+            let resource_name = match CFN_RESOURCES.captures(*key).unwrap() {
                 Some(cap) => {
                     cap.get(1).unwrap().as_str()
                 },
@@ -441,7 +441,7 @@ fn get_resource_name(key: &&str, count: usize, matches: usize) -> String {
     placeholder = str::replacen(&placeholder, c, "/", 2); // count = 2 -> because always need to replace the Slashes for /Resources/
 
     // placeholder = "/Resources/foo\fbar/baz"
-    match CFN_RESOURCES.captures(&placeholder) {
+    match CFN_RESOURCES.captures(&placeholder).unwrap() {
         Some(cap) => {
             // resource_name = "foo/bar"
             str::replace(cap.get(1).unwrap().as_str(), c, "/")

--- a/guard/src/commands/validate/cfn_reporter.rs
+++ b/guard/src/commands/validate/cfn_reporter.rs
@@ -3,7 +3,7 @@ use std::fmt::Debug;
 use std::io::Write;
 
 use lazy_static::*;
-use regex::Regex;
+use fancy_regex::Regex;
 
 use crate::commands::tracker::StatusContext;
 use crate::commands::validate::{OutputFormatType, Reporter};
@@ -69,7 +69,7 @@ impl Reporter for CfnReporter {
                             }
                             let mut resource_info = super::common::extract_name_info(
                                 &each_failed_rule.context, each_failing_clause)?;
-                            let (resource_name, property_path) = match CFN_RESOURCES.captures(&resource_info.path) {
+                            let (resource_name, property_path) = match CFN_RESOURCES.captures(&resource_info.path).unwrap() {
                                 Some(caps) => {
                                     (caps["name"].to_string(), caps["rest"].replace("/", "."))
                                 },

--- a/guard/src/commands/validate/common.rs
+++ b/guard/src/commands/validate/common.rs
@@ -8,7 +8,7 @@ use std::fmt::Debug;
 use std::io::Write;
 use std::collections::{HashMap, HashSet, BTreeSet, BTreeMap};
 use std::convert::TryInto;
-use regex::Regex;
+use fancy_regex::Regex;
 use lazy_static::*;
 use crate::rules::eval_context::{EventRecord, FileReport, simplifed_json_from_root, ClauseReport, ValueComparisons, BinaryComparison, UnaryComparison, ValueUnResolved, GuardClauseReport, UnaryCheck, BinaryCheck, InComparison};
 use crate::commands::validate::OutputFormatType;
@@ -411,7 +411,7 @@ pub(super) fn extract_name_info<'a>(rule_name: &'a str,
         // No from is how we indicate retrieval errors.
         //
         let (path, error) = each_failing_clause.msg.as_ref().map_or(("".to_string(), "".to_string()), |msg| {
-            match PATH_FROM_MSG.captures(msg) {
+            match PATH_FROM_MSG.captures(msg).unwrap() {
                 Some(cap) => (cap["path"].to_string(), msg.clone()),
                 None => ("".to_string(), msg.clone())
             }

--- a/guard/src/commands/validate/tf.rs
+++ b/guard/src/commands/validate/tf.rs
@@ -97,7 +97,7 @@ struct ResourceView<'report, 'value: 'report> {
 }
 
 lazy_static! {
-    static ref RESOURCE_CHANGE_EXTRACTION: regex::Regex = regex::Regex::new("/resource_changes/(?P<index_or_name>[^/]+)/change/after/(?P<property_name>.*)?")
+    static ref RESOURCE_CHANGE_EXTRACTION: fancy_regex::Regex = fancy_regex::Regex::new("/resource_changes/(?P<index_or_name>[^/]+)/change/after/(?P<property_name>.*)?")
         .ok().unwrap();
 }
 
@@ -137,7 +137,7 @@ fn single_line(writer: &mut dyn Write,
 
     let mut by_resources = HashMap::new();
     for (key, value) in path_tree.range("/resource_changes/"..) {
-        let resource_ptr = match RESOURCE_CHANGE_EXTRACTION.captures(*key) {
+        let resource_ptr = match RESOURCE_CHANGE_EXTRACTION.captures(*key).unwrap() {
             Some(cap) => cap.name("index_or_name").unwrap().as_str(),
             None => unreachable!()
         };
@@ -288,12 +288,7 @@ fn single_line(writer: &mut dyn Write,
                     prefix.clone(),
                     &mut err_writer
                 )?;
-//                pprint_clauses(
-//                    writer,
-//                    each_rule,
-//                    &resource,
-//                    prefix.clone()
-//                )?;
+
             }
         }
         writeln!(writer, "}}")?;

--- a/guard/src/rules/errors.rs
+++ b/guard/src/rules/errors.rs
@@ -120,7 +120,7 @@ pub enum ErrorKind {
     FormatError(std::fmt::Error),
     IoError(std::io::Error),
     ParseError(String),
-    RegexError(regex::Error),
+    RegexError(fancy_regex::Error),
     MissingProperty(String),
     MissingValue(String),
     RetrievalError(String),
@@ -158,8 +158,8 @@ impl From<std::io::Error> for Error {
     }
 }
 
-impl From<regex::Error> for Error {
-    fn from(err: regex::Error) -> Self {
+impl From<fancy_regex::Error> for Error {
+    fn from(err: fancy_regex::Error) -> Self {
         Error(ErrorKind::RegexError(err))
     }
 }

--- a/guard/src/rules/functions/strings.rs
+++ b/guard/src/rules/functions/strings.rs
@@ -62,10 +62,10 @@ pub(crate) fn regex_replace(args: &[QueryResult<'_>], extract_expr: &str, replac
             QueryResult::Literal(v) |
             QueryResult::Resolved(v) => {
                 if let PathAwareValue::String((path, val)) = v {
-                    let regex = regex::Regex::new(extract_expr)?;
+                    let regex = fancy_regex::Regex::new(extract_expr)?;
                     let mut replaced = String::with_capacity(replace_expr.len()*2);
                     for cap in regex.captures_iter(val) {
-                        cap.expand(replace_expr, &mut replaced);
+                        cap?.expand(replace_expr, &mut replaced);
                     }
                     aggr.push(Some(
                         PathAwareValue::String((path.clone(), replaced))

--- a/guard/src/rules/path_value.rs
+++ b/guard/src/rules/path_value.rs
@@ -1,5 +1,6 @@
 pub(crate) mod traversal;
 
+use fancy_regex::Regex;
 use std::cmp::Ordering;
 use std::convert::{TryFrom, TryInto};
 //
@@ -330,15 +331,15 @@ impl PartialEq for PathAwareValue {
             (PathAwareValue::Bool((_, b1)), PathAwareValue::Bool((_, b2))) => b1 == b2,
 
             (PathAwareValue::String((_, s)), PathAwareValue::Regex((_, r))) => {
-                if let Ok(regex) = regex::Regex::new(r.as_str()) {
-                    regex.is_match(s.as_str())
+                if let Ok(regex) = Regex::new(r.as_str()) {
+                    regex.is_match(s.as_str()).unwrap()
                 } else {
                     false
                 }
             },
             (PathAwareValue::Regex((_, r)), PathAwareValue::String((_, s))) =>  {
-                if let Ok(regex) = regex::Regex::new(r.as_str()) {
-                    regex.is_match(s.as_str())
+                if let Ok(regex) = Regex::new(r.as_str()) {
+                    regex.is_match(s.as_str()).unwrap()
                 } else {
                     false
                 }
@@ -1111,8 +1112,8 @@ fn compare_values(first: &PathAwareValue, other: &PathAwareValue) -> Result<Orde
 
 pub(crate) fn compare_eq(first: &PathAwareValue, second: &PathAwareValue) -> Result<bool, Error> {
     let (reg, s) = match (first, second) {
-        (PathAwareValue::String((_, s)), PathAwareValue::Regex((_, r))) => (regex::Regex::new(r.as_str())?, s.as_str()),
-        (PathAwareValue::Regex((_, r)), PathAwareValue::String((_, s))) => (regex::Regex::new(r.as_str())?, s.as_str()),
+        (PathAwareValue::String((_, s)), PathAwareValue::Regex((_, r))) => (fancy_regex::Regex::new(r.as_str()).unwrap(), s.as_str()),
+        (PathAwareValue::Regex((_, r)), PathAwareValue::String((_, s))) => (fancy_regex::Regex::new(r.as_str()).unwrap(), s.as_str()),
 
         (PathAwareValue::String((_, s1)), PathAwareValue::String((_, s2))) => return Ok(s1 == s2),
 
@@ -1183,7 +1184,7 @@ pub(crate) fn compare_eq(first: &PathAwareValue, second: &PathAwareValue) -> Res
             _ => Ok(false)
         }
     };
-    Ok(reg.is_match(s))
+    Ok(reg.is_match(s).unwrap())
 }
 
 pub(crate) fn compare_lt(first: &PathAwareValue, other: &PathAwareValue) -> Result<bool, Error> {

--- a/guard/src/rules/path_value/traversal.rs
+++ b/guard/src/rules/path_value/traversal.rs
@@ -1,7 +1,7 @@
 use crate::rules::path_value::PathAwareValue;
 use crate::rules::errors::{Error, ErrorKind};
 use lazy_static::lazy_static;
-use regex::Regex;
+use fancy_regex::Regex;
 use std::collections::BTreeMap;
 
 lazy_static! {
@@ -110,7 +110,7 @@ impl<'value> Traversal<'value> {
             return Ok(TraversalResult::Key(node.value.self_path().relative()))
         }
 
-        if let Some(captures) = RELATIVE_PATH.captures(pointer) {
+        if let Some(captures) = RELATIVE_PATH.captures(pointer).unwrap() {
             //
             // Safe to unwrap as we capture ints in regex
             //


### PR DESCRIPTION
*Issue #, if available:*
Internal, TIX-212

*Description of changes:*
Added support for advanced regular expressions that support features such as look-ahead and look-behinds.

Replaced the standard `regex` crate with `fancy-regex` since the latter uses a hybrid approach and automatically delegates the basic regular expressions to the native engine.

[Source `fancy-regex`](https://github.com/fancy-regex/fancy-regex#theory):

> The fundamental idea is that it's a backtracking VM like PCRE, but as much as possible it delegates to an "inner" RE engine like RE2 (in this case, the Rust one). For the sublanguage not using fancy features, the library becomes a thin wrapper.


---
*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
