### PR TITLE
bugfix for failing test commands + new tests to cover this

### DIFF
--- a/guard/resources/data-dir/s3-server-side-encryption-template-non-compliant.yaml
+++ b/guard/resources/data-dir/s3-server-side-encryption-template-non-compliant.yaml
@@ -12,8 +12,5 @@ Resources:
         IgnorePublicAcls: true
         RestrictPublicBuckets: true
       BucketEncryption:
-        # ServerSideEncryptionConfiguration:
-        #   - ServerSideEncryptionByDefault:
-        #       SSEAlgorithm: AES256
       VersioningConfiguration:
         Status: Enabled

--- a/guard/resources/rules-dir/s3_bucket_logging_enabled.guard
+++ b/guard/resources/rules-dir/s3_bucket_logging_enabled.guard
@@ -1,0 +1,41 @@
+#
+#####################################
+##           Gherkin               ##
+#####################################
+# Rule Identifier:
+#    S3_BUCKET_LOGGING_ENABLED
+#
+# Description:
+#   Checks whether logging is enabled for your S3 buckets.
+#
+# Reports on:
+#    AWS::S3::Bucket
+#
+# Evaluates:
+#    AWS CloudFormation
+#
+# Rule Parameters:
+#    NA
+#
+# Scenarios:
+# a) SKIP: when there are no S3 resource present
+# b) PASS: when all S3 resources Logging Configuration exists
+# c) FAIL: when all S3 resources have Logging Configuration is not set
+# d) SKIP: when metadata includes the suppression for rule S3_BUCKET_LOGGING_ENABLED
+
+#
+# Select all S3 resources from incoming template (payload)
+#
+
+let s3_buckets_bucket_logging_enabled = Resources.*[ Type == 'AWS::S3::Bucket'
+  Metadata.guard.SuppressedRules not exists or
+  Metadata.guard.SuppressedRules.* != "S3_BUCKET_LOGGING_ENABLED"
+]
+
+rule S3_BUCKET_LOGGING_ENABLED when %s3_buckets_bucket_logging_enabled  !empty {
+  %s3_buckets_bucket_logging_enabled.Properties.LoggingConfiguration exists
+  <<
+    Violation: S3 Bucket Logging needs to be configured to enable logging.
+    Fix: Set the S3 Bucket property LoggingConfiguration to start logging into S3 bucket.
+  >>
+}

