### PR TITLE
Fix for broken release workflow 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       run: cargo build --verbose --release
     - name: Get release
       id: get_release
-      uses: bruceadams/get-release@v1.2.2
+      uses: bruceadams/get-release@v1.3.2
       env:
         GITHUB_TOKEN: ${{ github.token }}
     - name: Package release
@@ -25,8 +25,8 @@ jobs:
       run: |
         mkdir cfn-guard-v2-${{ matrix.os }}
         cp ./target/release/cfn-guard ./cfn-guard-v2-${{ matrix.os }}/
-        cp ./target/release/*.so ./cfn-guard-v2-${{ matrix.os }}/
-        cp ./target/release/*.dylib ./cfn-guard-v2-${{ matrix.os }}/
+        test -e ./target/release/*.so && cp ./target/release/*.so ./cfn-guard-v2-${{ matrix.os }}/
+        test -e ./target/release/*.dylib && cp ./target/release/*.dylib ./cfn-guard-v2-${{ matrix.os }}/
         cp README.md ./cfn-guard-v2-${{ matrix.os }}/
         tar czvf ./cfn-guard-v2-${{ matrix.os }}.tar.gz ./cfn-guard-v2-${{ matrix.os }}
     - name: Upload Release Asset


### PR DESCRIPTION
*Issue #, if available:*
This PR fixes a bug in the release workflow. *.dylib files were not present on linux machines, while *.so files were not present on macos machines, causing the action to fail. We now test the existence of those files before attempting to copy them, and if theyre present we copy them. 

*Description of changes:*


---
*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
