### PR TITLE
Improve handling of function references for test command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,9 +14,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.19"
+version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4f55bd91a0978cbfd91c457a164bab8b4001c833b7f323132c0a4e1922dd44e"
+checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
 dependencies = [
  "memchr",
 ]
@@ -63,7 +63,7 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.1.19",
  "libc",
  "winapi",
 ]
@@ -97,13 +97,14 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bstr"
-version = "0.2.17"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
+checksum = "b7f0778972c64420fdedc63f09919c8a88bda7b25135357fd25a5d9f3257e832"
 dependencies = [
- "lazy_static",
  "memchr",
+ "once_cell",
  "regex-automata",
+ "serde",
 ]
 
 [[package]]
@@ -114,9 +115,9 @@ checksum = "2c676a478f63e9fa2dd5368a42f28bba0d6c560b775f38583c8bbaa7fcd67c9c"
 
 [[package]]
 name = "bytes"
-version = "1.2.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec8a7b6a70fde80372154c65702f00a0f56f3e1c36abbc6c440484be248856db"
+checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
 
 [[package]]
 name = "cfg-if"
@@ -205,9 +206,9 @@ dependencies = [
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.31"
+version = "0.8.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9852635589dc9f9ea1b6fe9f05b50ef208c85c834a562f0c6abb1c475736ec2b"
+checksum = "071a31f4ee85403370b58aca746f01041ede6f0da2730960ad001edc2b71b394"
 dependencies = [
  "cfg-if",
 ]
@@ -269,9 +270,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "futures"
-version = "0.3.24"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f21eda599937fba36daeb58a22e8f5cee2d14c4a17b5b7739c7c8e5e3b8230c"
+checksum = "13e2792b0ff0340399d58445b88fd9770e3489eff258a4cbc1523418f12abf84"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -284,9 +285,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.24"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30bdd20c28fadd505d0fd6712cdfcb0d4b5648baf45faef7f852afb2399bb050"
+checksum = "2e5317663a9089767a1ec00a487df42e0ca174b61b4483213ac24448e4664df5"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -294,15 +295,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.24"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e5aa3de05362c3fb88de6531e6296e85cde7739cccad4b9dfeeb7f6ebce56bf"
+checksum = "ec90ff4d0fe1f57d600049061dc6bb68ed03c7d2fbd697274c41805dcb3f8608"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.24"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ff63c23854bee61b6e9cd331d523909f238fc7636290b96826e9cfa5faa00ab"
+checksum = "e8de0a35a6ab97ec8869e32a2473f4b1324459e14c29275d14b10cb1fd19b50e"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -311,15 +312,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.24"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbf4d2a7a308fd4578637c0b17c7e1c7ba127b8f6ba00b29f717e9655d85eb68"
+checksum = "bfb8371b6fb2aeb2d280374607aeabfc99d95c72edfe51692e42d3d7f0d08531"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.24"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42cd15d1c7456c04dbdf7e88bcd69760d74f3a798d6444e16974b505b0e62f17"
+checksum = "95a73af87da33b5acf53acfebdc339fe592ecf5357ac7c0a7734ab9d8c876a70"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -328,15 +329,15 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.24"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b20ba5a92e727ba30e72834706623d94ac93a725410b6a6b6fbc1b07f7ba56"
+checksum = "f310820bb3e8cfd46c80db4d7fb8353e15dfff853a127158425f31e0be6c8364"
 
 [[package]]
 name = "futures-task"
-version = "0.3.24"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6508c467c73851293f390476d4491cf4d227dbabcd4170f3bb6044959b294f1"
+checksum = "dcf79a1bf610b10f42aea489289c5a2c478a786509693b80cd39c44ccd936366"
 
 [[package]]
 name = "futures-timer"
@@ -346,9 +347,9 @@ checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
 
 [[package]]
 name = "futures-util"
-version = "0.3.24"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44fb6cb1be61cc1d2e43b262516aafcf63b241cffdb1d3fa115f91d9c7b09c90"
+checksum = "9c1d6de3acfef38d2be4b1f543f553131788603495be83da675e180c8d6b7bd1"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -364,18 +365,18 @@ dependencies = [
 
 [[package]]
 name = "grep-matcher"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d27563c33062cd33003b166ade2bb4fd82db1fd6a86db764dfdad132d46c1cc"
+checksum = "3902ca28f26945fe35cad349d776f163981d777fee382ccd6ef451126f51b319"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "grep-regex"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1345f8d33c89f2d5b081f2f2a41175adef9fd0bed2fea6a26c96c2deb027e58e"
+checksum = "997598b41d53a37a2e3fc5300d5c11d825368c054420a9c65125b8fe1078463f"
 dependencies = [
  "aho-corasick",
  "bstr",
@@ -388,9 +389,9 @@ dependencies = [
 
 [[package]]
 name = "grep-searcher"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48852bd08f9b4eb3040ecb6d2f4ade224afe880a9a0909c5563cc59fa67932cc"
+checksum = "5601c4b9f480f0c9ebb40b1f6cbf447b8a50c5369223937a6c5214368c58779f"
 dependencies = [
  "bstr",
  "bytecount",
@@ -421,6 +422,15 @@ name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "hermit-abi"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
 dependencies = [
  "libc",
 ]
@@ -461,9 +471,9 @@ checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
 
 [[package]]
 name = "hyper"
-version = "0.14.20"
+version = "0.14.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02c929dc5c39e335a03c405292728118860721b10190d98c2a0f0efd5baafbac"
+checksum = "5e011372fa0b68db8350aa7a248930ecc7839bf46d8485577d69f117a75f164c"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -484,9 +494,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.9.1"
+version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
+checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -495,9 +505,9 @@ dependencies = [
 
 [[package]]
 name = "indoc"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da2d6f23ffea9d7e76c53eee25dfb67bcd8fde7f1198b0855350698c9f07c780"
+checksum = "bfa799dd5ed20a7e349f3b4639aa80d74549c81716d9ec4f994c9b5815598306"
 
 [[package]]
 name = "itertools"
@@ -507,9 +517,9 @@ checksum = "c4a9b56eb56058f43dc66e58f40a214b2ccbc9f3df51861b63d51dec7b65bc3f"
 
 [[package]]
 name = "itoa"
-version = "1.0.3"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8af84674fe1f223a982c933a0ee1086ac4d4052aa0fb8060c12c6ad838e754"
+checksum = "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
 
 [[package]]
 name = "lambda_runtime"
@@ -552,9 +562,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.134"
+version = "0.2.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "329c933548736bc49fd575ee68c89e8be4d260064184389a5b77517cddd99ffb"
+checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 
 [[package]]
 name = "log"
@@ -573,23 +583,23 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "memmap2"
-version = "0.5.7"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95af15f345b17af2efc8ead6080fb8bc376f8cec1b35277b935637595fe77498"
+checksum = "4b182332558b18d807c4ce1ca8ca983b34c3ee32765e47b3f0f69b90355cc1dc"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "mio"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57ee1c23c7c63b0c9250c339ffdc69255f110b298b901b9f6c82547b7b87caaf"
+checksum = "e5d732bc30207a6423068df043e3d02e0735b155ad7ce1a6f76fe2baa5b158de"
 dependencies = [
  "libc",
  "log",
  "wasi",
- "windows-sys 0.36.1",
+ "windows-sys",
 ]
 
 [[package]]
@@ -616,11 +626,11 @@ dependencies = [
 
 [[package]]
 name = "num_cpus"
-version = "1.13.1"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
+checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.2.6",
  "libc",
 ]
 
@@ -635,9 +645,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.15.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e82dad04139b71a90c080c8463fe0dc7902db5192d939bd0950f074d014339e1"
+checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
 
 [[package]]
 name = "pin-project-lite"
@@ -653,27 +663,27 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.46"
+version = "1.0.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94e2ef8dbfc347b10c094890f778ee2e36ca9bb4262e86dc99cd217e35f3470b"
+checksum = "5d727cae5b39d21da60fa540906919ad737832fe0b1c165da3a34d6548c849d6"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
+checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "regex"
-version = "1.6.0"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c4eb3267174b8c6c2f654116623910a0fef09c4753f8dd83db29c48a0df988b"
+checksum = "48aaa5748ba571fb95cd2c85c09f629215d3a6ece942baa100950af03a34f733"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -688,9 +698,9 @@ checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.27"
+version = "0.6.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
+checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
 
 [[package]]
 name = "rstest"
@@ -728,9 +738,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
+checksum = "7b4b9743ed687d4b4bcedf9ff5eaa7398495ae14e61cba0a295704edbc7decde"
 
 [[package]]
 name = "same-file"
@@ -743,24 +753,24 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.14"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e25dfac463d778e353db5be2449d1cce89bd6fd23c9f1ea21310ce6e5a1b29c4"
+checksum = "58bc9567378fc7690d6b2addae4e60ac2eeea07becb2c64b9f218b53865cba2a"
 
 [[package]]
 name = "serde"
-version = "1.0.145"
+version = "1.0.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "728eb6351430bccb993660dfffc5a72f91ccc1295abaa8ce19b27ebe4f75568b"
+checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.145"
+version = "1.0.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81fa1584d3d1bcacd84c277a0dfe21f5b0f6accf4a23d04d4c6d61f1af522b4c"
+checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -769,9 +779,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.85"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e55a28e3aaef9d5ce0506d0a14dbba8054ddc7e499ef522dd8b26859ec9d4a44"
+checksum = "cad406b69c91885b5107daf2c29572f6c8cdb3c66826821e286c533490c0bc76"
 dependencies = [
  "indexmap",
  "itoa",
@@ -811,7 +821,7 @@ dependencies = [
  "colored",
  "log",
  "time",
- "windows-sys 0.42.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -862,9 +872,9 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "syn"
-version = "1.0.101"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e90cde112c4b9690b8cbe810cba9ddd8bc1d7472e2cae317b69e9438c1cba7d2"
+checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -920,9 +930,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.24.2"
+version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a12a59981d9e3c38d216785b0c37399f6e415e8d0712047620f189371b0bb"
+checksum = "c8e00990ebabbe4c14c08aca901caed183ecd5c09562a12c824bb53d3c3fd3af"
 dependencies = [
  "autocfg",
  "bytes",
@@ -933,14 +943,14 @@ dependencies = [
  "pin-project-lite",
  "socket2",
  "tokio-macros",
- "windows-sys 0.42.0",
+ "windows-sys",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "1.8.0"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9724f9a975fb987ef7a3cd9be0350edcbe130698af5b8f7a631e23d42d052484"
+checksum = "d266c00fde287f55d3f1c3e96c500c362a2b8c695076ec180f27918820bc6df8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -949,9 +959,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6edf2d6bc038a43d31353570e27270603f4648d18f5ed10c0e179abe43255af"
+checksum = "d660770404473ccd7bc9f8b28494a811bc18542b915c0855c51e8f419d5223ce"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -966,9 +976,9 @@ checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
 name = "tracing"
-version = "0.1.36"
+version = "0.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fce9567bd60a67d08a16488756721ba392f24f29006402881e43b19aac64307"
+checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
 dependencies = [
  "cfg-if",
  "log",
@@ -979,9 +989,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.22"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11c75893af559bc8e10716548bdef5cb2b983f8e637db9d0e15126b61b484ee2"
+checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -990,9 +1000,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.29"
+version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aeea4303076558a00714b823f9ad67d58a3bbda1df83d8827d21193156e22f7"
+checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
 dependencies = [
  "once_cell",
  "valuable",
@@ -1021,21 +1031,21 @@ dependencies = [
 
 [[package]]
 name = "try-lock"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
+checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.4"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcc811dc4066ac62f84f11307873c4850cb653bfa9b1719cee2bd2204a4bc5dd"
+checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.10.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fdbf052a0783de01e944a6ce7a8cb939e295b1e7be835a1112c3b9a7f047a5a"
+checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
 
 [[package]]
 name = "unicode-width"
@@ -1045,9 +1055,9 @@ checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
 name = "unsafe-libyaml"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1e5fa573d8ac5f1a856f8d7be41d390ee973daf97c806b2c1a465e4e1406e68"
+checksum = "bc7ed8ba44ca06be78ea1ad2c3682a43349126c8818054231ee6f4748012aed2"
 
 [[package]]
 name = "urlencoding"
@@ -1160,100 +1170,57 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
-dependencies = [
- "windows_aarch64_msvc 0.36.1",
- "windows_i686_gnu 0.36.1",
- "windows_i686_msvc 0.36.1",
- "windows_x86_64_gnu 0.36.1",
- "windows_x86_64_msvc 0.36.1",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
 dependencies = [
  "windows_aarch64_gnullvm",
- "windows_aarch64_msvc 0.42.0",
- "windows_i686_gnu 0.42.0",
- "windows_i686_msvc 0.42.0",
- "windows_x86_64_gnu 0.42.0",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
  "windows_x86_64_gnullvm",
- "windows_x86_64_msvc 0.42.0",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d2aa71f6f0cbe00ae5167d90ef3cfe66527d6f613ca78ac8024c3ccab9a19e"
+checksum = "8c9864e83243fdec7fc9c5444389dcbbfd258f745e7853198f365e3c4968a608"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.36.1"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd0f252f5a35cac83d6311b2e795981f5ee6e67eb1f9a7f64eb4500fbc4dcdb4"
+checksum = "4c8b1b673ffc16c47a9ff48570a9d85e25d265735c503681332589af6253c6c7"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.36.1"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbeae19f6716841636c28d695375df17562ca208b2b7d0dc47635a50ae6c5de7"
+checksum = "de3887528ad530ba7bdbb1faa8275ec7a1155a45ffa57c37993960277145d640"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.36.1"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84c12f65daa39dd2babe6e442988fc329d6243fdce47d7d2d155b8d874862246"
+checksum = "bf4d1122317eddd6ff351aa852118a2418ad4214e6613a50e0191f7004372605"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.36.1"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf7b1b21b5362cbc318f686150e5bcea75ecedc74dd157d874d754a2ca44b0ed"
+checksum = "c1040f221285e17ebccbc2591ffdc2d44ee1f9186324dd3e84e99ac68d699c45"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09d525d2ba30eeb3297665bd434a54297e4170c7f1a44cad4ef58095b4cd2028"
+checksum = "628bfdf232daa22b0d64fdb62b09fcc36bb01f05a3939e20ab73aaf9470d0463"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.36.1"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"
+checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -34,7 +34,4 @@ let api_gws = Resources.*[ Type == 'AWS::ApiGateway::RestApi' ]
 
 3. When performing `!=` comparison, if the values are incompatible like comparing a `string` to `int`, an error is thrown internally but currently suppressed and converted to `false` to satisfy the requirements of Rust’s [PartialEq](https://doc.rust-lang.org/std/cmp/trait.PartialEq.html). We are tracking to release a fix for this issue soon.
 4. `exists` and `empty` checks do not display the JSON pointer path inside the document in the error messages. Both these clauses often have retrieval errors which does not maintain this traversal information today. We are tracking to resolve this issue. 
-5. When evaluating CloudFormation templates in YAML format, we do not support the short form versions of CloudFormation intrinsic functions like `!Join`, `!Sub` and others. Guard does not support these YAML extensions when evaluating.
-    
-> **Workaround**: use the expanded form when using these functions. 
-6. Currently, for `string` literals, Guard does not support embedded escaped strings. We are tracking to resolve this issue soon.
+5. Currently, for `string` literals, Guard does not support embedded escaped strings. We are tracking to resolve this issue soon.

--- a/guard/src/rules/eval_tests.rs
+++ b/guard/src/rules/eval_tests.rs
@@ -1,6 +1,8 @@
 use std::collections::HashMap;
 
 use grep_searcher::SearcherBuilder;
+use indoc::{formatdoc, indoc};
+use rstest::rstest;
 
 use crate::rules::eval_context::eval_context_tests::BasicQueryTesting;
 use crate::rules::eval_context::{root_scope, EventRecord, RecordTracker};
@@ -1854,70 +1856,89 @@ fn test_multiple_valued_clause_reporting() -> Result<()> {
     Ok(())
 }
 
-#[test]
-fn test_in_comparison_operator_for_list_of_lists() -> Result<()> {
-    let template = r###"
-Resources:
-    MasterRecord:
-        Type: AWS::Route53::RecordSet
-        Properties:
-            HostedZoneName: !Ref 'HostedZoneName'
-            Comment: DNS name for my instance.
-            Name: !Join ['', [!Ref 'SubdomainMaster', ., !Ref 'HostedZoneName']]
-            Type: A
-            TTL: '900'
-            ResourceRecords:
-                - !GetAtt Master.PrivateIp
-    InternalRecord:
-        Type: AWS::Route53::RecordSet
-        Properties:
-            HostedZoneName: !Ref 'HostedZoneName'
-            Comment: DNS name for my instance.
-            Name: !Join ['', [!Ref 'SubdomainInternal', ., !Ref 'HostedZoneName']]
-            Type: A
-            TTL: '900'
-            ResourceRecords:
-                - !GetAtt Master.PrivateIp
-    SubdomainRecord:
-        Type: AWS::Route53::RecordSet
-        Properties:
-            HostedZoneName: !Ref 'HostedZoneName'
-            Comment: DNS name for my instance.
-            Name: !Join ['', [!Ref 'SubdomainDefault', ., !Ref 'HostedZoneName']]
-            Type: A
-            TTL: '900'
-            ResourceRecords:
-                - !GetAtt Infra1.PrivateIp
-    WildcardRecord:
-        Type: AWS::Route53::RecordSet
-        Properties:
-            HostedZoneName: !Ref 'HostedZoneName'
-            Comment: DNS name for my instance.
-            Name: !Join ['', [!Ref 'SubdomainWild', ., !Ref 'HostedZoneName']]
-            Type: A
-            TTL: '900'
-            ResourceRecords:
-                - !GetAtt Infra1.PrivateIp
-    "###;
+#[rstest::rstest]
+#[case("SubdomainMaster", "Master.PrivateIp", Status::PASS)]
+#[case("SubdomainInternal", "Master.PrivateIp", Status::PASS)]
+#[case("SubdomainDefault", "Infra1.PrivateIp", Status::PASS)]
+#[case("SubdomainDefault", "Infra1.PrivateIp", Status::PASS)]
+#[case("Subdomain", "Infra1.PrivateIp", Status::FAIL)]
+#[case("SubdomainDefault", "Infra1.PublicIp", Status::FAIL)]
+#[case("Subdomain", "Master.PrivateIp", Status::FAIL)]
+#[case("SubdomainDefault", "Master.PublicIp", Status::FAIL)]
+fn test_in_comparison_operator_for_list_of_lists(
+    #[case] name_arg: &str,
+    #[case] resource_records_arg: &str,
+    #[case] status_arg: Status,
+) -> Result<()> {
+    let template = formatdoc! {
+        r###"
+        Resources:
+            MasterRecord:
+                Type: AWS::Route53::RecordSet
+                Properties:
+                    HostedZoneName: !Ref 'HostedZoneName'
+                    Comment: DNS name for my instance.
+                    Name: !Join ['', [!Ref '{}', ., !Ref 'HostedZoneName']]
+                    Type: A
+                    TTL: "900"
+                    ResourceRecords:
+                    - !GetAtt '{}'"###, 
+        name_arg,
+        resource_records_arg,
+    };
 
     let rules = r###"
     let aws_route53_recordset_resources = Resources.*[ Type == 'AWS::Route53::RecordSet' ]
     rule aws_route53_recordset when %aws_route53_recordset_resources !empty {
+      let targets = [{"Fn::Join": ["",[{"Ref": "SubdomainMaster"},".", {"Ref": "HostedZoneName"}]]}, {"Fn::Join": ["",[{"Ref": "SubdomainWild"},".", {"Ref": "HostedZoneName"}]]}, {"Fn::Join": ["",[{"Ref": 'SubdomainInternal'},".", {"Ref": "HostedZoneName"}]]}, {"Fn::Join": ["",[{"Ref": "SubdomainDefault"},".", {"Ref": "HostedZoneName"}]]}]
       %aws_route53_recordset_resources.Properties.Comment == "DNS name for my instance."
-      let targets = [["",["SubdomainWild",".","HostedZoneName"]], ["",["SubdomainInternal",".","HostedZoneName"]], ["",["SubdomainMaster",".","HostedZoneName"]], ["",["SubdomainDefault",".","HostedZoneName"]]]
+      %aws_route53_recordset_resources.Properties.ResourceRecords IN [[{"Fn::GetAtt": "Master.PrivateIp"}], [{"Fn::GetAtt": "Infra1.PrivateIp"}]]
       %aws_route53_recordset_resources.Properties.Name IN %targets
       %aws_route53_recordset_resources.Properties.Type == "A"
-      %aws_route53_recordset_resources.Properties.ResourceRecords IN [["Master.PrivateIp"], ["Infra1.PrivateIp"]]
       %aws_route53_recordset_resources.Properties.TTL == "900"
-      %aws_route53_recordset_resources.Properties.HostedZoneName == "HostedZoneName"
+      %aws_route53_recordset_resources.Properties.HostedZoneName == {"Ref": "HostedZoneName"}
     }
     "###;
 
-    let value = PathAwareValue::try_from(serde_yaml::from_str::<serde_yaml::Value>(template)?)?;
+    let value = PathAwareValue::try_from(serde_yaml::from_str::<serde_yaml::Value>(&template)?)?;
     let rule_eval = RulesFile::try_from(rules)?;
     let mut context = root_scope(&rule_eval, &value)?;
     let status = eval_rules_file(&rule_eval, &mut context)?;
-    assert_eq!(status, Status::PASS);
+    assert_eq!(status, status_arg);
+
+    Ok(())
+}
+
+#[rstest::rstest]
+#[case(r#"'900'"#, Status::PASS)]
+#[case(r#"!!str 900"#, Status::PASS)]
+#[case(r#"900"#, Status::FAIL)]
+#[case(r#"!!int "900""#, Status::FAIL)]
+#[case(r#"!!float "900""#, Status::FAIL)]
+fn test_type_conversions(#[case] ttl_arg: &str, #[case] status_arg: Status) -> Result<()> {
+    let template = formatdoc! {
+        r###"
+        Resources:
+            MasterRecord:
+                Type: AWS::Route53::RecordSet
+                Properties:
+                    TTL: {}
+                    "###,
+        ttl_arg,
+    };
+
+    let rules = r###"
+    let aws_route53_recordset_resources = Resources.*[ Type == 'AWS::Route53::RecordSet' ]
+    rule aws_route53_recordset when %aws_route53_recordset_resources !empty {
+      %aws_route53_recordset_resources.Properties.TTL == "900"
+    }
+    "###;
+
+    let value = PathAwareValue::try_from(serde_yaml::from_str::<serde_yaml::Value>(&template)?)?;
+    let rule_eval = RulesFile::try_from(rules)?;
+    let mut context = root_scope(&rule_eval, &value)?;
+    let status = eval_rules_file(&rule_eval, &mut context)?;
+    assert_eq!(status, status_arg);
 
     Ok(())
 }

--- a/guard/src/rules/libyaml/loader.rs
+++ b/guard/src/rules/libyaml/loader.rs
@@ -1,4 +1,3 @@
-use lazy_static::lazy_static;
 use std::borrow::Cow;
 
 use crate::rules::{
@@ -9,69 +8,10 @@ use crate::rules::{
         parser::Parser,
     },
     path_value::Location,
+    short_form_to_long,
     values::MarkedValue,
+    SEQUENCE_VALUE_FUNC_REF, SINGLE_VALUE_FUNC_REF,
 };
-
-use std::collections::{HashMap, HashSet};
-
-lazy_static! {
-    static ref SHORT_FORM_TO_LONG_MAPPING: HashMap<&'static str, &'static str> = {
-        let mut m = HashMap::new();
-        m.insert("Ref", "Ref");
-        m.insert("GetAtt", "Fn::GetAtt");
-        m.insert("Base64", "Fn::Base64");
-        m.insert("Sub", "Fn::Sub");
-        m.insert("GetAZs", "Fn::GetAZs");
-        m.insert("ImportValue", "Fn::ImportValue");
-        m.insert("Condition", "Condition");
-        m.insert("RefAll", "Fn::RefAll");
-        m.insert("Select", "Fn::Select");
-        m.insert("Split", "Fn::Split");
-        m.insert("Join", "Fn::Join");
-        m.insert("FindInMap", "Fn::FindInMap");
-        m.insert("And", "Fn::And");
-        m.insert("Equals", "Fn::Equals");
-        m.insert("Contains", "Fn::Contains");
-        m.insert("EachMemberIn", "Fn::EachMemberIn");
-        m.insert("EachMemberEquals", "Fn::EachMemberEquals");
-        m.insert("ValueOf", "Fn::ValueOf");
-        m.insert("If", "Fn::If");
-        m.insert("Not", "Fn::Not");
-        m.insert("Or", "Fn::Or");
-        m
-    };
-    static ref SINGLE_VALUE_FUNC_REF: HashSet<&'static str> = {
-        let mut set = HashSet::new();
-        set.insert("Ref");
-        set.insert("Base64");
-        set.insert("Sub");
-        set.insert("GetAZs");
-        set.insert("ImportValue");
-        set.insert("GetAtt");
-        set.insert("Condition");
-        set.insert("RefAll");
-        set
-    };
-    static ref SEQUENCE_VALUE_FUNC_REF: HashSet<&'static str> = {
-        let mut set = HashSet::new();
-        set.insert("GetAtt");
-        set.insert("Sub");
-        set.insert("Select");
-        set.insert("Split");
-        set.insert("Join");
-        set.insert("FindInMap");
-        set.insert("And");
-        set.insert("Equals");
-        set.insert("Contains");
-        set.insert("EachMemberIn");
-        set.insert("EachMemberEquals");
-        set.insert("ValueOf");
-        set.insert("If");
-        set.insert("Not");
-        set.insert("Or");
-        set
-    };
-}
 
 const TYPE_REF_PREFIX: &str = "tag:yaml.org,2002:";
 
@@ -192,14 +132,11 @@ impl Loader {
             let handle = tag.get_handle();
             let suffix = tag.get_suffix(handle.len());
             if handle == "!" {
-                match handle_sequence_value_func_ref(location.clone(), &suffix) {
-                    Some(value) => {
-                        self.stack.push(value);
-                        let fn_ref = short_form_to_long(&suffix);
-                        self.func_support_index
-                            .push((self.stack.len() - 1, (fn_ref.to_owned(), location.clone())));
-                    }
-                    None => {}
+                if let Some(value) = handle_sequence_value_func_ref(location.clone(), &suffix) {
+                    self.stack.push(value);
+                    let fn_ref = short_form_to_long(&suffix);
+                    self.func_support_index
+                        .push((self.stack.len() - 1, (fn_ref.to_owned(), location.clone())));
                 }
             }
         }
@@ -229,13 +166,6 @@ impl Loader {
         self.stack
             .push(MarkedValue::Map(indexmap::IndexMap::new(), location));
         self.last_container_index.push(self.stack.len() - 1);
-    }
-}
-
-fn short_form_to_long(fn_ref: &str) -> &'static str {
-    match SHORT_FORM_TO_LONG_MAPPING.get(fn_ref) {
-        Some(fn_ref) => fn_ref,
-        _ => unreachable!(),
     }
 }
 

--- a/guard/src/rules/mod.rs
+++ b/guard/src/rules/mod.rs
@@ -17,11 +17,72 @@ use crate::rules::exprs::{ParameterizedRule, QueryPart};
 use crate::rules::path_value::PathAwareValue;
 use crate::rules::values::CmpOperator;
 use colored::*;
+use lazy_static::lazy_static;
 use nom::lib::std::convert::TryFrom;
 use serde::Serialize;
+use std::collections::{HashMap, HashSet};
 use std::fmt::Formatter;
 
 pub(crate) type Result<R> = std::result::Result<R, Error>;
+
+lazy_static! {
+    pub static ref SHORT_FORM_TO_LONG_MAPPING: HashMap<&'static str, &'static str> = {
+        let mut m = HashMap::new();
+        m.insert("Ref", "Ref");
+        m.insert("GetAtt", "Fn::GetAtt");
+        m.insert("Base64", "Fn::Base64");
+        m.insert("Sub", "Fn::Sub");
+        m.insert("GetAZs", "Fn::GetAZs");
+        m.insert("ImportValue", "Fn::ImportValue");
+        m.insert("Condition", "Condition");
+        m.insert("RefAll", "Fn::RefAll");
+        m.insert("Select", "Fn::Select");
+        m.insert("Split", "Fn::Split");
+        m.insert("Join", "Fn::Join");
+        m.insert("FindInMap", "Fn::FindInMap");
+        m.insert("And", "Fn::And");
+        m.insert("Equals", "Fn::Equals");
+        m.insert("Contains", "Fn::Contains");
+        m.insert("EachMemberIn", "Fn::EachMemberIn");
+        m.insert("EachMemberEquals", "Fn::EachMemberEquals");
+        m.insert("ValueOf", "Fn::ValueOf");
+        m.insert("If", "Fn::If");
+        m.insert("Not", "Fn::Not");
+        m.insert("Or", "Fn::Or");
+        m
+    };
+    static ref SINGLE_VALUE_FUNC_REF: HashSet<&'static str> = {
+        let mut set = HashSet::new();
+        set.insert("Ref");
+        set.insert("Base64");
+        set.insert("Sub");
+        set.insert("GetAZs");
+        set.insert("ImportValue");
+        set.insert("GetAtt");
+        set.insert("Condition");
+        set.insert("RefAll");
+        set
+    };
+    static ref SEQUENCE_VALUE_FUNC_REF: HashSet<&'static str> = {
+        let mut set = HashSet::new();
+        set.insert("GetAtt");
+        set.insert("Sub");
+        set.insert("Select");
+        set.insert("Split");
+        set.insert("Join");
+        set.insert("FindInMap");
+        set.insert("And");
+        set.insert("Equals");
+        set.insert("Contains");
+        set.insert("EachMemberIn");
+        set.insert("EachMemberEquals");
+        set.insert("ValueOf");
+        set.insert("If");
+        set.insert("Not");
+        set.insert("Or");
+        set
+    };
+}
 
 #[derive(Debug, Clone, PartialEq, Copy, Serialize)]
 pub(crate) enum Status {
@@ -343,4 +404,11 @@ pub(crate) trait Evaluate {
         context: &'s PathAwareValue,
         var_resolver: &'s dyn EvaluationContext,
     ) -> Result<Status>;
+}
+
+pub fn short_form_to_long(fn_ref: &str) -> &'static str {
+    match SHORT_FORM_TO_LONG_MAPPING.get(fn_ref) {
+        Some(fn_ref) => fn_ref,
+        _ => unreachable!(),
+    }
 }


### PR DESCRIPTION
*Issue #, if available:*
#301 

*Description of changes:*
This PR addresses the way the test command handles yaml tags. Previously the tag was just dropped, and the value was consumed as a string. This PR handles them the same way as the validate command. This means that the short hand value is converted into its long form equivalent, and the function will map to its arguments. 

this change now allows us to validate the following rule with a unit test 
``` 
// rule
let redshift_clusters = Resources.*[ Type == 'AWS::Redshift::Cluster'
  Metadata.guard.SuppressedRules not exists or
  Metadata.guard.SuppressedRules.* != "REDSHIFT_ENCRYPTED_CMK"
]

rule REDSHIFT_ENCRYPTED_CMK when %redshift_clusters !empty {
    %redshift_clusters.Properties.KmsKeyId exists

    %redshift_clusters.Properties.KmsKeyId == {"Fn::ImportValue": {"Fn::Sub":"${pSecretKmsKey}"}}
}

// unit test
- name: a redshift cluster with short hand functions
  input:
    Resources:
      myCluster:
        Type: "AWS::Redshift::Cluster"
        Properties:
          DBName: "mydb"
          KmsKeyId: 
            Fn::ImportValue:
              !Sub "${pSecretKmsKey}"
  expectations:
    rules:
      REDSHIFT_ENCRYPTED_CMK: PASS
```



note how `!Sub "${pSecretKmsKey}"` resolves to "Fn::Sub": "${pSecretKmsKey}" 
in previous versions of guard this would have resolved to "${pSecretKmsKey}"

---
*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
