### PR TITLE
Fix handling short notation form for !GetAtt 

### DIFF
--- a/guard/src/commands/parse_tree.rs
+++ b/guard/src/commands/parse_tree.rs
@@ -81,7 +81,7 @@ impl Command for ParseTree {
                 if yaml {
                     serde_yaml::to_writer(out, &rules)?;
                 } else {
-                    serde_json::to_writer(out, &rules)?;
+                    serde_json::to_writer_pretty(out, &rules)?;
                 }
             }
         }

--- a/guard/src/rules/eval_context.rs
+++ b/guard/src/rules/eval_context.rs
@@ -591,9 +591,11 @@ fn query_retrieval_with_converter<'value, 'loc: 'value>(
             _ => to_unresolved_result(
                 current,
                 format!(
-                    "Attempting to retrieve from index {} but type is not an array at path {}",
+                    "Attempting to retrieve from index {} but type is not an array at path {}, \
+                    type {}",
                     index,
-                    current.self_path()
+                    current.self_path(),
+                    current.type_info()
                 ),
                 &query[query_index..],
             ),

--- a/guard/src/rules/libyaml/loader.rs
+++ b/guard/src/rules/libyaml/loader.rs
@@ -213,13 +213,26 @@ impl Loader {
         fn_ref: &str,
     ) -> Option<MarkedValue> {
         match fn_ref {
-            "Ref" | "Base64" | "Sub" | "GetAZs" | "ImportValue" | "GetAtt" | "Condition"
-            | "RefAll" => {
+            "Ref" | "Base64" | "Sub" | "GetAZs" | "ImportValue" | "Condition" | "RefAll" => {
                 let mut map = indexmap::IndexMap::new();
                 let fn_ref = Self::short_form_to_long(fn_ref);
                 map.insert(
                     (fn_ref.to_string(), loc.clone()),
                     MarkedValue::String(val, loc.clone()),
+                );
+                Some(MarkedValue::Map(map, loc))
+            }
+
+            "GetAtt" => {
+                let mut map = indexmap::IndexMap::new();
+                let fn_ref = Self::short_form_to_long(fn_ref);
+                let array: Vec<MarkedValue> = val
+                    .split(".")
+                    .map(|s| MarkedValue::String(s.to_string(), loc.clone()))
+                    .collect();
+                map.insert(
+                    (fn_ref.to_string(), loc.clone()),
+                    MarkedValue::List(array, loc.clone()),
                 );
                 Some(MarkedValue::Map(map, loc))
             }


### PR DESCRIPTION
*Issue #, if available:* NEW bug found when testing


*Description of changes:*

1. When using the short form in YAML for `Fn::GetAtt`, like `!GetAtt MyKey.Arn`, the argument was used directly as a string. This change coverts it correctly into the long form for Fn::GetAtt. 
2. Fix for improved error message with type information 
3. Pretty print JSON as default for parse-tree


---
*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
