### PR TITLE
Addit cargo-audit to CI + bump up clap to 3.0

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -40,3 +40,11 @@ jobs:
           components: rustfmt
       - name: Rustfmt Check
         uses: actions-rust-lang/rustfmt@v1
+
+  security_audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/audit-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -40,11 +40,3 @@ jobs:
           components: rustfmt
       - name: Rustfmt Check
         uses: actions-rust-lang/rustfmt@v1
-
-  security_audit:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions-rs/audit-check@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/security_audit.yml
+++ b/.github/workflows/security_audit.yml
@@ -1,7 +1,7 @@
 name: Security audit
 on:
   schedule:
-    - cron: '0 0 * * *'
+    - cron: '0 12 * * *'
 jobs:
   audit:
     runs-on: ubuntu-latest

--- a/.github/workflows/security_audit.yml
+++ b/.github/workflows/security_audit.yml
@@ -1,7 +1,7 @@
 name: Security audit
 on:
   schedule:
-    - cron: '0 12 * * *'
+    - cron: '0 17 * * *'
 jobs:
   audit:
     runs-on: ubuntu-latest

--- a/.github/workflows/security_audit.yml
+++ b/.github/workflows/security_audit.yml
@@ -1,0 +1,12 @@
+name: Security audit
+on:
+  schedule:
+    - cron: '0 0 * * *'
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions-rs/audit-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,15 +22,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "arrayvec"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -181,17 +172,26 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "2.34.0"
+version = "3.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+checksum = "71655c45cb9845d3270c9d6df84ebe72b4dad3c2ba3f7023ad47c144e4e473a5"
 dependencies = [
- "ansi_term",
  "atty",
  "bitflags",
+ "clap_lex",
+ "indexmap",
  "strsim",
+ "termcolor",
  "textwrap",
- "unicode-width",
- "vec_map",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+dependencies = [
+ "os_str_bytes",
 ]
 
 [[package]]
@@ -651,6 +651,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
 
 [[package]]
+name = "os_str_bytes"
+version = "6.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -867,9 +873,9 @@ dependencies = [
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
@@ -883,13 +889,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "textwrap"
-version = "0.11.0"
+name = "termcolor"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
 dependencies = [
- "unicode-width",
+ "winapi-util",
 ]
+
+[[package]]
+name = "textwrap"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 
 [[package]]
 name = "thiserror"
@@ -1069,12 +1081,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
 
 [[package]]
-name = "unicode-width"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
-
-[[package]]
 name = "unsafe-libyaml"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1097,12 +1103,6 @@ name = "valuable"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"

--- a/guard/Cargo.toml
+++ b/guard/Cargo.toml
@@ -20,7 +20,7 @@ crate-type = ["rlib"]
 nom = "5.1.2"
 nom_locate = "2.0.0"
 indexmap = { version = "1.6.0", features = ["serde-1"] }
-clap = "2.29.0"
+clap = "3.0.0"
 strip-ansi-escapes = "0.1.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.9.10"

--- a/guard/src/command.rs
+++ b/guard/src/command.rs
@@ -5,6 +5,6 @@ use crate::utils::writer::Writer;
 
 pub trait Command {
     fn name(&self) -> &'static str;
-    fn command(&self) -> App<'static, 'static>;
+    fn command(&self) -> App<'static>;
     fn execute(&self, args: &ArgMatches, writer: &mut Writer) -> Result<i32, Error>;
 }

--- a/guard/src/commands/migrate.rs
+++ b/guard/src/commands/migrate.rs
@@ -34,7 +34,7 @@ impl Command for Migrate {
         MIGRATE
     }
 
-    fn command(&self) -> App<'static, 'static> {
+    fn command(&self) -> App<'static> {
         App::new(MIGRATE)
             .about(
                 r#"Migrates 1.0 rules to 2.0 compatible rules.
@@ -58,7 +58,7 @@ impl Command for Migrate {
             )
     }
 
-    fn execute(&self, app: &ArgMatches<'_>, writer: &mut Writer) -> Result<i32> {
+    fn execute(&self, app: &ArgMatches, writer: &mut Writer) -> Result<i32> {
         let file_input = app.value_of(RULES.0).unwrap();
         let path = PathBuf::from_str(file_input).unwrap();
         let file_name = path.to_str().unwrap_or("").to_string();

--- a/guard/src/commands/mod.rs
+++ b/guard/src/commands/mod.rs
@@ -23,30 +23,30 @@ pub const RULEGEN: &str = "rulegen";
 pub const TEST: &str = "test";
 pub const VALIDATE: &str = "validate";
 // Arguments for validate
-pub const ALPHABETICAL: (&str, &str) = ("alphabetical", "a");
-pub const DATA: (&str, &str) = ("data", "d");
-pub const LAST_MODIFIED: (&str, &str) = ("last-modified", "m");
-pub const OUTPUT_FORMAT: (&str, &str) = ("output-format", "o");
-pub const INPUT_PARAMETERS: (&str, &str) = ("input-parameters", "i");
-pub const PAYLOAD: (&str, &str) = ("payload", "P");
-pub const PREVIOUS_ENGINE: (&str, &str) = ("previous-engine", "E");
-pub const PRINT_JSON: (&str, &str) = ("print-json", "p");
-pub const SHOW_CLAUSE_FAILURES: (&str, &str) = ("show-clause-failures", "s");
-pub const SHOW_SUMMARY: (&str, &str) = ("show-summary", "S");
-pub const TYPE: (&str, &str) = ("type", "t");
-pub const VERBOSE: (&str, &str) = ("verbose", "v");
+pub const ALPHABETICAL: (&str, char) = ("alphabetical", 'a');
+pub const DATA: (&str, char) = ("data", 'd');
+pub const LAST_MODIFIED: (&str, char) = ("last-modified", 'm');
+pub const OUTPUT_FORMAT: (&str, char) = ("output-format", 'o');
+pub const INPUT_PARAMETERS: (&str, char) = ("input-parameters", 'i');
+pub const PAYLOAD: (&str, char) = ("payload", 'P');
+pub const PREVIOUS_ENGINE: (&str, char) = ("previous-engine", 'E');
+pub const PRINT_JSON: (&str, char) = ("print-json", 'p');
+pub const SHOW_CLAUSE_FAILURES: (&str, char) = ("show-clause-failures", 's');
+pub const SHOW_SUMMARY: (&str, char) = ("show-summary", 'S');
+pub const TYPE: (&str, char) = ("type", 't');
+pub const VERBOSE: (&str, char) = ("verbose", 'v');
 // Arguments for validate, migrate, parse tree
-pub const RULES: (&str, &str) = ("rules", "r");
+pub const RULES: (&str, char) = ("rules", 'r');
 // Arguments for migrate, parse-tree, rulegen
-pub const OUTPUT: (&str, &str) = ("output", "o");
+pub const OUTPUT: (&str, char) = ("output", 'o');
 // Arguments for parse-tree
-pub const PRINT_YAML: (&str, &str) = ("print-yaml", "y");
+pub const PRINT_YAML: (&str, char) = ("print-yaml", 'y');
 // Arguments for test
-pub const RULES_FILE: (&str, &str) = ("rules-file", "r");
-pub const TEST_DATA: (&str, &str) = ("test-data", "t");
-pub const DIRECTORY: (&str, &str) = ("dir", "d");
+pub const RULES_FILE: (&str, char) = ("rules-file", 'r');
+pub const TEST_DATA: (&str, char) = ("test-data", 't');
+pub const DIRECTORY: (&str, char) = ("dir", 'd');
 // Arguments for rulegen
-pub const TEMPLATE: (&str, &str) = ("template", "t");
+pub const TEMPLATE: (&str, char) = ("template", 't');
 // Arg group for validate
 pub(crate) const REQUIRED_FLAGS: &str = "required_flags";
 // Arg group for test

--- a/guard/src/commands/parse_tree.rs
+++ b/guard/src/commands/parse_tree.rs
@@ -20,7 +20,7 @@ impl Command for ParseTree {
         PARSE_TREE
     }
 
-    fn command(&self) -> App<'static, 'static> {
+    fn command(&self) -> App<'static> {
         App::new(PARSE_TREE)
             .about(
                 r#"Prints out the parse tree for the rules defined in the file.
@@ -58,7 +58,7 @@ impl Command for ParseTree {
             )
     }
 
-    fn execute(&self, app: &ArgMatches<'_>, writer: &mut Writer) -> Result<i32> {
+    fn execute(&self, app: &ArgMatches, writer: &mut Writer) -> Result<i32> {
         let mut file: Box<dyn std::io::Read> = match app.value_of(RULES.0) {
             Some(file) => Box::new(std::io::BufReader::new(File::open(file)?)),
             None => Box::new(std::io::stdin()),

--- a/guard/src/commands/rulegen.rs
+++ b/guard/src/commands/rulegen.rs
@@ -27,7 +27,7 @@ impl Command for Rulegen {
         RULEGEN
     }
 
-    fn command(&self) -> App<'static, 'static> {
+    fn command(&self) -> App<'static> {
         App::new(RULEGEN)
             .about(r#"Autogenerate rules from an existing JSON- or YAML- formatted data. (Currently works with only CloudFormation templates)
 "#)
@@ -35,7 +35,7 @@ impl Command for Rulegen {
             .arg(Arg::with_name(OUTPUT.0).long(OUTPUT.0).short(OUTPUT.1).takes_value(true).help("Write to output file").required(false))
     }
 
-    fn execute(&self, app: &ArgMatches<'_>, writer: &mut Writer) -> Result<i32> {
+    fn execute(&self, app: &ArgMatches, writer: &mut Writer) -> Result<i32> {
         let file = app.value_of(TEMPLATE.0).unwrap();
         let template_contents = fs::read_to_string(file)?;
 

--- a/guard/src/commands/test.rs
+++ b/guard/src/commands/test.rs
@@ -43,7 +43,7 @@ impl Command for Test {
         TEST
     }
 
-    fn command(&self) -> App<'static, 'static> {
+    fn command(&self) -> App<'static> {
         App::new(TEST)
             .about(r#"Built in unit testing capability to validate a Guard rules file against
 unit tests specified in YAML format to determine each individual rule's success
@@ -79,7 +79,7 @@ or failure testing.
                 .help("Verbose logging"))
     }
 
-    fn execute(&self, app: &ArgMatches<'_>, writer: &mut Writer) -> Result<i32> {
+    fn execute(&self, app: &ArgMatches, writer: &mut Writer) -> Result<i32> {
         let mut exit_code = 0;
         let cmp = if let Some(_ignored) = app.value_of(ALPHABETICAL.0) {
             alpabetical

--- a/guard/src/commands/validate.rs
+++ b/guard/src/commands/validate.rs
@@ -116,7 +116,7 @@ impl Command for Validate {
         VALIDATE
     }
 
-    fn command(&self) -> App<'static, 'static> {
+    fn command(&self) -> App<'static> {
         App::new(VALIDATE)
             .about(r#"Evaluates rules against the data files to determine success or failure.
 You can point rules flag to a rules directory and point data flag to a data directory.
@@ -173,7 +173,7 @@ or rules files.
                 .required(true))
     }
 
-    fn execute(&self, app: &ArgMatches<'_>, writer: &mut Writer) -> Result<i32> {
+    fn execute(&self, app: &ArgMatches, writer: &mut Writer) -> Result<i32> {
         let cmp = if app.is_present(LAST_MODIFIED.0) {
             last_modified
         } else {

--- a/guard/src/main.rs
+++ b/guard/src/main.rs
@@ -1,4 +1,4 @@
-use clap::App;
+use clap::{App, ArgMatches};
 use std::collections::HashMap;
 use std::fs::File;
 mod command;
@@ -47,9 +47,11 @@ fn main() -> Result<(), Error> {
         app = app.subcommand(each.command());
     }
 
+    let help = app.render_usage();
     let app = app.get_matches();
+
     match app.subcommand() {
-        (name, Some(value)) => {
+        Some((name, value)) => {
             if let Some(command) = mappings.get(name) {
                 let mut output_writer: Writer = if [PARSE_TREE, MIGRATE, RULEGEN]
                     .contains(&command.name())
@@ -76,13 +78,13 @@ fn main() -> Result<(), Error> {
                     Ok(code) => exit(code),
                 }
             } else {
-                println!("{}", app.usage());
+                println!("{}", help);
             }
         }
-
-        (_, None) => {
-            println!("{}", app.usage());
+        None => {
+            println!("{}", help);
         }
     }
+
     Ok(())
 }

--- a/guard/tests/utils.rs
+++ b/guard/tests/utils.rs
@@ -95,7 +95,7 @@ pub trait CommandTestRunner {
         let app = app.get_matches_from(command_options);
 
         match app.subcommand() {
-            (name, Some(value)) => {
+            Some((name, value)) => {
                 if let Some(command) = mappings.get(name) {
                     match (*command).execute(value, &mut writer) {
                         Err(e) => {
@@ -112,7 +112,7 @@ pub trait CommandTestRunner {
                 }
             }
 
-            (_, None) => StatusCode::PREPROCESSOR_ERROR,
+            None => StatusCode::PREPROCESSOR_ERROR,
         }
     }
 }


### PR DESCRIPTION
*Issue #, if available:*


*Description of changes:*
This PR adds cargo audit to CI which will run every day at noon EST. While running cargo audit locally our current version for clap-rs was flagged. For this reason, I bumped up clap to 3.0

---
*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
