### PR TITLE
Added OS-specific cargo targets to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,21 +23,21 @@ jobs:
     - name: Package release
       id: package
       uses: knicknic/os-specific-run@v1.0.3
-        with:
-          macos: |
-            rustup target add x86_64-apple-darwin
-            cargo build --release --target x86_64-apple-darwin
-            mkdir cfn-guard-v2-${{ matrix.os }}
-            cp ./target/x86_64-apple-darwin/release/cfn-guard ./cfn-guard-v2-${{ matrix.os }}/
-            cp README.md ./cfn-guard-v2-${{ matrix.os }}/
-            tar czvf ./cfn-guard-v2-${{ matrix.os }}.tar.gz ./cfn-guard-v2-${{ matrix.os }}
-          linux: |
-            rustup target add x86_64-unknown-linux-musl
-            cargo build --release --target x86_64-unknown-linux-musl
-            mkdir cfn-guard-v2-${{ matrix.os }}
-            cp ./target/x86_64-unknown-linux-musl/release/cfn-guard ./cfn-guard-v2-${{ matrix.os }}/
-            cp README.md ./cfn-guard-v2-${{ matrix.os }}/
-            tar czvf ./cfn-guard-v2-${{ matrix.os }}.tar.gz ./cfn-guard-v2-${{ matrix.os }}
+      with:
+        macos: |
+          rustup target add x86_64-apple-darwin
+          cargo build --release --target x86_64-apple-darwin
+          mkdir cfn-guard-v2-${{ matrix.os }}
+          cp ./target/x86_64-apple-darwin/release/cfn-guard ./cfn-guard-v2-${{ matrix.os }}/
+          cp README.md ./cfn-guard-v2-${{ matrix.os }}/
+          tar czvf ./cfn-guard-v2-${{ matrix.os }}.tar.gz ./cfn-guard-v2-${{ matrix.os }}
+        linux: |
+          rustup target add x86_64-unknown-linux-musl
+          cargo build --release --target x86_64-unknown-linux-musl
+          mkdir cfn-guard-v2-${{ matrix.os }}
+          cp ./target/x86_64-unknown-linux-musl/release/cfn-guard ./cfn-guard-v2-${{ matrix.os }}/
+          cp README.md ./cfn-guard-v2-${{ matrix.os }}/
+          tar czvf ./cfn-guard-v2-${{ matrix.os }}.tar.gz ./cfn-guard-v2-${{ matrix.os }}
     - name: Upload Release Asset
       id: upload-release-asset 
       uses: actions/upload-release-asset@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,9 +20,10 @@ jobs:
       uses: bruceadams/get-release@v1.3.2
       env:
         GITHUB_TOKEN: ${{ github.token }}
-        TARGETS: '{ "ubuntu-latest": "x86_64-unknown-linux-musl", "macos-latest": "x86_64-apple-darwin" }'
     - name: Package release
       id: package
+      env:
+        TARGETS: '{ "ubuntu-latest": "x86_64-unknown-linux-musl", "macos-latest": "x86_64-apple-darwin" }'
       run: |
         TARGET=${{ fromJson( ${TARGETS} )[ ${{ matrix.os }} ] }}
         echo "Building for target ${TARGET}..."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
         rustup target add ${TARGET}
         cargo build --release --target ${TARGET}
         mkdir cfn-guard-v2-${{ matrix.os }}
-        cp ./target/$TARGET/release/cfn-guard ./cfn-guard-v2-${{ matrix.os }}/
+        cp ./target/${TARGET}/release/cfn-guard ./cfn-guard-v2-${{ matrix.os }}/
         cp README.md ./cfn-guard-v2-${{ matrix.os }}/
         tar czvf ./cfn-guard-v2-${{ matrix.os }}.tar.gz ./cfn-guard-v2-${{ matrix.os }}
     - name: Upload Release Asset

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,22 +22,16 @@ jobs:
         GITHUB_TOKEN: ${{ github.token }}
     - name: Package release
       id: package
