### PR TITLE
Add instances to rules integration tests

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -2,9 +2,9 @@ name: Rust
 
 on:
   push:
-    branches: [ main, development, rogue_one]
+    branches: [ main, development, rogue_one ]
   pull_request:
-    branches: [ main, development, rogue_one]
+    branches: [ main, development, rogue_one ]
 
 env:
   CARGO_TERM_COLOR: always
@@ -39,9 +39,12 @@ jobs:
       - name: Rustfmt Check
         uses: actions-rust-lang/rustfmt@v1
 
-  aws-guard-rules-registry-ubuntu-integration-tests:
-    name: Integration tests against aws-guard-rules-registry on Ubuntu
-    runs-on: ubuntu-latest
+  aws-guard-rules-registry-integration-tests-linux:
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, macos-latest ]
+    runs-on: ${{ matrix.os }}
+    name: Integration tests against aws-guard-rules-registry
     steps:
       - uses: actions/checkout@v3
         name: Checkout cfn-guard
@@ -106,3 +109,68 @@ jobs:
           else
               echo "All the rules have succeeded the parse-tree integration tests."
           fi
+
+  aws-guard-rules-registry-integration-tests-windows:
+    runs-on: windows-latest
+    name: Integration tests against aws-guard-rules-registry for Windows
+    steps:
+      - uses: actions/checkout@v3
+        name: Checkout cfn-guard
+        with:
+          path: cloudformation-guard
+      - name: Build binary
+        run: |
+          cd cloudformation-guard/guard/
+          cargo build --release
+      - uses: actions/checkout@v3
+        name: Checkout aws-guard-rules-registry
+        with:
+          repository: aws-cloudformation/aws-guard-rules-registry
+          path: aws-guard-rules-registry
+          ref: main
+      - name: Run integration tests using test command
+        run: |
+          if (cloudformation-guard/target/release/cfn-guard test -d aws-guard-rules-registry/rules) {
+              echo "The integration tests for test command have passed."
+          }
+          else {
+              echo "The integration tests for test command have failed."
+              exit 1
+          }
+
+      - name: Run integration tests using parse-tree command
+        run: |
+          cd aws-guard-rules-registry/rules
+          
+          $FAILED_RULES = @()
+          $SKIPPED_RULES = @()
+          
+          $rules  = @(Get-ChildItem -Path .\ -Filter *.guard -Recurse -File)
+
+          Foreach ($rule in $rules) {
+              $rule_files_without_comments = (Get-Content $rule.FullName) -replace '^[ \s]*#.*$', ''
+              if ([String]::IsNullOrWhiteSpace($rule_files_without_comments)){
+              $SKIPPED_RULES += "$rule"
+          }
+          elseif (../../cloudformation-guard/target/release/cfn-guard parse-tree --rules $rule.FullName) {
+              continue
+          } else {
+              $FAILED_RULES += "$rule"
+            }
+          }
+          
+          $SKIPPED_RULE_COUNT = $SKIPPED_RULES.Length
+          if ($SKIPPED_RULE_COUNT -gt 0) {
+              echo "The following `$SKIPPED_RULE_COUNT.Length` rule(s) were skipped because they contained only comments:"
+              echo $SKIPPED_RULES
+          }
+          
+          $FAILED_RULE_COUNT = $FAILED_RULES.Length
+  
+          if ($FAILED_RULE_COUNT -gt 0) {
+              echo "The following $FAILED_RULE_COUNT rule(s) have failed the parse-tree integration tests with a non-zero error code:"
+              echo $FAILED_RULES
+              exit 1
+          } else {
+              echo "All the rules have succeeded the parse-tree integration tests."
+          }

--- a/README.md
+++ b/README.md
@@ -7,17 +7,19 @@ We are excited to release Guard 2.1! We recommend building locally from source c
 
 AWS CloudFormation Guard is an open-source general-purpose policy-as-code evaluation tool. It provides developers with a simple-to-use, yet powerful and expressive domain-specific language (DSL) to define policies and enables developers to validate JSON- or YAML- formatted structured data with those policies.
 
-Guard 2.0 release is a complete re-write of the earlier 1.0 version to make the tool general-purpose. With Guard 2.0, developers can continue writing policies for CloudFormation Templates. In addition, developers can use Guard in the following business domains:
+The Guard 3.0 release introduces support for advanced regular expressions, improved handling of intrinsic functions for the test command, as well as the --structured flag to the validate command to emit JSON/YAML parseable output.  Note that previously written tests may have to be reviewed due to the corrected behavior of instrinisic function handling.  Please see the release notes for full details and examples.
+
+Guard can be used for the following domains:
 
 1. **Preventative Governance and Compliance (shift left):** validate Infrastructure-as-code (IaC) or infrastructure/service compositions such as CloudFormation Templates, CloudFormation ChangeSets, Terraform JSON configuration files, Kubernetes configurations, and more against Guard policies representing your organizational best practices for security, compliance, and more. For example, developers can use Guard policies with
