### PR TITLE
Added deprecated short flag for print-json in parse-tree

### DIFF
--- a/guard/src/commands/mod.rs
+++ b/guard/src/commands/mod.rs
@@ -31,6 +31,7 @@ pub const INPUT_PARAMETERS: (&str, char) = ("input-parameters", 'i');
 pub const PAYLOAD: (&str, char) = ("payload", 'P');
 pub const PREVIOUS_ENGINE: (&str, char) = ("previous-engine", 'E');
 pub const PRINT_JSON: (&str, char) = ("print-json", 'p');
+pub const PRINT_JSON_DEPRECATED: char = 'j';
 pub const SHOW_CLAUSE_FAILURES: (&str, char) = ("show-clause-failures", 's');
 pub const SHOW_SUMMARY: (&str, char) = ("show-summary", 'S');
 pub const TYPE: (&str, char) = ("type", 't');

--- a/guard/src/commands/parse_tree.rs
+++ b/guard/src/commands/parse_tree.rs
@@ -1,5 +1,5 @@
 use crate::command::Command;
-use crate::commands::{OUTPUT, PARSE_TREE, PRINT_JSON, PRINT_YAML, RULES};
+use crate::commands::{OUTPUT, PARSE_TREE, PRINT_JSON, PRINT_YAML, RULES, PRINT_JSON_DEPRECATED};
 use crate::rules::Result;
 use crate::utils::reader::Reader;
 use crate::utils::writer::Writer;
@@ -44,6 +44,7 @@ impl Command for ParseTree {
                 Arg::new(PRINT_JSON.0)
                     .long(PRINT_JSON.0)
                     .short(PRINT_JSON.1)
+                    .short_alias(PRINT_JSON_DEPRECATED)
                     .action(ArgAction::SetTrue)
                     .help("Print output in JSON format"),
             )

--- a/guard/src/commands/parse_tree.rs
+++ b/guard/src/commands/parse_tree.rs
@@ -46,7 +46,7 @@ impl Command for ParseTree {
                     .short(PRINT_JSON.1)
                     .short_alias(PRINT_JSON_DEPRECATED)
                     .action(ArgAction::SetTrue)
-                    .help("Print output in JSON format"),
+                    .help("Print output in JSON format. Use -p going forward, as the short flag -j is on deprecation path."),
             )
             .arg(
                 Arg::new(PRINT_YAML.0)

--- a/guard/src/commands/parse_tree.rs
+++ b/guard/src/commands/parse_tree.rs
@@ -1,5 +1,5 @@
 use crate::command::Command;
-use crate::commands::{OUTPUT, PARSE_TREE, PRINT_JSON, PRINT_YAML, RULES, PRINT_JSON_DEPRECATED};
+use crate::commands::{OUTPUT, PARSE_TREE, PRINT_JSON, PRINT_JSON_DEPRECATED, PRINT_YAML, RULES};
 use crate::rules::Result;
 use crate::utils::reader::Reader;
 use crate::utils::writer::Writer;


### PR DESCRIPTION
*Issue #, if available:*


*Description of changes:*
* Added deprecated `-j` flag for `--print-json` in `parse-tree` command for backward compatibility

---
*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