--- a/guard/resources/rules-dir/s3_bucket_server_side_encryption_enabled.guard
+++ b/guard/resources/rules-dir/s3_bucket_server_side_encryption_enabled.guard
@@ -1,4 +1,7 @@
-let s3_buckets_server_side_encryption = Resources.*[ Type == 'AWS::S3::Bucket' ]
+let s3_buckets_server_side_encryption = Resources.*[ Type == 'AWS::S3::Bucket'
+  Metadata.guard.SuppressedRules not exists or
+  Metadata.guard.SuppressedRules.* != "S3_BUCKET_SERVER_SIDE_ENCRYPTION_ENABLED"
+]
 
 rule S3_BUCKET_SERVER_SIDE_ENCRYPTION_ENABLED when %s3_buckets_server_side_encryption !empty {
   %s3_buckets_server_side_encryption.Properties.BucketEncryption exists

--- a/guard/resources/test-data-dir/s3_bucket_logging_enabled_tests.json
+++ b/guard/resources/test-data-dir/s3_bucket_logging_enabled_tests.json
@@ -1,0 +1,92 @@
+[
+  {
+    "name": "Empty, SKIP",
+    "input": {},
+    "expectations": {
+      "rules": {
+        "S3_BUCKET_LOGGING_ENABLED": "SKIP"
+      }
+    }
+  },
+  {
+    "name": "No resources, SKIP",
+    "input": {
+      "Resources": {}
+    },
+    "expectations": {
+      "rules": {
+        "S3_BUCKET_LOGGING_ENABLED": "SKIP"
+      }
+    }
+  },
+  {
+    "name": "S3 Bucket with Logging Configuration present in resource, PASS",
+    "input": {
+      "Resources": {
+        "ExampleS3": {
+          "Type": "AWS::S3::Bucket",
+          "Properties": {
+            "BucketName": "my-bucket",
+            "VersioningConfiguration": {
+              "Status": "Enabled"
+            },
+            "LoggingConfiguration": {
+              "DestinationBucketName": {
+                "Ref": "LoggingBucket"
+              },
+              "LogFilePrefix": "testing-logs"
+            }
+          }
+        }
+      }
+    },
+    "expectations": {
+      "rules": {
+        "S3_BUCKET_LOGGING_ENABLED": "PASS"
+      }
+    }
+  },
+  {
+    "name": "S3 Bucket with Logging Configuration missing, FAIL",
+    "input": {
+      "Resources": {
+        "ExampleS3": {
+          "Type": "AWS::S3::Bucket",
+          "Properties": {
+            "BucketName": "my-bucket"
+          }
+        }
+      }
+    },
+    "expectations": {
+      "rules": {
+        "S3_BUCKET_LOGGING_ENABLED": "FAIL"
+      }
+    }
+  },
+  {
+    "name": "S3 Bucket with Logging Configuration missing with suppression, SKIP",
+    "input": {
+      "Resources": {
+        "ExampleS3": {
+          "Type": "AWS::S3::Bucket",
+          "Metadata": {
+            "guard": {
+              "SuppressedRules": [
+                "S3_BUCKET_LOGGING_ENABLED"
+              ]
+            }
+          },
+          "Properties": {
+            "BucketName": "my-bucket"
+          }
+        }
+      }
+    },
+    "expectations": {
+      "rules": {
+        "S3_BUCKET_LOGGING_ENABLED": "SKIP"
+      }
+    }
+  }
+]

--- a/guard/resources/test-data-dir/s3_bucket_logging_enabled_tests.yaml
+++ b/guard/resources/test-data-dir/s3_bucket_logging_enabled_tests.yaml
@@ -1,0 +1,58 @@
+###
+# S3_BUCKET_LOGGING_ENABLED tests
+###
+---
+- name: Empty, SKIP
+  input: {}
+  expectations:
+    rules:
+      S3_BUCKET_LOGGING_ENABLED: SKIP
+
+- name: No resources, SKIP
+  input:
+    Resources: {}
+  expectations:
+    rules:
+      S3_BUCKET_LOGGING_ENABLED: SKIP
+
+- name: S3 Bucket with Logging Configuration present in resource, PASS
+  input:
+    Resources:
+      ExampleS3:
+        Type: AWS::S3::Bucket
+        Properties:
+          BucketName: my-bucket
+          VersioningConfiguration:
+            Status: Enabled
+          LoggingConfiguration:
+            DestinationBucketName: !Ref LoggingBucket
+            LogFilePrefix: testing-logs
+  expectations:
+    rules:
+      S3_BUCKET_LOGGING_ENABLED: PASS
+
+- name: S3 Bucket with Logging Configuration missing, FAIL
+  input:
+    Resources:
+      ExampleS3:
+        Type: AWS::S3::Bucket
+        Properties:
+          BucketName: my-bucket
+  expectations:
+    rules:
+      S3_BUCKET_LOGGING_ENABLED: FAIL
+
+- name: S3 Bucket with Logging Configuration missing with suppression, SKIP
+  input:
+    Resources:
+      ExampleS3:
+        Type: AWS::S3::Bucket
+        Metadata:
+          guard:
+            SuppressedRules:
+              - S3_BUCKET_LOGGING_ENABLED
+        Properties:
+          BucketName: my-bucket
+  expectations:
+    rules:
+      S3_BUCKET_LOGGING_ENABLED: SKIP

--- a/guard/resources/test-data-dir/s3_bucket_server_side_encryption_enabled.json
+++ b/guard/resources/test-data-dir/s3_bucket_server_side_encryption_enabled.json
@@ -1,0 +1,120 @@
+[
+  {
+    "name": "Empty, SKIP",
+    "input": {},
+    "expectations": {
+      "rules": {
+        "S3_BUCKET_SERVER_SIDE_ENCRYPTION_ENABLED": "SKIP"
+      }
+    }
+  },
+  {
+    "name": "No resources, SKIP",
+    "input": {
+      "Resources": {}
+    },
+    "expectations": {
+      "rules": {
+        "S3_BUCKET_SERVER_SIDE_ENCRYPTION_ENABLED": "SKIP"
+      }
+    }
+  },
+  {
+    "name": "S3 Bucket Encryption set to SSE AES 256, PASS",
+    "input": {
+      "Resources": {
+        "ExampleS3": {
+          "Type": "AWS::S3::Bucket",
+          "Properties": {
+            "BucketName": "my-bucket",
+            "BucketEncryption": {
+              "ServerSideEncryptionConfiguration": [
+                {
+                  "ServerSideEncryptionByDefault": {
+                    "SSEAlgorithm": "AES256"
+                  }
+                }
+              ]
+            }
+          }
+        }
+      }
+    },
+    "expectations": {
+      "rules": {
+        "S3_BUCKET_SERVER_SIDE_ENCRYPTION_ENABLED": "PASS"
+      }
+    }
+  },
+  {
+    "name": "S3 Bucket Encryption set to SSE AWS KMS key, PASS",
+    "input": {
+      "Resources": {
+        "ExampleS3": {
+          "Type": "AWS::S3::Bucket",
+          "Properties": {
+            "BucketName": "my-bucket",
+            "BucketEncryption": {
+              "ServerSideEncryptionConfiguration": [
+                {
+                  "ServerSideEncryptionByDefault": {
+                    "SSEAlgorithm": "aws:kms",
+                    "KMSMasterKeyID": "ARN:AWS:12345678912"
+                  }
+                }
+              ]
+            }
+          }
+        }
+      }
+    },
+    "expectations": {
+      "rules": {
+        "S3_BUCKET_SERVER_SIDE_ENCRYPTION_ENABLED": "PASS"
+      }
+    }
+  },
+  {
+    "name": "S3 Bucket Encryption not set, FAIL",
+    "input": {
+      "Resources": {
+        "ExampleS3": {
+          "Type": "AWS::S3::Bucket",
+          "Properties": {
+            "BucketName": "my-bucket"
+          }
+        }
+      }
+    },
+    "expectations": {
+      "rules": {
+        "S3_BUCKET_SERVER_SIDE_ENCRYPTION_ENABLED": "FAIL"
+      }
+    }
+  },
+  {
+    "name": "S3 Bucket Encryption not set but rule is suppressed, SKIP",
+    "input": {
+      "Resources": {
+        "ExampleS3": {
+          "Type": "AWS::S3::Bucket",
+          "Metadata": {
+            "guard": {
+              "SuppressedRules": [
+                "S3_BUCKET_SERVER_SIDE_ENCRYPTION_ENABLED"
+              ]
+            }
+          },
+          "Properties": {
+            "BucketName": "my-bucket"
+          }
+        }
+      }
+    },
+    "expectations": {
+      "rules": {
+        "S3_BUCKET_SERVER_SIDE_ENCRYPTION_ENABLED": "SKIP"
+      }
+    }
+  }
+]

--- a/guard/resources/test-data-dir/s3_bucket_server_side_encryption_enabled.yaml
+++ b/guard/resources/test-data-dir/s3_bucket_server_side_encryption_enabled.yaml
@@ -1,0 +1,73 @@
+###
+# S3_BUCKET_SERVER_SIDE_ENCRYPTION_ENABLED tests
+###
+---
+- name: Empty, SKIP
+  input: {}
+  expectations:
+    rules:
+      S3_BUCKET_SERVER_SIDE_ENCRYPTION_ENABLED: SKIP
+
+- name: No resources, SKIP
+  input:
+    Resources: {}
+  expectations:
+    rules:
+      S3_BUCKET_SERVER_SIDE_ENCRYPTION_ENABLED: SKIP
+
+- name: S3 Bucket Encryption set to SSE AES 256, PASS
+  input:
+    Resources:
+      ExampleS3:
+        Type: AWS::S3::Bucket
+        Properties:
+          BucketName: my-bucket
+          BucketEncryption:
+            ServerSideEncryptionConfiguration:
+              - ServerSideEncryptionByDefault:
+                  SSEAlgorithm: AES256
+  expectations:
+    rules:
+      S3_BUCKET_SERVER_SIDE_ENCRYPTION_ENABLED: PASS
+
+- name: S3 Bucket Encryption set to SSE AWS KMS key, PASS
+  input:
+    Resources:
+      ExampleS3:
+        Type: AWS::S3::Bucket
+        Properties:
+          BucketName: my-bucket
+          BucketEncryption:
+            ServerSideEncryptionConfiguration:
+              - ServerSideEncryptionByDefault:
+                  SSEAlgorithm: "aws:kms"
+                  KMSMasterKeyID: "ARN:AWS:12345678912"
+  expectations:
+    rules:
+      S3_BUCKET_SERVER_SIDE_ENCRYPTION_ENABLED: PASS
+
+- name: S3 Bucket Encryption not set, FAIL
+  input:
+    Resources:
+      ExampleS3:
+        Type: AWS::S3::Bucket
+        Properties:
+          BucketName: my-bucket
+  expectations:
+    rules:
+      S3_BUCKET_SERVER_SIDE_ENCRYPTION_ENABLED: FAIL
+
+- name: S3 Bucket Encryption not set but rule is suppressed, SKIP
+  input:
+    Resources:
+      ExampleS3:
+        Type: AWS::S3::Bucket
+        Metadata:
+          guard:
+            SuppressedRules:
+              - S3_BUCKET_SERVER_SIDE_ENCRYPTION_ENABLED
+        Properties:
+          BucketName: my-bucket
+  expectations:
+    rules:
+      S3_BUCKET_SERVER_SIDE_ENCRYPTION_ENABLED: SKIP

--- a/guard/src/commands/mod.rs
+++ b/guard/src/commands/mod.rs
@@ -1,7 +1,7 @@
 pub(crate) mod files;
 pub mod validate;
 pub(crate) mod rulegen;
-pub(crate) mod test;
+pub mod test;
 pub(crate) mod helper;
 pub(crate) mod parse_tree;
 pub(crate) mod migrate;
@@ -20,7 +20,7 @@ pub const APP_VERSION: &'static str = env!("CARGO_PKG_VERSION");
 pub(crate)  const MIGRATE: &str = "migrate";
 pub(crate)  const PARSE_TREE: &str = "parse-tree";
 pub(crate) const RULEGEN: &str = "rulegen";
-pub(crate)  const TEST: &str = "test";
+pub  const TEST: &str = "test";
 pub const VALIDATE: &str = "validate";
 // Arguments for validate
 pub(crate) const ALPHABETICAL: (&str, &str) = ("alphabetical", "a");
@@ -43,7 +43,7 @@ pub(crate) const OUTPUT: (&str, &str) = ("output", "o");
 pub(crate) const PRINT_YAML: (&str, &str) = ("print-yaml", "y");
 // Arguments for test
 pub(crate) const RULES_FILE: (&str, &str) = ("rules-file", "r");
-pub(crate) const TEST_DATA: (&str, &str) = ("test-data", "t");
+pub const TEST_DATA: (&str, &str) = ("test-data", "t");
 pub(crate) const DIRECTORY: (&str, &str) = ("dir", "d");
 // Arguments for rulegen
 pub(crate) const TEMPLATE: (&str, &str) = ("template", "t");

--- a/guard/src/commands/test.rs
+++ b/guard/src/commands/test.rs
@@ -28,10 +28,10 @@ use crate::rules::Status::SKIP;
 use crate::rules::{Evaluate, NamedStatus, RecordType, Result, Status};
 
 #[derive(Clone, Copy, Eq, PartialEq)]
-pub(crate) struct Test {}
+pub struct Test {}
 
 impl Test {
-    pub(crate) fn new() -> Self {
+    pub fn new() -> Self {
         Test {}
     }
 }
@@ -273,8 +273,8 @@ struct TestExpectations {
 
 #[derive(Serialize, Deserialize, Debug)]
 struct TestSpec {
-    name: Option<serde_json::Value>,
-    input: serde_json::Value,
+    name: Option<String>,
+    input: serde_yaml::Value,
     expectations: TestExpectations,
 }
 

--- a/guard/src/rules/libyaml/parser.rs
+++ b/guard/src/rules/libyaml/parser.rs
@@ -27,7 +27,7 @@ pub(crate) struct Parser<'input> {
 struct ParserPinned<'input> {
     sys: sys::yaml_parser_t,
     input: Cow<'input, [u8]>,
-    }
+}
 
 
 impl<'input> Parser<'input> {

--- a/guard/tests/functional.rs
+++ b/guard/tests/functional.rs
@@ -174,7 +174,7 @@ mod tests {
         let data_option = format!("-{}", DATA.1);
         let rules_option = format!("-{}", RULES.1);
         let args = vec![VALIDATE, &data_option, &data_arg, &rules_option, &rules_arg];
-        assert_eq!(0, utils::cfn_guard_test_command(args, Box::new(Validate::new())));
+        assert_eq!(0, utils::cfn_guard_test_command(Validate::new(), args));
     }
 
     #[test]
@@ -188,7 +188,7 @@ mod tests {
         let data_option = format!("-{}", DATA.1);
         let rules_option = format!("-{}", RULES.1);
         let args = vec![VALIDATE, &data_option, &data_arg, &rules_option, &rules_arg];
-        assert_eq!(5, utils::cfn_guard_test_command(args, Box::new(Validate::new())));
+        assert_eq!(5, utils::cfn_guard_test_command(Validate::new(), args));
     }
 
     #[test]
@@ -200,7 +200,7 @@ mod tests {
         let data_option = format!("-{}", DATA.1);
         let rules_option = format!("-{}", RULES.1);
         let args = vec![VALIDATE, &data_option, &data_arg, &rules_option, &rules_arg];
-        assert_eq!(5, utils::cfn_guard_test_command(args, Box::new(Validate::new())));
+        assert_eq!(5, utils::cfn_guard_test_command(Validate::new(), args));
     }
 
     #[test]
@@ -212,7 +212,7 @@ mod tests {
         let data_option = format!("-{}", DATA.1);
         let rules_option = format!("-{}", RULES.1);
         let args = vec![VALIDATE, &data_option, &data_arg, &rules_option, &rules_arg];
-        assert_eq!(5, utils::cfn_guard_test_command(args, Box::new(Validate::new())));
+        assert_eq!(5, utils::cfn_guard_test_command(Validate::new(), args));
     }
 
     #[test]
@@ -222,7 +222,7 @@ mod tests {
         let data_option = format!("-{}", DATA.1);
         let rules_option = format!("-{}", RULES.1);
         let args = vec![VALIDATE, &data_option, &data_arg, &rules_option, &rules_arg];
-        assert_eq!(5, utils::cfn_guard_test_command(args, Box::new(Validate::new())));
+        assert_eq!(5, utils::cfn_guard_test_command(Validate::new(), args));
     }
 
     #[test]
@@ -247,7 +247,7 @@ mod tests {
             &rules_option,
             &rules_arg,
         ];
-        assert_eq!(5, utils::cfn_guard_test_command(args, Box::new(Validate::new())));
+        assert_eq!(5, utils::cfn_guard_test_command(Validate::new(), args));
     }
 
     #[test]
@@ -272,7 +272,7 @@ mod tests {
             &rules_option,
             &rules_arg2,
         ];
-        assert_eq!(5, utils::cfn_guard_test_command(args, Box::new(Validate::new())));
+        assert_eq!(5, utils::cfn_guard_test_command(Validate::new(), args));
     }
 
     #[test]