-    1. Terraform plan (in JSON format) for deployment safety assessment checks or Terraform state files to detect live state deviations.
+    1. Terraform plan (**in JSON format**) for deployment safety assessment checks or Terraform state files to detect live state deviations.
     2. Static assessment of IaC templates to determine network reachability like Amazon Redshift cluster deployed inside a VPC and prevent the provision of such stacks.
 2. **Detective Governance and Compliance:** validate conformity of Configuration Management Database (CMDB) resources such as AWS Config-based configuration items (CIs). For example, developers can use Guard policies against AWS Config CIs to continuously monitor state of deployed AWS and non-AWS resources, detect violations from policies, and trigger remediation.
-3. **Deployment Safety:** validate CloudFormation ChangeSets to ensure changes are safe before deployment. For example, renaming an Amazon DynamoDB Table will cause a replacement of the Table. With Guard 2.0, you can prevent such changes in your CI/CD pipelines.
+3. **Deployment Safety:** validate CloudFormation ChangeSets to ensure changes are safe before deployment. For example, renaming an Amazon DynamoDB Table will cause a replacement of the Table. With Guard 3.0, you can prevent such changes in your CI/CD pipelines.
 
-> **NOTE**: If you are using Guard 1.0, we highly recommend adopting Guard 2.0 because Guard 2.0 is a major release that introduces multiple features to simplify your current policy-as-code experience. Guard 2.0 and higher versions are backward incompatible with your Guard 1.0 rules and can result in breaking changes. To migrate from Guard 1.0 to Guard 2.0, 1) use migrate command to transition your existing 1.0 rules to 2.0 rules and 2) read all new Guard 2.0 features.
+> **NOTE**: If you are using Guard 1.0, we highly recommend adopting Guard 3.0 because Guard 3.0 is a major release that introduces multiple features to simplify your current policy-as-code experience. Guard 2.0 and higher versions are backward incompatible with your Guard 1.0 rules and can result in breaking changes. The Guard 2.0 release was a complete re-write of the earlier 1.0 version to make the tool general-purpose. 
 >
-> You can find code related to Guard 2.0 on the main branch of the repo and code related to Guard 1.0 on [Guard1.0 branch](https://github.com/aws-cloudformation/cloudformation-guard/tree/Guard1.0) of the repo.
+
 
 **Guard In Action**
 
@@ -40,7 +42,7 @@ Guard 2.0 release is a complete re-write of the earlier 1.0 version to make the 
 > Guard is an open-source command line interface (CLI) that provides developers a general purpose domain-specific language (DSL) to express policy-as-code and then validate their JSON- and YAML-formatted data against that code. Guard’s DSL is a simple, powerful, and expressive declarative language to define policies. It is built on the foundation of clauses, which are assertions that evaluate to `true` or `false`. Examples clauses can include simple validations like all Amazon Simple Storage Service (S3) buckets must have versioning enabled, or combined to express complex validations like preventing public network reachability of Amazon Redshift clusters placed in a subnet. Guard has support for looping, queries with filtering, cross query joins, single shot variable assignments, conditional executions, and composable rules. These features help developers to express simple and advanced policies for various domains.
 
 **2) What Guard is not?**
-> Guard **is not** a general-purpose programming language. It is a purpose-built DSL that is designed for policy definition and evaluation. Both non-technical people and developers can easily pick up Guard. Guard is human-readable and machine enforceable.
+> Guard **is not** a general-purpose programming language. It is a **purpose-built** DSL that is designed for policy definition and evaluation. Both non-technical people and developers can easily pick up Guard. Guard is human-readable and machine enforceable.
 
 **3) Where can I use Guard?**
 > You can use Guard to define any type of policy for evaluation. You can apply Guard in the context of multiple domains: a) validating IaC/service compositions such as [CloudFormation Templates](https://aws.amazon.com/cloudformation/resources/templates/), Terraform JSON configuration files, and Kubernetes configurations, b) verifying conformity of CMDB resources such as AWS Config-based CIs, and c) assessing security postures across resources like AWS Security Hub. The policy language and expression is common to all of them, based on simple Guard clauses.
@@ -156,7 +158,7 @@ These tenets help guide the development of the Guard DSL:
 
 ##### MacOS
 
-By default this is built for macOS-10 (Catalina). It has been tested to work on macOS-11 (Big Sur). See [OS Matrix](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#github-hosted-runners)
+By default this is built for macOS-12 (Monterey). See [OS Matrix](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#github-hosted-runners)
 
 1. Open terminal of your choice. Default `Cmd+Space`, type `terminal`
 2. Cut-n-paste the commands below (change version=X for other versions)


### PR DESCRIPTION
*Issue #, if available:*


*Description of changes:*
* Added macOS and windows instances to rules-registry integration tests
* Successful execution - https://github.com/akshayrane/cloudformation-guard/actions/runs/4506809585/jobs/7933983547

---
*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
