### PR TITLE
Fix for cfn-guard-lambda for timestamp offset & GitHub actions for auto-testing Lambda

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Build
       run: cargo build --release --verbose
     - name: Run tests
@@ -29,3 +29,111 @@ jobs:
     - uses: actions/checkout@v2
     - name: Shellcheck
       run: shellcheck install-guard.sh
+
+  test-lambda:
+
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-region: ${{ secrets.AWS_REGION }}
+          role-to-assume: ${{ secrets.LAMBDA_CREATION_ROLE_NAME }}
+          role-session-name: LambdaTestGitHubAction
+
+
+      - name: Generate identifiers
+        id: generate-identifiers
+        run: |
+          LAMBDA_FUNCTION_PREFIX=GhCfnGrd
+          git_hash=$(git rev-parse --short "$GITHUB_SHA")
+          git_branch=${GITHUB_REF#refs/heads/}
+          commit_hash=${git_branch}_${git_hash}
+          LAMBDA_FUNCTION_NAME=${LAMBDA_FUNCTION_PREFIX}_${commit_hash}
+          ROLE_NAME="${LAMBDA_FUNCTION_NAME}Role"
+          
+          echo "LAMBDA_FUNCTION_NAME=${LAMBDA_FUNCTION_NAME}" >> $GITHUB_OUTPUT
+          echo "ROLE_NAME=${ROLE_NAME}" >> $GITHUB_OUTPUT
+
+
+      - name: Deploy cfn-guard-lambda
+        env:
+          AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
+          AWS_REGION: ${{ secrets.AWS_REGION }}
+          LAMBDA_FUNCTION_NAME: ${{ steps.generate-identifiers.outputs.LAMBDA_FUNCTION_NAME }}
+          ROLE_NAME: ${{ steps.generate-identifiers.outputs.ROLE_NAME }}
+        run: |
+          rustup target add x86_64-unknown-linux-musl
+          cd guard-lambda
+          cargo build --release --target x86_64-unknown-linux-musl --verbose
+          cp ./../target/x86_64-unknown-linux-musl/release/cfn-guard-lambda ./bootstrap && zip lambda.zip bootstrap && rm bootstrap
+        
+          aws iam create-role \
+            --role-name $ROLE_NAME \
+            --assume-role-policy-document '{"Version": "2012-10-17","Statement": [{ "Effect": "Allow", "Principal": {"Service": "lambda.amazonaws.com"}, "Action": "sts:AssumeRole"}]}'
+          
+          aws iam attach-role-policy --role-name $ROLE_NAME \
+            --policy-arn arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+          
+          sleep 10
+          
+          aws lambda create-function \
+            --function-name $LAMBDA_FUNCTION_NAME \
+            --handler guard.handler \
+            --zip-file fileb://./lambda.zip \
+            --runtime provided \
+            --role "arn:aws:iam::${AWS_ACCOUNT_ID}:role/${ROLE_NAME}" \
+            --environment Variables={RUST_BACKTRACE=1} \
+            --tracing-config Mode=Active \
+            --region $AWS_REGION
+
+
+      - name: Invoke Lambda and test output
+        env:
+          LAMBDA_FUNCTION_NAME: ${{ steps.generate-identifiers.outputs.LAMBDA_FUNCTION_NAME }}
+        run: |
+          aws lambda invoke \
+            --function-name $LAMBDA_FUNCTION_NAME \
+            --payload '{"data":"{\"Resources\":{\"NewVolume\":{\"Type\":\"AWS::EC2::Volume\",\"Properties\":{\"Size\":500,\"Encrypted\":true,\"AvailabilityZone\":\"us-west-2b\"}},\"NewVolume2\":{\"Type\":\"AWS::EC2::Volume\",\"Properties\":{\"Size\":50,\"Encrypted\":true,\"AvailabilityZone\":\"us-west-2c\"}}}}","rules":["let ec2_volumes = Resources.*[ Type == /EC2::Volume/ ]\nrule EC2_ENCRYPTION_BY_DEFAULT when %ec2_volumes !empty {\n    %ec2_volumes.Properties.Encrypted == true \n      <<\n            Violation: All EBS Volumes should be encryped \n            Fix: Set Encrypted property to true\n       >>\n}"],"verbose":false}' \
+            --cli-binary-format raw-in-base64-out \
+            output.json
+          
+          echo '{"message":[{"data_from":"lambda-payload","rules_from":"lambda-rule","not_compliant":{},"not_applicable":[],"compliant":["EC2_ENCRYPTION_BY_DEFAULT"]}]}' > expected-output.json
+          
+          difference=`diff expected-output.json output.json -w | wc -c`
+          
+          if [ "$difference" != 0 ]
+          then
+            echo "Lambda output does not match the expected one"
+            echo "--------------------------------"
+            echo "Actual output:"
+            cat output.json
+            echo "--------------------------------"
+            echo "Expected output:"
+            cat expected-output.json
+            echo "--------------------------------"
+            echo "diff:"
+            echo "$difference"
+            exit 1
+          fi
+
+
+      - name: Clean up resources
+        if: success() || failure()
+        env:
+          LAMBDA_FUNCTION_NAME: ${{ steps.generate-identifiers.outputs.LAMBDA_FUNCTION_NAME }}
+          ROLE_NAME: ${{ steps.generate-identifiers.outputs.ROLE_NAME }}
+        run: |
+          aws lambda delete-function --function-name $LAMBDA_FUNCTION_NAME
+          aws iam detach-role-policy \
+            --role-name $ROLE_NAME \
+            --policy-arn arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+          aws iam delete-role --role-name $ROLE_NAME

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-region: ${{ secrets.AWS_REGION }}
+          aws-region: ${{ secrets.LAMBDA_CREATION_AWS_REGION }}
           role-to-assume: ${{ secrets.LAMBDA_CREATION_ROLE_NAME }}
           role-session-name: LambdaTestGitHubAction
 
@@ -55,8 +55,15 @@ jobs:
         run: |
           LAMBDA_FUNCTION_PREFIX=GhCfnGrd
           git_hash=$(git rev-parse --short "$GITHUB_SHA")
-          git_branch=${GITHUB_REF#refs/heads/}
-          commit_hash=${git_branch}_${git_hash}
+          
+          if [[ $GITHUB_REF == *"/heads/"* ]]; then
+            git_branch_or_pr=${GITHUB_REF#refs/heads/}
+          else
+            git_branch_or_pr="PR$(echo $GITHUB_REF | awk 'BEGIN { FS = "/" } ; { print $3 }')"
+          fi
+        
+          commit_hash=${git_branch_or_pr}_${git_hash}
+          
           LAMBDA_FUNCTION_NAME=${LAMBDA_FUNCTION_PREFIX}_${commit_hash}
           ROLE_NAME="${LAMBDA_FUNCTION_NAME}Role"
           
@@ -66,8 +73,8 @@ jobs:
 
       - name: Deploy cfn-guard-lambda
         env:
-          AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
-          AWS_REGION: ${{ secrets.AWS_REGION }}
+          AWS_ACCOUNT_ID: ${{ secrets.LAMBDA_CREATION_AWS_ACCOUNT_ID }}
+          AWS_REGION: ${{ secrets.LAMBDA_CREATION_AWS_REGION }}
           LAMBDA_FUNCTION_NAME: ${{ steps.generate-identifiers.outputs.LAMBDA_FUNCTION_NAME }}
           ROLE_NAME: ${{ steps.generate-identifiers.outputs.ROLE_NAME }}
         run: |

--- a/.github/workflows/publish_docker.yml
+++ b/.github/workflows/publish_docker.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
-        aws-region: ${{ secrets.AWS_REGION }}
+        aws-region: ${{ secrets.PUBLISHER_AWS_REGION }}
         role-to-assume: ${{ secrets.PUBLISHER_ROLE_NAME }}
         role-session-name: PublishToElasticContainerRegistry
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -115,7 +115,7 @@ version = "2.1.2"
 dependencies = [
  "Inflector",
  "clap",
- "colored 2.0.0",
+ "colored",
  "enumflags2",
  "enumflags2_derive",
  "grep-matcher",
@@ -132,7 +132,6 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
- "simple_logger",
  "string-builder",
  "unsafe-libyaml",
  "urlencoding",
@@ -174,17 +173,6 @@ dependencies = [
  "textwrap",
  "unicode-width",
  "vec_map",
-]
-
-[[package]]
-name = "colored"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4ffc801dacf156c5854b9df4f425a626539c3a6ef7893cc0c5084a23f0b6c59"
-dependencies = [
- "atty",
- "lazy_static",
- "winapi",
 ]
 
 [[package]]
@@ -568,7 +556,7 @@ dependencies = [
  "libc",
  "log",
  "wasi",
- "windows-sys",
+ "windows-sys 0.36.1",
 ]
 
 [[package]]
@@ -782,15 +770,15 @@ dependencies = [
 
 [[package]]
 name = "simple_logger"
-version = "1.16.0"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45b60258a35dc3cb8a16890b8fd6723349bfa458d7960e25e633f1b1c19d7b5e"
+checksum = "e190a521c2044948158666916d9e872cbb9984f755e9bb3b5b75a836205affcd"
 dependencies = [
  "atty",
- "colored 1.9.3",
+ "colored",
  "log",
  "time",
- "winapi",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -861,21 +849,32 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.15"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d634a985c4d4238ec39cacaed2e7ae552fbd3c476b552c1deac3021b7d7eaf0c"
+checksum = "a561bf4617eebd33bca6434b988f39ed798e527f51a1e797d0ee4f61c0a38376"
 dependencies = [
  "itoa",
  "libc",
  "num_threads",
+ "serde",
+ "time-core",
  "time-macros",
 ]
 
 [[package]]
-name = "time-macros"
-version = "0.2.4"
+name = "time-core"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42657b1a6f4d817cda8e7a0ace261fe0cc946cf3a80314390b22cc61ae080792"
+checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
+
+[[package]]
+name = "time-macros"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d967f99f534ca7e495c575c62638eebc2898a8c84c119b89e250477bc4ba16b2"
+dependencies = [
+ "time-core",
+]
 
 [[package]]
 name = "tokio"
@@ -1096,12 +1095,33 @@ version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
 dependencies = [
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_msvc",
+ "windows_aarch64_msvc 0.36.1",
+ "windows_i686_gnu 0.36.1",
+ "windows_i686_msvc 0.36.1",
+ "windows_x86_64_gnu 0.36.1",
+ "windows_x86_64_msvc 0.36.1",
 ]
+
+[[package]]
+name = "windows-sys"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc 0.42.0",
+ "windows_i686_gnu 0.42.0",
+ "windows_i686_msvc 0.42.0",
+ "windows_x86_64_gnu 0.42.0",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc 0.42.0",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d2aa71f6f0cbe00ae5167d90ef3cfe66527d6f613ca78ac8024c3ccab9a19e"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -1110,10 +1130,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
 
 [[package]]
+name = "windows_aarch64_msvc"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd0f252f5a35cac83d6311b2e795981f5ee6e67eb1f9a7f64eb4500fbc4dcdb4"
+
+[[package]]
 name = "windows_i686_gnu"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbeae19f6716841636c28d695375df17562ca208b2b7d0dc47635a50ae6c5de7"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1122,13 +1154,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84c12f65daa39dd2babe6e442988fc329d6243fdce47d7d2d155b8d874862246"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf7b1b21b5362cbc318f686150e5bcea75ecedc74dd157d874d754a2ca44b0ed"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09d525d2ba30eeb3297665bd434a54297e4170c7f1a44cad4ef58095b4cd2028"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"

--- a/guard-lambda/Cargo.toml
+++ b/guard-lambda/Cargo.toml
@@ -14,7 +14,7 @@ lambda_runtime = "0.3.0"
 serde = { version = "1.0.92", features = ["derive"] }
 serde_json = "1.0.64"
 serde_derive = "1.0.92"
-simple_logger = "1.3.0"
+simple_logger = "4.0.0"
 log = "0.4.6"
 tokio = "1.8.4"
 cfn-guard = { version = "2.1.2", path = "../guard" }

--- a/guard/Cargo.toml
+++ b/guard/Cargo.toml
@@ -21,10 +21,8 @@ nom = "5.1.2"
 nom_locate = "2.0.0"
 indexmap = { version = "1.6.0", features = ["serde-1"] }
 regex = "1.5.5"
-simple_logger = "1.3.0"
 clap = "2.29.0"
 serde = { version = "1.0", features = ["derive"] }
-#serde_json = "1.0.57"
 serde_yaml = "0.9.10"
 walkdir = "2.3.1"
 colored = "2.0.0"


### PR DESCRIPTION
*Issue #, if available:*
NA

*Duplicate of PR:*
#304 - Had to create the PR from the main repo to initialize GitHub secrets properly. ([Reference](https://stackoverflow.com/a/58740879))

*Description of changes:*
* Fix for `cfn-guard-lambda`'s simple-logger dependency, issue with [timestamps not getting initialized](https://github.com/borntyping/rust-simple_logger/issues/52 ) bumped it up to latest version.
* Added GitHub action for automatically testing Lambda behind the scenes


P.S. The GitHub action won't work until all the repository secrets are supplied.


---
*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