@@ -295,7 +295,7 @@ mod tests {
             &rules_option,
             &rules_arg,
         ];
-        assert_eq!(5, utils::cfn_guard_test_command(args, Box::new(Validate::new())));
+        assert_eq!(5, utils::cfn_guard_test_command(Validate::new(), args));
     }
 
     #[test]
@@ -318,7 +318,7 @@ mod tests {
             &rules_option,
             &rules_arg2,
         ];
-        assert_eq!(5, utils::cfn_guard_test_command(args, Box::new(Validate::new())));
+        assert_eq!(5, utils::cfn_guard_test_command(Validate::new(), args));
     }
 
     #[test]
@@ -339,7 +339,7 @@ mod tests {
             &rules_option,
             &rules_arg2,
         ];
-        assert_eq!(5, utils::cfn_guard_test_command(args, Box::new(Validate::new())));
+        assert_eq!(5, utils::cfn_guard_test_command(Validate::new(), args));
     }
 
     #[test]
@@ -360,7 +360,7 @@ mod tests {
             &rules_option,
             &rules_arg,
         ];
-        assert_eq!(5, utils::cfn_guard_test_command(args, Box::new(Validate::new())));
+        assert_eq!(5, utils::cfn_guard_test_command(Validate::new(), args));
     }
 
     #[test]