-      uses: knicknic/os-specific-run@v1.0.3
-      with:
-        macos: |
-          rustup target add x86_64-apple-darwin
-          cargo build --release --target x86_64-apple-darwin
-          mkdir cfn-guard-v2-${{ matrix.os }}
-          cp ./target/x86_64-apple-darwin/release/cfn-guard ./cfn-guard-v2-${{ matrix.os }}/
-          cp README.md ./cfn-guard-v2-${{ matrix.os }}/
-          tar czvf ./cfn-guard-v2-${{ matrix.os }}.tar.gz ./cfn-guard-v2-${{ matrix.os }}
-        linux: |
-          rustup target add x86_64-unknown-linux-musl
-          cargo build --release --target x86_64-unknown-linux-musl
-          mkdir cfn-guard-v2-${{ matrix.os }}
-          cp ./target/x86_64-unknown-linux-musl/release/cfn-guard ./cfn-guard-v2-${{ matrix.os }}/
-          cp README.md ./cfn-guard-v2-${{ matrix.os }}/
-          tar czvf ./cfn-guard-v2-${{ matrix.os }}.tar.gz ./cfn-guard-v2-${{ matrix.os }}
+      run: |
+        declare -A TARGETS=( ["ubuntu-latest"]="x86_64-unknown-linux-musl" ["macos-latest"]="x86_64-apple-darwin")
+        TARGET=${TARGETS[${{ matrix.os }}]}
+        echo "Building for target ${TARGET}..."
+        rustup target add ${TARGET}
+        cargo build --release --target ${TARGET}
+        mkdir cfn-guard-v2-${{ matrix.os }}
+        cp ./target/$TARGET/release/cfn-guard ./cfn-guard-v2-${{ matrix.os }}/
+        cp README.md ./cfn-guard-v2-${{ matrix.os }}/
+        tar czvf ./cfn-guard-v2-${{ matrix.os }}.tar.gz ./cfn-guard-v2-${{ matrix.os }}
     - name: Upload Release Asset
       id: upload-release-asset 
       uses: actions/upload-release-asset@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,16 +22,22 @@ jobs:
         GITHUB_TOKEN: ${{ github.token }}
     - name: Package release
       id: package
-      run: |
-        declare -A TARGETS=( ["ubuntu-latest"]="x86_64-unknown-linux-musl" ["macos-latest"]="x86_64-apple-darwin")
-        TARGET=${TARGETS[${{ matrix.os }}]}
-        echo "Building for target ${TARGET}..."
-        rustup target add ${TARGET}
-        cargo build --release --target ${TARGET}
-        mkdir cfn-guard-v2-${{ matrix.os }}
-        cp ./target/${TARGET}/release/cfn-guard ./cfn-guard-v2-${{ matrix.os }}/
-        cp README.md ./cfn-guard-v2-${{ matrix.os }}/
-        tar czvf ./cfn-guard-v2-${{ matrix.os }}.tar.gz ./cfn-guard-v2-${{ matrix.os }}
+      uses: knicknic/os-specific-run@v1.0.3
+        with:
+          macos: |
+            rustup target add x86_64-apple-darwin
+            cargo build --release --target x86_64-apple-darwin
+            mkdir cfn-guard-v2-${{ matrix.os }}
+            cp ./target/x86_64-apple-darwin/release/cfn-guard ./cfn-guard-v2-${{ matrix.os }}/
+            cp README.md ./cfn-guard-v2-${{ matrix.os }}/
+            tar czvf ./cfn-guard-v2-${{ matrix.os }}.tar.gz ./cfn-guard-v2-${{ matrix.os }}
+          linux: |
+            rustup target add x86_64-unknown-linux-musl
+            cargo build --release --target x86_64-unknown-linux-musl
+            mkdir cfn-guard-v2-${{ matrix.os }}
+            cp ./target/x86_64-unknown-linux-musl/release/cfn-guard ./cfn-guard-v2-${{ matrix.os }}/
+            cp README.md ./cfn-guard-v2-${{ matrix.os }}/
+            tar czvf ./cfn-guard-v2-${{ matrix.os }}.tar.gz ./cfn-guard-v2-${{ matrix.os }}
     - name: Upload Release Asset
       id: upload-release-asset 
       uses: actions/upload-release-asset@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,9 +20,14 @@ jobs:
       uses: bruceadams/get-release@v1.3.2
       env:
         GITHUB_TOKEN: ${{ github.token }}
+        TARGETS: '{ "ubuntu-latest": "x86_64-unknown-linux-musl", "macos-latest": "x86_64-apple-darwin" }'
     - name: Package release
       id: package
       run: |
