### PR TITLE
Populated filename in the output

### DIFF
--- a/guard/resources/validate/output-dir/payload_verbose_non_compliant.out
+++ b/guard/resources/validate/output-dir/payload_verbose_non_compliant.out
@@ -85,7 +85,7 @@ Resource = MyBucket {
     }
   }
 }
-`- File(, Status=FAIL)[Context=File(rules=1)]
+`- File(STDIN, Status=FAIL)[Context=File(rules=1)]
    `- Rule(S3_BUCKET_PUBLIC_READ_PROHIBITED, Status=FAIL)[Context=S3_BUCKET_PUBLIC_READ_PROHIBITED]
       |- Rule/When(Status=PASS)[Context=Rule#S3_BUCKET_PUBLIC_READ_PROHIBITED/When]
       |  `- GuardClauseBlock(Status = PASS)[Context=GuardAccessClause#block %s3_bucket_public_read_prohibited not EMPTY  ]

--- a/guard/resources/validate/output-dir/payload_verbose_success.out
+++ b/guard/resources/validate/output-dir/payload_verbose_success.out
@@ -1,4 +1,4 @@
-`- File(, Status=PASS)[Context=File(rules=1)]
+`- File(STDIN, Status=PASS)[Context=File(rules=1)]
    `- Rule(S3_BUCKET_PUBLIC_READ_PROHIBITED, Status=PASS)[Context=S3_BUCKET_PUBLIC_READ_PROHIBITED]
       |- Rule/When(Status=PASS)[Context=Rule#S3_BUCKET_PUBLIC_READ_PROHIBITED/When]
       |  `- GuardClauseBlock(Status = PASS)[Context=GuardAccessClause#block %s3_bucket_public_read_prohibited not EMPTY  ]

--- a/guard/resources/validate/output-dir/payload_verbose_yaml_compliant.out
+++ b/guard/resources/validate/output-dir/payload_verbose_yaml_compliant.out
@@ -1,11 +1,11 @@
-name: ''
+name: STDIN
 metadata: {}
 status: PASS
 not_compliant: []
 not_applicable: []
 compliant:
 - S3_BUCKET_PUBLIC_READ_PROHIBITED
-`- File(, Status=PASS)[Context=File(rules=1)]
+`- File(STDIN, Status=PASS)[Context=File(rules=1)]
    `- Rule(S3_BUCKET_PUBLIC_READ_PROHIBITED, Status=PASS)[Context=S3_BUCKET_PUBLIC_READ_PROHIBITED]
       |- Rule/When(Status=PASS)[Context=Rule#S3_BUCKET_PUBLIC_READ_PROHIBITED/When]
       |  `- GuardClauseBlock(Status = PASS)[Context=GuardAccessClause#block %s3_bucket_public_read_prohibited not EMPTY  ]

--- a/guard/resources/validate/output-dir/structured-payload.json
+++ b/guard/resources/validate/output-dir/structured-payload.json
@@ -1,6 +1,6 @@
 [
   {
-    "name": "",
+    "name": "DATA_STDIN[1]",
     "metadata": {},
     "status": "PASS",
     "not_compliant": [],
@@ -10,7 +10,7 @@
     ]
   },
   {
-    "name": "",
+    "name": "DATA_STDIN[2]",
     "metadata": {},
     "status": "PASS",
     "not_compliant": [],
@@ -20,7 +20,7 @@
     ]
   },
   {
-    "name": "",
+    "name": "DATA_STDIN[1]",
     "metadata": {},
     "status": "PASS",
     "not_compliant": [],
@@ -30,7 +30,7 @@
     ]
   },
   {
-    "name": "",
+    "name": "DATA_STDIN[2]",
     "metadata": {},
     "status": "PASS",
     "not_compliant": [],

--- a/guard/resources/validate/output-dir/structured.json
+++ b/guard/resources/validate/output-dir/structured.json
@@ -1,6 +1,6 @@
 [
   {
-    "name": "",
+    "name": "s3-public-read-prohibited-template-non-compliant.yaml",
     "metadata": {},
     "status": "FAIL",
     "not_compliant": [
@@ -115,7 +115,7 @@
     "compliant": []
   },
   {
-    "name": "",
+    "name": "s3-public-read-prohibited-template-non-compliant.yaml",
     "metadata": {},
     "status": "FAIL",
     "not_compliant": [
@@ -176,7 +176,7 @@
     "compliant": []
   },
   {
-    "name": "",
+    "name": "s3-public-read-prohibited-template-non-compliant.yaml",
     "metadata": {},
     "status": "FAIL",
     "not_compliant": [
@@ -397,7 +397,7 @@
     "compliant": []
   },
   {
-    "name": "",
+    "name": "s3-public-read-prohibited-template-non-compliant.yaml",
     "metadata": {},
     "status": "PASS",
     "not_compliant": [],

--- a/guard/resources/validate/output-dir/structured.yaml
+++ b/guard/resources/validate/output-dir/structured.yaml
@@ -1,4 +1,4 @@
-- name: ''
+- name: s3-public-read-prohibited-template-non-compliant.yaml
   metadata: {}
   status: FAIL
   not_compliant:
@@ -65,7 +65,7 @@
                 - true
   not_applicable: []
   compliant: []
-- name: ''
+- name: s3-public-read-prohibited-template-non-compliant.yaml
   metadata: {}
   status: FAIL
   not_compliant:
@@ -101,7 +101,7 @@
                 - false
   not_applicable: []
   compliant: []
-- name: ''
+- name: s3-public-read-prohibited-template-non-compliant.yaml
   metadata: {}
   status: FAIL
   not_compliant:
@@ -229,7 +229,7 @@
                 - false
   not_applicable: []
   compliant: []
-- name: ''
+- name: s3-public-read-prohibited-template-non-compliant.yaml
   metadata: {}
   status: PASS
   not_compliant: []

--- a/guard/resources/validate/output-dir/test_single_data_file_single_rules_file_verbose_compliant.out
+++ b/guard/resources/validate/output-dir/test_single_data_file_single_rules_file_verbose_compliant.out
@@ -2,7 +2,7 @@ s3-public-read-prohibited-template-compliant.yaml Status = PASS
 PASS rules
 s3_bucket_public_read_prohibited.guard/S3_BUCKET_PUBLIC_READ_PROHIBITED    PASS
 ---
-`- File(, Status=PASS)[Context=File(rules=1)]
+`- File(s3-public-read-prohibited-template-compliant.yaml, Status=PASS)[Context=File(rules=1)]
    `- Rule(S3_BUCKET_PUBLIC_READ_PROHIBITED, Status=PASS)[Context=S3_BUCKET_PUBLIC_READ_PROHIBITED]
       |- Rule/When(Status=PASS)[Context=Rule#S3_BUCKET_PUBLIC_READ_PROHIBITED/When]
       |  `- GuardClauseBlock(Status = PASS)[Context=GuardAccessClause#block %s3_bucket_public_read_prohibited not EMPTY  ]

--- a/guard/resources/validate/output-dir/test_single_data_file_single_rules_file_verbose_non_compliant.out
+++ b/guard/resources/validate/output-dir/test_single_data_file_single_rules_file_verbose_non_compliant.out
@@ -85,7 +85,7 @@ Resource = MyBucket {
     }
   }
 }
-`- File(, Status=FAIL)[Context=File(rules=1)]
+`- File(s3-public-read-prohibited-template-non-compliant.yaml, Status=FAIL)[Context=File(rules=1)]
    `- Rule(S3_BUCKET_PUBLIC_READ_PROHIBITED, Status=FAIL)[Context=S3_BUCKET_PUBLIC_READ_PROHIBITED]
       |- Rule/When(Status=PASS)[Context=Rule#S3_BUCKET_PUBLIC_READ_PROHIBITED/When]
       |  `- GuardClauseBlock(Status = PASS)[Context=GuardAccessClause#block %s3_bucket_public_read_prohibited not EMPTY  ]

--- a/guard/src/commands/helper.rs
+++ b/guard/src/commands/helper.rs
@@ -4,7 +4,7 @@
 use crate::commands::validate::generic_summary::GenericSummary;
 use crate::commands::validate::{DataFile, OutputFormatType, Reporter};
 use crate::rules::errors::Error;
-use crate::rules::eval::{eval_rules_file, FileData};
+use crate::rules::eval::eval_rules_file;
 use crate::rules::eval_context::root_scope;
 use crate::rules::path_value::traversal::Traversal;
 use crate::rules::path_value::PathAwareValue;
@@ -45,40 +45,37 @@ pub fn validate_and_return_json(
     let span = crate::rules::parser::Span::new_extra(&rules.content, rules.file_name);
 
     let rules_file_name = rules.file_name;
-    match crate::rules::parser::rules_file(span) {
-        Ok(rules) => match input_data.path_value {
-            Ok(root) => {
-                let mut write_output = BufWriter::new(Vec::new());
+    return match crate::rules::parser::rules_file(span) {
+        Ok(rules) => {
+            let mut write_output = BufWriter::new(Vec::new());
+            let root = input_data.path_value;
+            let traversal = Traversal::from(&root);
+            let mut root_scope = root_scope(&rules, &root)?;
+            let status = eval_rules_file(&rules, &mut root_scope, Some(&input_data.name))?;
+            let root_record = root_scope.reset_recorder().extract();
 
-                let traversal = Traversal::from(&root);
-                let mut root_scope = root_scope(&rules, &root)?;
-                let status = eval_rules_file(&rules, &mut root_scope, Some(&input_data.name))?;
-                let root_record = root_scope.reset_recorder().extract();
-
-                if verbose {
-                    return Ok(serde_json::to_string_pretty(&root_record)?);
-                }
-
-                let reporter = &GenericSummary::new() as &dyn Reporter;
-
-                reporter.report_eval(
-                    &mut write_output,
-                    status,
-                    &root_record,
-                    rules_file_name,
-                    data.file_name,
-                    data.content,
-                    &traversal,
-                    OutputFormatType::JSON,
-                )?;
-
-                match String::from_utf8(write_output.buffer().to_vec()) {
-                    Ok(val) => return Ok(val),
-                    Err(e) => return Err(Error::ParseError(e.to_string())),
-                }
+            if verbose {
+                return Ok(serde_json::to_string_pretty(&root_record)?);
             }
-            Err(e) => return Err(e),
-        },
-        Err(e) => return Err(Error::ParseError(e.to_string())),
-    }
+
+            let reporter = &GenericSummary::new() as &dyn Reporter;
+
+            reporter.report_eval(
+                &mut write_output,
+                status,
+                &root_record,
+                rules_file_name,
+                data.file_name,
+                data.content,
+                &traversal,
+                OutputFormatType::JSON,
+            )?;
+
+            match String::from_utf8(write_output.buffer().to_vec()) {
+                Ok(val) => Ok(val),
+                Err(e) => Err(Error::ParseError(e.to_string())),
+            }
+        }
+        Err(e) => Err(Error::ParseError(e.to_string())),
+    };
 }

--- a/guard/src/commands/test.rs
+++ b/guard/src/commands/test.rs
@@ -350,7 +350,7 @@ fn test_with_data(
                         let mut by_result = HashMap::new();
                         let root = PathAwareValue::try_from(each.input)?;
                         let mut root_scope = crate::rules::eval_context::root_scope(rules, &root)?;
-                        eval_rules_file(rules, &mut root_scope)?;
+                        eval_rules_file(rules, &mut root_scope, None)?; // we never use data file name in the output
                         let top = root_scope.reset_recorder().extract();
 
                         let by_rules = top.children.iter().fold(HashMap::new(), |mut acc, rule| {

--- a/guard/src/commands/validate.rs
+++ b/guard/src/commands/validate.rs
@@ -47,9 +47,9 @@ mod tf;
 
 #[derive(Eq, Clone, Debug, PartialEq)]
 pub(crate) struct DataFile {
-    content: String,
-    path_value: PathAwareValue,
-    name: String,
+    pub(crate) content: String,
+    pub(crate) path_value: PathAwareValue,
+    pub(crate) name: String,
 }
 
 #[derive(Copy, Eq, Clone, Debug, PartialEq)]

--- a/guard/src/commands/validate.rs
+++ b/guard/src/commands/validate.rs
@@ -935,7 +935,8 @@ fn evaluate_against_data_input<'r>(
             };
             let traversal = Traversal::from(&each);
             let mut root_scope = root_scope(rules, &each)?;
-            let status = eval_rules_file(rules, &mut root_scope)?;
+            let status = eval_rules_file(rules, &mut root_scope, Some(&file.name))?;
+
             let root_record = root_scope.reset_recorder().extract();
 
             reporter.report_eval(

--- a/guard/src/commands/validate/structured.rs
+++ b/guard/src/commands/validate/structured.rs
@@ -1,6 +1,7 @@
 use crate::commands::validate::{parse_rules, DataFile, OutputFormatType, RuleFileInfo};
 use crate::rules;
-use crate::rules::eval::eval_rules_file;
+use crate::rules::errors::Error;
+use crate::rules::eval::{eval_rules_file, FileData};
 use crate::rules::eval_context::{root_scope, simplifed_json_from_root};
 use crate::rules::exprs::RulesFile;
 use crate::rules::path_value::PathAwareValue;
@@ -18,14 +19,19 @@ pub struct StructuredEvaluator<'eval> {
 }
 
 impl<'eval> StructuredEvaluator<'eval> {
-    fn merge_input_params_with_data(&mut self) -> Vec<PathAwareValue> {
+    fn merge_input_params_with_data(&mut self) -> Vec<FileData> {
         self.data.iter().fold(vec![], |mut res, file| {
             let each = match &self.input_params {
                 Some(data) => data.clone().merge(file.path_value.clone()).unwrap(),
                 None => file.path_value.clone(),
             };
 
-            res.push(each);
+            let merged_file_data = FileData {
+                path_aware_value: Ok(each),
+                file_name: file.name.to_owned(),
+            };
+
+            res.push(merged_file_data);
             res
         })
     }
@@ -56,16 +62,28 @@ impl<'eval> StructuredEvaluator<'eval> {
         let mut records = vec![];
         for rule in &rules {
             for each in &merged_data {
-                let mut root_scope = root_scope(rule, each)?;
+                match &each.path_aware_value {
+                    Ok(path_aware_value) => {
+                        let mut root_scope = root_scope(rule, path_aware_value)?;
 
-                if let Status::FAIL = eval_rules_file(rule, &mut root_scope)? {
-                    self.exit_code = 5;
-                }
+                        if let Status::FAIL =
+                            eval_rules_file(rule, &mut root_scope, Some(&each.file_name))?
+                        {
+                            self.exit_code = 5;
+                        }
 
-                let root_record = root_scope.reset_recorder().extract();
+                        let root_record = root_scope.reset_recorder().extract();
 
-                let report = simplifed_json_from_root(&root_record)?;
-                records.push(report)
+                        let report = simplifed_json_from_root(&root_record)?;
+                        records.push(report)
+                    }
+                    Err(e) => {
+                        return Err(Error::ParseError(format!(
+                            "Unable to process data in file {}, Error {},",
+                            each.file_name, e
+                        )))
+                    }
+                };
             }
         }
 

--- a/guard/src/rules/eval.rs
+++ b/guard/src/rules/eval.rs
@@ -407,11 +407,6 @@ struct UnResolvedRhs<'r> {
     lhs: &'r PathAwareValue,
 }
 
-pub(crate) struct FileData {
-    pub(crate) path_aware_value: Result<PathAwareValue>,
-    pub(crate) file_name: String,
-}
-
 fn each_lhs_compare<'r, 'value: 'r, C>(
     cmp: C,
     lhs: &'value PathAwareValue,

--- a/guard/src/rules/eval.rs
+++ b/guard/src/rules/eval.rs
@@ -407,6 +407,11 @@ struct UnResolvedRhs<'r> {
     lhs: &'r PathAwareValue,
 }
 
+pub(crate) struct FileData {
+    pub(crate) path_aware_value: Result<PathAwareValue>,
+    pub(crate) file_name: String,
+}
+
 fn each_lhs_compare<'r, 'value: 'r, C>(
     cmp: C,
     lhs: &'value PathAwareValue,
@@ -1906,6 +1911,7 @@ impl<'loc> std::fmt::Display for RulesFile<'loc> {
 pub(crate) fn eval_rules_file<'value, 'loc: 'value>(
     rule: &'value RulesFile<'loc>,
     resolver: &mut dyn EvalContext<'value, 'loc>,
+    data_file_name: Option<&'value str>,
 ) -> Result<Status> {
     let context = format!("{}", rule);
     resolver.start_record(&context)?;
@@ -1949,7 +1955,10 @@ pub(crate) fn eval_rules_file<'value, 'loc: 'value>(
         &context,
         RecordType::FileCheck(NamedStatus {
             status: overall,
-            name: "",
+            name: match data_file_name {
+                Some(file_name) => file_name,
+                None => "",
+            },
             ..Default::default()
         }),
     )?;

--- a/guard/src/rules/eval_tests.rs
+++ b/guard/src/rules/eval_tests.rs
@@ -892,7 +892,7 @@ Resources:
     let value = PathAwareValue::try_from(serde_yaml::from_str::<serde_yaml::Value>(template)?)?;
     let mut root = root_scope(&rules, &value)?;
     //let mut tracker = RecordTracker::new(&mut root);
-    let status = eval_rules_file(&rules, &mut root)?;
+    let status = eval_rules_file(&rules, &mut root, None)?;
     assert_eq!(status, Status::PASS);
     Ok(())
 }
@@ -1211,7 +1211,7 @@ fn variable_projections() -> Result<()> {
     "#,
     )?;
     let mut root_scope = root_scope(&rules_file, &path_value)?;
-    let status = eval_rules_file(&rules_file, &mut root_scope)?;
+    let status = eval_rules_file(&rules_file, &mut root_scope, None)?;
     assert_eq!(status, Status::PASS);
 
     Ok(())
@@ -1251,7 +1251,7 @@ fn variable_projections_failures() -> Result<()> {
     "#,
     )?;
     let mut root_scope = root_scope(&rules_file, &path_value)?;
-    let status = eval_rules_file(&rules_file, &mut root_scope)?;
+    let status = eval_rules_file(&rules_file, &mut root_scope, None)?;
     assert_eq!(status, Status::FAIL); // for s3_bucket_policy_2.Properties.Bucket == ""
 
     let top = root_scope.reset_recorder().extract();
@@ -1336,7 +1336,7 @@ fn query_cross_joins() -> Result<()> {
     "#,
     )?;
     let mut root_scope = root_scope(&rules_files, &path_value)?;
-    let status = eval_rules_file(&rules_files, &mut root_scope)?;
+    let status = eval_rules_file(&rules_files, &mut root_scope, None)?;
     assert_eq!(status, Status::PASS);
 
     let rules_files = RulesFile::try_from(
@@ -1350,7 +1350,7 @@ fn query_cross_joins() -> Result<()> {
     "#,
     )?;
     let mut root_scope = eval_context::root_scope(&rules_files, &path_value)?;
-    let status = eval_rules_file(&rules_files, &mut root_scope)?;
+    let status = eval_rules_file(&rules_files, &mut root_scope, None)?;
     assert_eq!(status, Status::SKIP);
 
     let path_value = PathAwareValue::try_from(serde_yaml::from_str::<serde_yaml::Value>(
@@ -1384,7 +1384,7 @@ fn query_cross_joins() -> Result<()> {
     "#,
     )?;
     let mut root_scope = eval_context::root_scope(&rules_files, &path_value)?;
-    let status = eval_rules_file(&rules_files, &mut root_scope)?;
+    let status = eval_rules_file(&rules_files, &mut root_scope, None)?;
     assert_eq!(status, Status::FAIL);
 
     //
@@ -1402,7 +1402,7 @@ fn query_cross_joins() -> Result<()> {
     "#,
     )?;
     let mut root_scope = eval_context::root_scope(&rules_files, &path_value)?;
-    let status = eval_rules_file(&rules_files, &mut root_scope)?;
+    let status = eval_rules_file(&rules_files, &mut root_scope, None)?;
     assert_eq!(status, Status::PASS);
 
     //
@@ -1420,7 +1420,7 @@ fn query_cross_joins() -> Result<()> {
     "#,
     )?;
     let mut root_scope = eval_context::root_scope(&rules_files, &path_value)?;
-    let status = eval_rules_file(&rules_files, &mut root_scope)?;
+    let status = eval_rules_file(&rules_files, &mut root_scope, None)?;
     assert_eq!(status, Status::PASS);
 
     Ok(())
@@ -1463,7 +1463,7 @@ fn cross_rule_clause_when_checks() -> Result<()> {
     let resources = PathAwareValue::try_from(input)?;
     let rules = RulesFile::try_from(rules_skipped)?;
     let mut root = root_scope(&rules, &resources)?;
-    let status = eval_rules_file(&rules, &mut root)?;
+    let status = eval_rules_file(&rules, &mut root, None)?;
     assert_eq!(status, Status::PASS);
     let mut expectations = HashMap::with_capacity(4);
     expectations.insert("skipped".to_string(), Status::SKIP);
@@ -1497,7 +1497,7 @@ fn cross_rule_clause_when_checks() -> Result<()> {
 
     let resources = PathAwareValue::try_from(input)?;
     let mut root = root_scope(&rules, &resources)?;
-    let status = eval_rules_file(&rules, &mut root)?;
+    let status = eval_rules_file(&rules, &mut root, None)?;
     assert_eq!(status, Status::PASS);
     expectations.clear();
     expectations.insert("skipped".to_string(), Status::PASS);
@@ -1853,7 +1853,7 @@ fn test_multiple_valued_clause_reporting() -> Result<()> {
 
     let rules = RulesFile::try_from(rule)?;
     let mut root = root_scope(&rules, &values)?;
-    let status = eval_rules_file(&rules, &mut root)?;
+    let status = eval_rules_file(&rules, &mut root, None)?;
     assert_eq!(status, Status::FAIL);
 
     Ok(())
@@ -1906,7 +1906,7 @@ fn test_in_comparison_operator_for_list_of_lists(
     let value = PathAwareValue::try_from(serde_yaml::from_str::<serde_yaml::Value>(&template)?)?;
     let rule_eval = RulesFile::try_from(rules)?;
     let mut context = root_scope(&rule_eval, &value)?;
-    let status = eval_rules_file(&rule_eval, &mut context)?;
+    let status = eval_rules_file(&rule_eval, &mut context, None)?;
     assert_eq!(status, status_arg);
 
     Ok(())
@@ -1940,7 +1940,7 @@ fn test_type_conversions(#[case] ttl_arg: &str, #[case] status_arg: Status) -> R
     let value = PathAwareValue::try_from(serde_yaml::from_str::<serde_yaml::Value>(&template)?)?;
     let rule_eval = RulesFile::try_from(rules)?;
     let mut context = root_scope(&rule_eval, &value)?;
-    let status = eval_rules_file(&rule_eval, &mut context)?;
+    let status = eval_rules_file(&rule_eval, &mut context, None)?;
     assert_eq!(status, status_arg);
 
     Ok(())
@@ -1964,7 +1964,7 @@ fn is_bool() -> Result<()> {
     let rules_file = RulesFile::try_from(rule_str)?;
     println!("{:?}", rules_file);
     let mut eval = root_scope(&rules_file, &value)?;
-    let status = eval_rules_file(&rules_file, &mut eval)?;
+    let status = eval_rules_file(&rules_file, &mut eval, None)?;
     assert_eq!(status, Status::PASS);
 
     let resources_str = r###"
@@ -1974,7 +1974,7 @@ fn is_bool() -> Result<()> {
     "###;
     let value = PathAwareValue::try_from(resources_str)?;
     let mut eval = root_scope(&rules_file, &value)?;
-    let status = eval_rules_file(&rules_file, &mut eval)?;
+    let status = eval_rules_file(&rules_file, &mut eval, None)?;
     assert_eq!(status, Status::FAIL);
 
     Ok(())
@@ -1998,7 +1998,7 @@ fn is_int() -> Result<()> {
     let rules_file = RulesFile::try_from(rule_str)?;
     println!("{:?}", rules_file);
     let mut eval = root_scope(&rules_file, &value)?;
-    let status = eval_rules_file(&rules_file, &mut eval)?;
+    let status = eval_rules_file(&rules_file, &mut eval, None)?;
     assert_eq!(status, Status::PASS);
 
     let resources_str = r###"
@@ -2008,7 +2008,7 @@ fn is_int() -> Result<()> {
     "###;
     let value = PathAwareValue::try_from(resources_str)?;
     let mut eval = root_scope(&rules_file, &value)?;
-    let status = eval_rules_file(&rules_file, &mut eval)?;
+    let status = eval_rules_file(&rules_file, &mut eval, None)?;
     assert_eq!(status, Status::FAIL);
 
     Ok(())
@@ -2070,7 +2070,7 @@ fn double_projection_tests() -> Result<()> {
     let value = PathAwareValue::try_from(resources_str)?;
     let rules_file = RulesFile::try_from(rule_str)?;
     let mut eval = root_scope(&rules_file, &value)?;
-    let status = eval_rules_file(&rules_file, &mut eval)?;
+    let status = eval_rules_file(&rules_file, &mut eval, None)?;
     assert_eq!(status, Status::PASS);
 
     let resources_str = r###"
@@ -2087,7 +2087,7 @@ fn double_projection_tests() -> Result<()> {
     "###;
     let value = PathAwareValue::try_from(resources_str)?;
     let mut eval = root_scope(&rules_file, &value)?;
-    let status = eval_rules_file(&rules_file, &mut eval)?;
+    let status = eval_rules_file(&rules_file, &mut eval, None)?;
     assert_eq!(status, Status::FAIL);
 
     Ok(())
@@ -2295,7 +2295,7 @@ rule check_rest_api_is_private_and_has_access {
 }"#;
     let rule = RulesFile::try_from(rule_str)?;
     let mut root = root_scope(&rule, &value)?;
-    let status = eval_rules_file(&rule, &mut root)?;
+    let status = eval_rules_file(&rule, &mut root, None)?;
     assert_eq!(status, Status::FAIL);
 
     let value_str = r#"
@@ -2316,7 +2316,7 @@ rule check_rest_api_is_private_and_has_access {
     let value = serde_yaml::from_str::<serde_yaml::Value>(value_str)?;
     let value = PathAwareValue::try_from(value)?;
     let mut root = root_scope(&rule, &value)?;
-    let status = eval_rules_file(&rule, &mut root)?;
+    let status = eval_rules_file(&rule, &mut root, None)?;
     assert_eq!(status, Status::PASS);
 
     Ok(())
@@ -2528,7 +2528,7 @@ fn filter_based_join_clauses_failures_and_skips() -> Result<()> {
     let path_value =
         PathAwareValue::try_from(serde_yaml::from_str::<serde_yaml::Value>(resources)?)?;
     let mut eval = root_scope(&rules_file, &path_value)?;
-    let status = eval_rules_file(&rules_file, &mut eval)?;
+    let status = eval_rules_file(&rules_file, &mut eval, None)?;
     assert_eq!(status, Status::FAIL);
 
     let top = eval.reset_recorder().extract();
@@ -2581,7 +2581,7 @@ fn filter_based_join_clauses_failures_and_skips() -> Result<()> {
     let path_value =
         PathAwareValue::try_from(serde_yaml::from_str::<serde_yaml::Value>(resources)?)?;
     let mut eval = root_scope(&rules_file, &path_value)?;
-    let status = eval_rules_file(&rules_file, &mut eval)?;
+    let status = eval_rules_file(&rules_file, &mut eval, None)?;
     assert_eq!(status, Status::SKIP);
 
     //
@@ -2607,7 +2607,7 @@ fn filter_based_join_clauses_failures_and_skips() -> Result<()> {
     let path_value =
         PathAwareValue::try_from(serde_yaml::from_str::<serde_yaml::Value>(resources)?)?;
     let mut eval = eval.reset_root(&path_value)?;
-    let status = eval_rules_file(&rules_file, &mut eval)?;
+    let status = eval_rules_file(&rules_file, &mut eval, None)?;
     assert_eq!(status, Status::SKIP);
 
     //
@@ -2638,7 +2638,7 @@ fn filter_based_join_clauses_failures_and_skips() -> Result<()> {
     //
     // Let us track failures and assert on what must be observed
     //
-    let status = eval_rules_file(&rules_file, &mut eval)?;
+    let status = eval_rules_file(&rules_file, &mut eval, None)?;
     assert_eq!(status, Status::FAIL);
 
     let top = eval.reset_recorder().extract();
@@ -2707,7 +2707,7 @@ fn filter_based_with_join_pass_use_cases() -> Result<()> {
         PathAwareValue::try_from(serde_yaml::from_str::<serde_yaml::Value>(resources)?)?;
     let rules_file = RulesFile::try_from(rules)?;
     let mut eval = root_scope(&rules_file, &path_value)?;
-    let status = eval_rules_file(&rules_file, &mut eval)?;
+    let status = eval_rules_file(&rules_file, &mut eval, None)?;
     assert_eq!(status, Status::PASS);
 
     Ok(())
@@ -2746,7 +2746,7 @@ fn rule_clause_tests() -> Result<()> {
 
     let value = PathAwareValue::try_from(v)?;
     let mut eval = root_scope(&rule, &value)?;
-    let status = eval_rules_file(&rule, &mut eval)?;
+    let status = eval_rules_file(&rule, &mut eval, None)?;
     assert_eq!(Status::PASS, status);
 
     //
@@ -2768,7 +2768,7 @@ fn rule_clause_tests() -> Result<()> {
 
     let value = PathAwareValue::try_from(v)?;
     let mut eval = eval.reset_root(&value)?;
-    let status = eval_rules_file(&rule, &mut eval)?;
+    let status = eval_rules_file(&rule, &mut eval, None)?;
     assert_eq!(Status::FAIL, status);
 
     Ok(())
@@ -2829,7 +2829,7 @@ fn rule_test_type_blocks() -> Result<()> {
     let root = PathAwareValue::try_from(serde_yaml::from_str::<serde_yaml::Value>(value)?)?;
     let rules_file = RulesFile::try_from(r)?;
     let mut root_context = root_scope(&rules_file, &root)?;
-    let status = eval_rules_file(&rules_file, &mut root_context)?;
+    let status = eval_rules_file(&rules_file, &mut root_context, None)?;
     assert_eq!(Status::FAIL, status);
 
     let top = root_context.reset_recorder().extract();
@@ -2922,7 +2922,7 @@ rule iam_basic_checks when iam_resources_exists {
     let root = PathAwareValue::try_from(value)?;
     let rules_file = RulesFile::try_from(file)?;
     let mut root_context = root_scope(&rules_file, &root)?;
-    let status = eval_rules_file(&rules_file, &mut root_context)?;
+    let status = eval_rules_file(&rules_file, &mut root_context, None)?;
     assert_eq!(Status::PASS, status);
 
     Ok(())
@@ -2991,7 +2991,7 @@ rule iam_basic_checks {
     let rules_file = RulesFile::try_from(file)?;
     let mut root_context = root_scope(&rules_file, &root)?;
 
-    let status = eval_rules_file(&rules_file, &mut root_context)?;
+    let status = eval_rules_file(&rules_file, &mut root_context, None)?;
     assert_eq!(Status::FAIL, status);
 
     let top = root_context.reset_recorder().extract();
@@ -3058,7 +3058,7 @@ rule iam_basic_checks {
 
     let root = PathAwareValue::try_from(value)?;
     let mut root_context = root_context.reset_root(&root)?;
-    let status = eval_rules_file(&rules_file, &mut root_context)?;
+    let status = eval_rules_file(&rules_file, &mut root_context, None)?;
     assert_eq!(Status::FAIL, status);
 
     let top = root_context.reset_recorder().extract();
@@ -3471,7 +3471,7 @@ rule deny_task_role_no_permission_boundary when %ecs_tasks !EMPTY {
     let rules_file = RulesFile::try_from(rules)?;
     let value = PathAwareValue::try_from(resources)?;
     let mut eval = root_scope(&rules_file, &value)?;
-    let status = eval_rules_file(&rules_file, &mut eval)?;
+    let status = eval_rules_file(&rules_file, &mut eval, None)?;
 
     println!("{}", status);
     Ok(())
@@ -3588,7 +3588,7 @@ rule deny_egress when %sgs NOT EMPTY {
 
     for (index, each) in samples.iter().enumerate() {
         let mut root_context = root_scope(&rules_file, each)?;
-        let status = eval_rules_file(&rules_file, &mut root_context)?;
+        let status = eval_rules_file(&rules_file, &mut root_context, None)?;
         println!("{}", format!("Status {} = {}", index, status).underline());
     }
 
@@ -3788,7 +3788,7 @@ fn test_s3_bucket_pro_serv() -> Result<()> {
 
     for (idx, each) in parsed_values.iter().enumerate() {
         let mut root_scope = root_scope(&s3_rule, each)?;
-        let status = eval_rules_file(&s3_rule, &mut root_scope)?;
+        let status = eval_rules_file(&s3_rule, &mut root_scope, None)?;
         assert_eq!(status, expectations[idx]);
     }
     Ok(())
@@ -3862,7 +3862,7 @@ fn parameterized_evaluations() -> Result<()> {
         PathAwareValue::try_from(serde_yaml::from_str::<serde_yaml::Value>(template_value)?)?;
 
     let mut eval = root_scope(&rules_files, &template)?;
-    let status = eval_rules_file(&rules_files, &mut eval)?;
+    let status = eval_rules_file(&rules_files, &mut eval, None)?;
     let top = eval.reset_recorder().extract();
     let mut writer = Writer::new(Stdout(stdout()), Stderr(stderr()));
     crate::commands::validate::print_verbose_tree(&top, &mut writer);
@@ -3883,7 +3883,7 @@ fn parameterized_evaluations() -> Result<()> {
         PathAwareValue::try_from(serde_yaml::from_str::<serde_yaml::Value>(aws_config_value)?)?;
 
     let mut eval = root_scope(&rules_files, &config_value)?;
-    let status = eval_rules_file(&rules_files, &mut eval)?;
+    let status = eval_rules_file(&rules_files, &mut eval, None)?;
     let top = eval.reset_recorder().extract();
     crate::commands::validate::print_verbose_tree(&top, &mut writer);
     assert_eq!(status, Status::PASS);
@@ -3923,7 +3923,7 @@ fn using_resource_names_for_assessment() -> Result<()> {
 
     let rules = RulesFile::try_from(rules_file)?;
     let mut eval = root_scope(&rules, &value)?;
-    let status = eval_rules_file(&rules, &mut eval)?;
+    let status = eval_rules_file(&rules, &mut eval, None)?;
     assert_eq!(status, Status::FAIL);
 
     Ok(())
@@ -3959,7 +3959,7 @@ fn test_string_in_comparison() -> Result<()> {
 
     let rules_files = RulesFile::try_from(rules)?;
     let mut eval = root_scope(&rules_files, &value)?;
-    let status = eval_rules_file(&rules_files, &mut eval)?;
+    let status = eval_rules_file(&rules_files, &mut eval, None)?;
     assert_eq!(status, Status::PASS);
 
     Ok(())

--- a/guard/tests/functional.rs
+++ b/guard/tests/functional.rs
@@ -29,7 +29,7 @@ mod functional_tests {
                   "context": "File(rules=1)",
                   "container": {
                     "FileCheck": {
-                      "name": "",
+                      "name": "functional_test.json",
                       "status": "FAIL",
                       "message": null
                     }


### PR DESCRIPTION
*Issue #, if available:*
NA

*Description of changes:*
* Populated filename in the output of the evaluation.

## Example:

### Rule
<details>
  <summary>
    (click to expand)
  </summary>

  #### s3_bucket_server_side_encryption_enabled.guard

  ```
  let s3_buckets_server_side_encryption = Resources.*[ Type == 'AWS::S3::Bucket']

  rule S3_BUCKET_SERVER_SIDE_ENCRYPTION_ENABLED when %s3_buckets_server_side_encryption !empty {
    %s3_buckets_server_side_encryption.Properties.BucketEncryption exists
    %s3_buckets_server_side_encryption.Properties.BucketEncryption.ServerSideEncryptionConfiguration[*].ServerSideEncryptionByDefault.SSEAlgorithm in ["aws:kms","AES256"]
    <<
      Violation: S3 Bucket must enable server-side encryption.
      Fix: Set the S3 Bucket property BucketEncryption.ServerSideEncryptionConfiguration.ServerSideEncryptionByDefault.SSEAlgorithm to either "aws:kms" or "AES256"
    >>
  }
```

</details>

### Data
<details>
  <summary>
    (click to expand)
  </summary>

   #### s3-server-side-encryption-template.yaml

   ``` yaml
    Resources:
      MyBucket1:
        Type: AWS::S3::Bucket
        Properties:
          BucketEncryption:
            ServerSideEncryptionConfiguration:
              - ServerSideEncryptionByDefault:
                  SSEAlgorithm: aws:kms
```


</details>

### Command:

```bash
cfn-guard validate \
 -d s3-server-side-encryption-template.yaml \
 -r s3_bucket_server_side_encryption_enabled.guard \
 --show-summary none -o json 
```
### Output
```json
{
  "name": "s3-server-side-encryption-template.yaml",
  "metadata": {},
  "status": "PASS",
  "not_compliant": [],
  "not_applicable": [],
  "compliant": [
    "S3_BUCKET_SERVER_SIDE_ENCRYPTION_ENABLED"
  ]
}
```

---
*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