@@ -386,7 +386,7 @@ mod tests {
             &rules_option,
             &rules_arg2,
         ];
-        assert_eq!(5, utils::cfn_guard_test_command(args, Box::new(Validate::new())));
+        assert_eq!(5, utils::cfn_guard_test_command(Validate::new(), args));
     }
 
     #[test]
@@ -408,7 +408,7 @@ mod tests {
             &input_parameters_option,
             &input_parameters_arg,
         ];
-        assert_eq!(5, utils::cfn_guard_test_command(args, Box::new(Validate::new())));
+        assert_eq!(5, utils::cfn_guard_test_command(Validate::new(), args));
     }
 
     #[test]
@@ -435,7 +435,7 @@ mod tests {
             &input_parameters_option,
             &input_parameters_arg2,
         ];
-        assert_eq!(0, utils::cfn_guard_test_command(args, Box::new(Validate::new())));
+        assert_eq!(0, utils::cfn_guard_test_command(Validate::new(), args));
     }
 
     #[test]
@@ -457,7 +457,7 @@ mod tests {
             &input_parameters_option,
             &input_parameters_arg,
         ];
-        assert_eq!(0, utils::cfn_guard_test_command(args, Box::new(Validate::new())));
+        assert_eq!(0, utils::cfn_guard_test_command(Validate::new(), args));
     }
 
     #[test]