+        TARGET=${{ fromJson( ${TARGETS} )[ ${{ matrix.os }} ] }}
+        echo "Building for target ${TARGET}..."
+        rustup target add $TARGET
+        cargo build --release --target $TARGET
         mkdir cfn-guard-v2-${{ matrix.os }}
         cp ./target/$TARGET/release/cfn-guard ./cfn-guard-v2-${{ matrix.os }}/
         cp README.md ./cfn-guard-v2-${{ matrix.os }}/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,9 +24,7 @@ jobs:
       id: package
       run: |
         mkdir cfn-guard-v2-${{ matrix.os }}
-        cp ./target/release/cfn-guard ./cfn-guard-v2-${{ matrix.os }}/
-        test -e ./target/release/*.so && cp ./target/release/*.so ./cfn-guard-v2-${{ matrix.os }}/
-        test -e ./target/release/*.dylib && cp ./target/release/*.dylib ./cfn-guard-v2-${{ matrix.os }}/
+        cp ./target/$TARGET/release/cfn-guard ./cfn-guard-v2-${{ matrix.os }}/
         cp README.md ./cfn-guard-v2-${{ matrix.os }}/
         tar czvf ./cfn-guard-v2-${{ matrix.os }}.tar.gz ./cfn-guard-v2-${{ matrix.os }}
     - name: Upload Release Asset

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,10 +22,8 @@ jobs:
         GITHUB_TOKEN: ${{ github.token }}
     - name: Package release
       id: package
-      env:
-        TARGETS: '{ "ubuntu-latest": "x86_64-unknown-linux-musl", "macos-latest": "x86_64-apple-darwin" }'
       run: |
-        TARGET=${{ fromJson( ${TARGETS} )[ ${{ matrix.os }} ] }}
+        TARGET=${{ fromJson('{ "ubuntu-latest": "x86_64-unknown-linux-musl", "macos-latest": "x86_64-apple-darwin" }')[ ${{ matrix.os }} ] }}
         echo "Building for target ${TARGET}..."
         rustup target add $TARGET
         cargo build --release --target $TARGET

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,15 +22,22 @@ jobs:
         GITHUB_TOKEN: ${{ github.token }}
     - name: Package release
       id: package
-      run: |
-        TARGET=${{ fromJson('{ "ubuntu-latest": "x86_64-unknown-linux-musl", "macos-latest": "x86_64-apple-darwin" }')[ ${{ matrix.os }} ] }}
-        echo "Building for target ${TARGET}..."
-        rustup target add $TARGET
-        cargo build --release --target $TARGET
-        mkdir cfn-guard-v2-${{ matrix.os }}
-        cp ./target/$TARGET/release/cfn-guard ./cfn-guard-v2-${{ matrix.os }}/
-        cp README.md ./cfn-guard-v2-${{ matrix.os }}/
-        tar czvf ./cfn-guard-v2-${{ matrix.os }}.tar.gz ./cfn-guard-v2-${{ matrix.os }}
+      uses: knicknic/os-specific-run@v1.0.3
+      with:
+        macos: |
+          rustup target add x86_64-apple-darwin
+          cargo build --release --target x86_64-apple-darwin
+          mkdir cfn-guard-v2-${{ matrix.os }}
+          cp ./target/x86_64-apple-darwin/release/cfn-guard ./cfn-guard-v2-${{ matrix.os }}/
+          cp README.md ./cfn-guard-v2-${{ matrix.os }}/
+          tar czvf ./cfn-guard-v2-${{ matrix.os }}.tar.gz ./cfn-guard-v2-${{ matrix.os }}
+        linux: |
+          rustup target add x86_64-unknown-linux-musl
+          cargo build --release --target x86_64-unknown-linux-musl
+          mkdir cfn-guard-v2-${{ matrix.os }}
+          cp ./target/x86_64-unknown-linux-musl/release/cfn-guard ./cfn-guard-v2-${{ matrix.os }}/
+          cp README.md ./cfn-guard-v2-${{ matrix.os }}/
+          tar czvf ./cfn-guard-v2-${{ matrix.os }}.tar.gz ./cfn-guard-v2-${{ matrix.os }}
     - name: Upload Release Asset
       id: upload-release-asset 
       uses: actions/upload-release-asset@v1


### PR DESCRIPTION
*Issue #, if available:*
#253 

*Description of changes:*
* Added OS-specific build targets for cargo, since Ubuntu build required `musl` compiler to be used instead of default GNU
* Removed non-executable binary libraries from the published artifacts

---
*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