@@ -470,7 +470,7 @@ mod tests {
         let rules_option = format!("-{}", RULES.1);
         let args = vec![VALIDATE, &data_option, &data_arg, &rules_option, &rules_arg];
         // -1 status code equates to Error being thrown
-        assert_eq!(-1, utils::cfn_guard_test_command(args, Box::new(Validate::new())));
+        assert_eq!(-1, utils::cfn_guard_test_command(Validate::new(), args));
     }
 
     #[test]
@@ -483,7 +483,7 @@ mod tests {
         let rules_option = format!("-{}", RULES.1);
         let args = vec![VALIDATE, &data_option, &data_arg, &rules_option, &rules_arg];
         // -1 status code equates to Error being thrown
-        assert_eq!(-1, utils::cfn_guard_test_command(args, Box::new(Validate::new())));
+        assert_eq!(-1, utils::cfn_guard_test_command(Validate::new(), args));
     }
 
     #[test]
@@ -506,7 +506,7 @@ mod tests {
             &input_parameters_arg,
         ];
         // -1 status code equates to Error being thrown
-        assert_eq!(-1, utils::cfn_guard_test_command(args, Box::new(Validate::new())));
+        assert_eq!(-1, utils::cfn_guard_test_command(Validate::new(), args));
     }
 
     #[test]
@@ -519,7 +519,7 @@ mod tests {
         let data_option = format!("-{}", DATA.1);
         let rules_option = format!("-{}", RULES.1);
         let args = vec![VALIDATE, &data_option, &data_arg, &rules_option, &rules_arg];
-        assert_eq!(5, utils::cfn_guard_test_command(args, Box::new(Validate::new())));
+        assert_eq!(5, utils::cfn_guard_test_command(Validate::new(), args));
     }
 
     #[test]
@@ -543,7 +543,7 @@ mod tests {
             &rules_option,
             &rules_arg2,
         ];
-        assert_eq!(5, utils::cfn_guard_test_command(args, Box::new(Validate::new())));
+        assert_eq!(5, utils::cfn_guard_test_command(Validate::new(), args));
     }
 
     #[test]
@@ -556,7 +556,7 @@ mod tests {
         let rules_option = format!("-{}", RULES.1);
         let args = vec![VALIDATE, &data_option, &data_arg, &rules_option, &rules_arg];
         // -1 status code equates to Error being thrown
-        assert_eq!(-1, utils::cfn_guard_test_command(args, Box::new(Validate::new())));
+        assert_eq!(-1, utils::cfn_guard_test_command(Validate::new(), args));
     }
 
     #[test]
@@ -580,7 +580,7 @@ mod tests {
             &rules_arg,
         ];
         // -1 status code equates to Error being thrown
-        assert_eq!(-1, utils::cfn_guard_test_command(args, Box::new(Validate::new())));
+        assert_eq!(-1, utils::cfn_guard_test_command(Validate::new(), args));
     }
 
     #[test]
@@ -603,7 +603,7 @@ mod tests {
             &input_parameters_arg,
         ];
         // -1 status code equates to Error being thrown
-        assert_eq!(-1, utils::cfn_guard_test_command(args, Box::new(Validate::new())));
+        assert_eq!(-1, utils::cfn_guard_test_command(Validate::new(), args));
     }
 
     #[test]
@@ -630,7 +630,7 @@ mod tests {
             &input_parameters_arg2,
         ];
         // -1 status code equates to Error being thrown
-        assert_eq!(-1, utils::cfn_guard_test_command(args, Box::new(Validate::new())));
+        assert_eq!(-1, utils::cfn_guard_test_command(Validate::new(), args));
     }
 
     #[test]
@@ -648,7 +648,7 @@ mod tests {
             let data_option = &format!("-{}", DATA.1);
             let rules_option = &format!("-{}", RULES.1);
             let args = vec![VALIDATE, data_option, &arg.0, rules_option, &arg.1];
-            assert_eq!(-1, utils::cfn_guard_test_command(args, Box::new(Validate::new())))
+            assert_eq!(-1, utils::cfn_guard_test_command(Validate::new(), args))
         }
     }
 }
@@ -678,7 +678,7 @@ mod test_test_command {
             &rule_arg,
         ];
 
-        assert_eq!(0, crate::utils::cfn_guard_test_command(args, Box::new(Test::new())));
+        assert_eq!(0, crate::utils::cfn_guard_test_command(Test::new(), args));
         Ok(())
     }
 
@@ -699,7 +699,7 @@ mod test_test_command {
             &rule_arg,
         ];
 
-        assert_eq!(0, crate::utils::cfn_guard_test_command(args, Box::new(Test::new())));
+        assert_eq!(0, crate::utils::cfn_guard_test_command(Test::new(), args));
         Ok(())
     }
 }

--- a/guard/tests/functional.rs
+++ b/guard/tests/functional.rs
@@ -1,7 +1,7 @@
 // Copyright Amazon Web Services, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-mod utils;
+pub(crate) mod utils;
 
 #[cfg(test)]
 mod tests {
@@ -9,6 +9,7 @@ mod tests {
 
     use cfn_guard;
     use cfn_guard::commands::{DATA, INPUT_PARAMETERS, RULES, VALIDATE};
+    use cfn_guard::commands::validate::Validate;
 
     use crate::utils;
 
@@ -173,7 +174,7 @@ mod tests {
         let data_option = format!("-{}", DATA.1);
         let rules_option = format!("-{}", RULES.1);
         let args = vec![VALIDATE, &data_option, &data_arg, &rules_option, &rules_arg];
-        assert_eq!(0, utils::cfn_guard_test_command(args));
+        assert_eq!(0, utils::cfn_guard_test_command(args, Box::new(Validate::new())));
     }
 
     #[test]
@@ -187,7 +188,7 @@ mod tests {
         let data_option = format!("-{}", DATA.1);
         let rules_option = format!("-{}", RULES.1);
         let args = vec![VALIDATE, &data_option, &data_arg, &rules_option, &rules_arg];
-        assert_eq!(5, utils::cfn_guard_test_command(args));
+        assert_eq!(5, utils::cfn_guard_test_command(args, Box::new(Validate::new())));
     }
 
     #[test]
@@ -199,7 +200,7 @@ mod tests {
         let data_option = format!("-{}", DATA.1);
         let rules_option = format!("-{}", RULES.1);
         let args = vec![VALIDATE, &data_option, &data_arg, &rules_option, &rules_arg];
-        assert_eq!(5, utils::cfn_guard_test_command(args));
+        assert_eq!(5, utils::cfn_guard_test_command(args, Box::new(Validate::new())));
     }
 
     #[test]
@@ -211,7 +212,7 @@ mod tests {
         let data_option = format!("-{}", DATA.1);
         let rules_option = format!("-{}", RULES.1);
         let args = vec![VALIDATE, &data_option, &data_arg, &rules_option, &rules_arg];
-        assert_eq!(5, utils::cfn_guard_test_command(args));
+        assert_eq!(5, utils::cfn_guard_test_command(args, Box::new(Validate::new())));
     }
 
     #[test]
@@ -221,7 +222,7 @@ mod tests {
         let data_option = format!("-{}", DATA.1);
         let rules_option = format!("-{}", RULES.1);
         let args = vec![VALIDATE, &data_option, &data_arg, &rules_option, &rules_arg];
-        assert_eq!(5, utils::cfn_guard_test_command(args));
+        assert_eq!(5, utils::cfn_guard_test_command(args, Box::new(Validate::new())));
     }
 
     #[test]
@@ -246,7 +247,7 @@ mod tests {
             &rules_option,
             &rules_arg,
         ];
-        assert_eq!(5, utils::cfn_guard_test_command(args));
+        assert_eq!(5, utils::cfn_guard_test_command(args, Box::new(Validate::new())));
     }
 
     #[test]
@@ -271,7 +272,7 @@ mod tests {
             &rules_option,
             &rules_arg2,
         ];
-        assert_eq!(5, utils::cfn_guard_test_command(args));
+        assert_eq!(5, utils::cfn_guard_test_command(args, Box::new(Validate::new())));
     }
 
     #[test]
@@ -294,7 +295,7 @@ mod tests {
             &rules_option,
             &rules_arg,
         ];
-        assert_eq!(5, utils::cfn_guard_test_command(args));
+        assert_eq!(5, utils::cfn_guard_test_command(args, Box::new(Validate::new())));
     }
 
     #[test]
@@ -317,7 +318,7 @@ mod tests {
             &rules_option,
             &rules_arg2,
         ];
-        assert_eq!(5, utils::cfn_guard_test_command(args));
+        assert_eq!(5, utils::cfn_guard_test_command(args, Box::new(Validate::new())));
     }
 
     #[test]
@@ -338,7 +339,7 @@ mod tests {
             &rules_option,
             &rules_arg2,
         ];
-        assert_eq!(5, utils::cfn_guard_test_command(args));
+        assert_eq!(5, utils::cfn_guard_test_command(args, Box::new(Validate::new())));
     }
 
     #[test]
@@ -359,7 +360,7 @@ mod tests {
             &rules_option,
             &rules_arg,
         ];
-        assert_eq!(5, utils::cfn_guard_test_command(args));
+        assert_eq!(5, utils::cfn_guard_test_command(args, Box::new(Validate::new())));
     }
 
     #[test]
@@ -385,7 +386,7 @@ mod tests {
             &rules_option,
             &rules_arg2,
         ];
-        assert_eq!(5, utils::cfn_guard_test_command(args));
+        assert_eq!(5, utils::cfn_guard_test_command(args, Box::new(Validate::new())));
     }
 
     #[test]
@@ -407,7 +408,7 @@ mod tests {
             &input_parameters_option,
             &input_parameters_arg,
         ];
-        assert_eq!(5, utils::cfn_guard_test_command(args));
+        assert_eq!(5, utils::cfn_guard_test_command(args, Box::new(Validate::new())));
     }
 
     #[test]
@@ -434,7 +435,7 @@ mod tests {
             &input_parameters_option,
             &input_parameters_arg2,
         ];
-        assert_eq!(0, utils::cfn_guard_test_command(args));
+        assert_eq!(0, utils::cfn_guard_test_command(args, Box::new(Validate::new())));
     }
 
     #[test]
@@ -456,7 +457,7 @@ mod tests {
             &input_parameters_option,
             &input_parameters_arg,
         ];
-        assert_eq!(0, utils::cfn_guard_test_command(args));
+        assert_eq!(0, utils::cfn_guard_test_command(args, Box::new(Validate::new())));
     }
 
     #[test]
@@ -469,7 +470,7 @@ mod tests {
         let rules_option = format!("-{}", RULES.1);
         let args = vec![VALIDATE, &data_option, &data_arg, &rules_option, &rules_arg];
         // -1 status code equates to Error being thrown
-        assert_eq!(-1, utils::cfn_guard_test_command(args));
+        assert_eq!(-1, utils::cfn_guard_test_command(args, Box::new(Validate::new())));
     }
 
     #[test]
@@ -482,7 +483,7 @@ mod tests {
         let rules_option = format!("-{}", RULES.1);
         let args = vec![VALIDATE, &data_option, &data_arg, &rules_option, &rules_arg];
         // -1 status code equates to Error being thrown
-        assert_eq!(-1, utils::cfn_guard_test_command(args));
+        assert_eq!(-1, utils::cfn_guard_test_command(args, Box::new(Validate::new())));
     }
 
     #[test]
@@ -505,7 +506,7 @@ mod tests {
             &input_parameters_arg,
         ];
         // -1 status code equates to Error being thrown
-        assert_eq!(-1, utils::cfn_guard_test_command(args));
+        assert_eq!(-1, utils::cfn_guard_test_command(args, Box::new(Validate::new())));
     }
 
     #[test]
@@ -518,7 +519,7 @@ mod tests {
         let data_option = format!("-{}", DATA.1);
         let rules_option = format!("-{}", RULES.1);
         let args = vec![VALIDATE, &data_option, &data_arg, &rules_option, &rules_arg];
-        assert_eq!(5, utils::cfn_guard_test_command(args));
+        assert_eq!(5, utils::cfn_guard_test_command(args, Box::new(Validate::new())));
     }
 
     #[test]
@@ -542,7 +543,7 @@ mod tests {
             &rules_option,
             &rules_arg2,
         ];
-        assert_eq!(5, utils::cfn_guard_test_command(args));
+        assert_eq!(5, utils::cfn_guard_test_command(args, Box::new(Validate::new())));
     }
 
     #[test]
@@ -555,7 +556,7 @@ mod tests {
         let rules_option = format!("-{}", RULES.1);
         let args = vec![VALIDATE, &data_option, &data_arg, &rules_option, &rules_arg];
         // -1 status code equates to Error being thrown
-        assert_eq!(-1, utils::cfn_guard_test_command(args));
+        assert_eq!(-1, utils::cfn_guard_test_command(args, Box::new(Validate::new())));
     }
 
     #[test]
@@ -579,7 +580,7 @@ mod tests {
             &rules_arg,
         ];
         // -1 status code equates to Error being thrown
-        assert_eq!(-1, utils::cfn_guard_test_command(args));
+        assert_eq!(-1, utils::cfn_guard_test_command(args, Box::new(Validate::new())));
     }
 
     #[test]
@@ -602,7 +603,7 @@ mod tests {
             &input_parameters_arg,
         ];
         // -1 status code equates to Error being thrown
-        assert_eq!(-1, utils::cfn_guard_test_command(args));
+        assert_eq!(-1, utils::cfn_guard_test_command(args, Box::new(Validate::new())));
     }
 
     #[test]
@@ -629,7 +630,7 @@ mod tests {
             &input_parameters_arg2,
         ];
         // -1 status code equates to Error being thrown
-        assert_eq!(-1, utils::cfn_guard_test_command(args));
+        assert_eq!(-1, utils::cfn_guard_test_command(args, Box::new(Validate::new())));
     }
 
     #[test]
@@ -647,7 +648,58 @@ mod tests {
             let data_option = &format!("-{}", DATA.1);
             let rules_option = &format!("-{}", RULES.1);
             let args = vec![VALIDATE, data_option, &arg.0, rules_option, &arg.1];
-            assert_eq!(-1, utils::cfn_guard_test_command(args))
+            assert_eq!(-1, utils::cfn_guard_test_command(args, Box::new(Validate::new())))
         }
+    }
+}
+
+
+#[cfg(test)]
+mod test_test_command {
+    use rstest::rstest;
+    use cfn_guard::commands::{RULES, TEST, TEST_DATA};
+    use cfn_guard::commands::test::Test;
+    use cfn_guard::Error;
+
+    #[rstest::rstest]
+    #[case("json")]
+    #[case("yaml")]
+    fn test_test_data_file_with_shorthand_reference(#[case] file_type: &str) -> Result<(), Error> {
+        let test_data_arg = crate::utils::get_full_path_for_resource_file(&format!("resources/test-data-dir/s3_bucket_logging_enabled_tests.{}", file_type));
+        let rule_arg = crate::utils::get_full_path_for_resource_file("resources/rules-dir/s3_bucket_logging_enabled.guard");
+        let data_option = format!("-{}", TEST_DATA.1);
+        let rules_option = format!("-{}", RULES.1);
+
+        let args = vec![
+            TEST,
+            &data_option,
+            &test_data_arg,
+            &rules_option,
+            &rule_arg,
+        ];
+
+        assert_eq!(0, crate::utils::cfn_guard_test_command(args, Box::new(Test::new())));
+        Ok(())
+    }
+
+    #[rstest::rstest]
+    #[case("json")]
+    #[case("yaml")]
+    fn test_test_data_file(#[case] file_type: &str) -> Result<(), Error> {
+        let test_data_arg = crate::utils::get_full_path_for_resource_file(&format!("resources/test-data-dir/s3_bucket_server_side_encryption_enabled.{}", file_type));
+        let rule_arg = crate::utils::get_full_path_for_resource_file("resources/rules-dir/s3_bucket_server_side_encryption_enabled.guard");
+        let data_option = format!("-{}", TEST_DATA.1);
+        let rules_option = format!("-{}", RULES.1);
+
+        let args = vec![
+            TEST,
+            &data_option,
+            &test_data_arg,
+            &rules_option,
+            &rule_arg,
+        ];
+
+        assert_eq!(0, crate::utils::cfn_guard_test_command(args, Box::new(Test::new())));
+        Ok(())
     }
 }

--- a/guard/tests/utils.rs
+++ b/guard/tests/utils.rs
@@ -35,16 +35,16 @@ pub fn get_full_path_for_resource_file(path: &str) -> String {
     return resource.display().to_string();
 }
 
-pub fn cfn_guard_test_command(args: Vec<&str>, command: Box<dyn Command>) -> i32 {
+pub fn cfn_guard_test_command<T: Command>(command: T, args: Vec<&str>) -> i32 {
     let TEST_APP_NAME = "cfn-guard-test";
     let mut app =
         App::new(TEST_APP_NAME);
     let mut command_options = Vec::new();
     command_options.push(TEST_APP_NAME);
-    command_options.append( args.clone().as_mut());
+    command_options.append(args.clone().as_mut());
 
     let mut commands: Vec<Box<dyn Command>> = Vec::with_capacity(2);
-    commands.push(command);
+    commands.push(Box::new(command));
 
     let mappings = commands.iter()
         .map(|s| (s.name(), s)).fold(

--- a/guard/tests/utils.rs
+++ b/guard/tests/utils.rs
@@ -9,6 +9,7 @@ use std::collections::HashMap;
 use clap::App;
 use cfn_guard::command::Command;
 use cfn_guard::commands::{DATA, RULES};
+use cfn_guard::commands::test::Test;
 
 pub fn get_data_option() -> String {
     format!("-{}", DATA.1)
@@ -34,7 +35,7 @@ pub fn get_full_path_for_resource_file(path: &str) -> String {
     return resource.display().to_string();
 }
 
-pub fn cfn_guard_test_command(args: Vec<&str>) -> i32 {
+pub fn cfn_guard_test_command(args: Vec<&str>, command: Box<dyn Command>) -> i32 {
     let TEST_APP_NAME = "cfn-guard-test";
     let mut app =
         App::new(TEST_APP_NAME);
@@ -43,8 +44,7 @@ pub fn cfn_guard_test_command(args: Vec<&str>) -> i32 {
     command_options.append( args.clone().as_mut());
 
     let mut commands: Vec<Box<dyn Command>> = Vec::with_capacity(2);
-    commands.push(Box::new(Validate::new()));
-    // crate::commands::
+    commands.push(command);
 
     let mappings = commands.iter()
         .map(|s| (s.name(), s)).fold(
@@ -61,27 +61,25 @@ pub fn cfn_guard_test_command(args: Vec<&str>) -> i32 {
 
     let app = app.get_matches_from(command_options);
 
-    match app.subcommand() {
+     match app.subcommand() {
         (name, Some(value)) => {
             if let Some(command) = mappings.get(name) {
                 match (*command).execute(value) {
                     Err(e) => {
                         println!("Error occurred {}", e);
-                        return -1;
+                        -1
                     },
                     Ok(code) => {
-                        return code;
+                        code
                     }
                 }
-            }
-            else {
-                return -2;
+            } else {
+                -2
             }
         },
 
         (_, None) => {
-            return -3;
+            -3
         }
     }
-
 }


### PR DESCRIPTION
*Issue #, if available:*
Fixed an issue causing test templates to fail + added 4 new tests to cover the test command

*Description of changes:*
Changed 2 fields on the TestSpec struct in  commands/validate.rs 

name: Option<serde_json::Value> -> Option<String> (this doesnt need to be a Value, this will always be a string) 
input: serde_json::Value -> serde_yaml::Value. Newer versions of serde_yaml broke this compatibility, previously we could go from serde_json::Value -> serde_yaml::Value, and vice versa. Now we are only able to safely go from serde_yaml::Value -> serde_json::Value. Hence the switch 

---
*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
