### PR TITLE
Support for some function expressions / stateful rules 

### DIFF
--- a/guard/Cargo.toml
+++ b/guard/Cargo.toml
@@ -22,7 +22,7 @@ nom_locate = "2.0.0"
 indexmap = { version = "1.6.0", features = ["serde-1"] }
 clap = "4.1.4"
 strip-ansi-escapes = "0.1.1"
-serde = { version = "1.0", features = ["derive"] }
+serde = { version = "1.0", features = ["derive", "rc"] }
 serde_yaml = "0.9.10"
 walkdir = "2.3.1"
 colored = "2.0.0"

--- a/guard/resources/test-command/functions/data/template.yaml
+++ b/guard/resources/test-command/functions/data/template.yaml
@@ -1,0 +1,21 @@
+---
+- name: Pass
+  input:
+    Resources:
+      newServer:
+        Type: AWS::New::Service
+        Properties:
+          Policy: |
+            {
+               "Principal": "*",
+               "Actions": ["s3*", "ec2*"]
+            }
+          Arn: arn:aws:newservice:us-west-2:123456789012:Table/extracted
+          Encoded: This%20string%20will%20be%20URL%20encoded
+        Collection:
+          - a
+          - b
+          - c
+  expectations:
+    rules:
+      SOME_RULE: PASS

--- a/guard/resources/test-command/functions/rules/json_parse.guard
+++ b/guard/resources/test-command/functions/rules/json_parse.guard
@@ -1,0 +1,16 @@
+let template = Resources.*[ Type == 'AWS::New::Service']
+
+let expected = {
+        "Principal": "*",
+        "Actions": ["s3*", "ec2*"]
+}
+
+rule SOME_RULE when %template !empty {
+    let policy = %template.Properties.Policy
+    let res = json_parse(%policy)
+
+    %res !empty
+    %res == %expected
+
+}
+

--- a/guard/resources/validate/functions/data/template.yaml
+++ b/guard/resources/validate/functions/data/template.yaml
@@ -9,5 +9,32 @@ Resources:
         }
       Arn: arn:aws:newservice:us-west-2:123456789012:Table/extracted
       Encoded: This%20string%20will%20be%20URL%20encoded
+    Collection:
+      - a
+      - b
+      - c
+    BucketPolicy:
+      PolicyText: '{"Version":"2012-10-17","Statement":[{"Sid":"DenyReducedReliabilityStorage","Effect":"Deny","Principal":"*","Action":"s3:*","Resource":"arn:aws:s3:::s3-test-123/*","Condition":{"StringEquals":{"s3:x-amz-storage-class-123":["ONEZONE_IA","REDUCED_REDUNDANCY"]}}}]}'
+
   s3:
+    Type: AWS::S3::Bucket
+    Properties:
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
+  bucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: false
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
+  bucket2:
+    Type: AWS::S3::Bucket
+  bucket3:
+    Type: AWS::S3::Bucket
+  bucket4:
     Type: AWS::S3::Bucket

--- a/guard/resources/validate/functions/data/template.yaml
+++ b/guard/resources/validate/functions/data/template.yaml
@@ -1,0 +1,13 @@
+Resources:
+  newServer:
+    Type: AWS::New::Service
+    Properties:
+      Policy: |
+        {
+           "Principal": "*",
+           "Actions": ["s3*", "ec2*"]
+        }
+      Arn: arn:aws:newservice:us-west-2:123456789012:Table/extracted
+      Encoded: This%20string%20will%20be%20URL%20encoded
+  s3:
+    Type: AWS::S3::Bucket

--- a/guard/resources/validate/functions/rules/count.guard
+++ b/guard/resources/validate/functions/rules/count.guard
@@ -1,10 +1,28 @@
-let template = Resources.*[ Type == 'AWS::New::Service']
-
+let template = Resources.*[ Type == 'AWS::New::Service' ]
 rule SOME_RULE when %template !empty {
     %template.Properties exists
+    %template.Properties is_struct
+
     let props = %template.Properties.*
-
     let res = count(%props)
-
     %res == 3
+
+    %template.Collection exists
+    %template.Collection is_list
+
+    let collection = %template.Collection.*
+    let res = count(%collection)
+    %res == 3
+}
+
+let buckets = Resources.*[ Type == 'AWS::S3::Bucket' ]
+rule SOME_BUCKET_RULE when %buckets !empty {
+    let b1 = %buckets[ Properties.PublicAccessBlockConfiguration exists ]
+    let res1 = count(%b1)
+    %res1 == 2
+
+    let b = %buckets[ Properties.PublicAccessBlockConfiguration.BlockPublicAcls == true ]
+
+    let res = count(%b)
+    %res == 1
 }

--- a/guard/resources/validate/functions/rules/count.guard
+++ b/guard/resources/validate/functions/rules/count.guard
@@ -1,0 +1,10 @@
+let template = Resources.*[ Type == 'AWS::New::Service']
+
+rule SOME_RULE when %template !empty {
+    %template.Properties exists
+    let props = %template.Properties.*
+
+    let res = count(%props)
+
+    %res == 3
+}

--- a/guard/resources/validate/functions/rules/join.guard
+++ b/guard/resources/validate/functions/rules/join.guard
@@ -10,3 +10,12 @@ rule SOME_RULE when %template !empty {
     let res = join(%arn, %encoded, ",")
     %res == "arn:aws:newservice:us-west-2:123456789012:Table/extracted,This%20string%20will%20be%20URL%20encoded"
 }
+
+
+let buckets = Resources[ Type == 'AWS::S3::Bucket' ]
+
+rule SOME_BUCKET_RULE when %buckets !empty {
+    let res = join(%buckets.Type, '-')
+
+    %res == "AWS::S3::Bucket-AWS::S3::Bucket-AWS::S3::Bucket-AWS::S3::Bucket-AWS::S3::Bucket"
+}

--- a/guard/resources/validate/functions/rules/join.guard
+++ b/guard/resources/validate/functions/rules/join.guard
@@ -1,0 +1,12 @@
+let template = Resources.*[ Type == 'AWS::New::Service']
+
+rule SOME_RULE when %template !empty {
+    %template.Properties.Arn exists
+    %template.Properties.Encoded exists
+
+    let encoded = %template.Properties.Encoded
+    let arn = %template.Properties.Arn
+
+    let res = join(%arn, %encoded, ",")
+    %res == "arn:aws:newservice:us-west-2:123456789012:Table/extracted,This%20string%20will%20be%20URL%20encoded"
+}

--- a/guard/resources/validate/functions/rules/join.guard
+++ b/guard/resources/validate/functions/rules/join.guard
@@ -1,14 +1,10 @@
 let template = Resources.*[ Type == 'AWS::New::Service']
 
 rule SOME_RULE when %template !empty {
-    %template.Properties.Arn exists
-    %template.Properties.Encoded exists
+    let collection = %template.Collection.*
 
-    let encoded = %template.Properties.Encoded
-    let arn = %template.Properties.Arn
-
-    let res = join(%arn, %encoded, ",")
-    %res == "arn:aws:newservice:us-west-2:123456789012:Table/extracted,This%20string%20will%20be%20URL%20encoded"
+    let res = join(%collection, ",")
+    %res == "a,b,c"
 }
 
 

--- a/guard/resources/validate/functions/rules/json_parse.guard
+++ b/guard/resources/validate/functions/rules/json_parse.guard
@@ -6,16 +6,12 @@ let expected = {
 }
 
 rule SOME_RULE when %template !empty {
-    %template.Properties.Policy exists
     let policy = %template.Properties.Policy
 
     let res = json_parse(%policy)
 
     %res !empty
     %res == %expected
-
-    %template.BucketPolicy exists
-    %template.BucketPolicy.PolicyText exists
 
     let policy_text = %template.BucketPolicy.PolicyText
     let res2 = json_parse(%policy_text)

--- a/guard/resources/validate/functions/rules/json_parse.guard
+++ b/guard/resources/validate/functions/rules/json_parse.guard
@@ -13,4 +13,17 @@ rule SOME_RULE when %template !empty {
 
     %res !empty
     %res == %expected
+
+    %template.BucketPolicy exists
+    %template.BucketPolicy.PolicyText exists
+
+    let policy_text = %template.BucketPolicy.PolicyText
+    let res2 = json_parse(%policy_text)
+
+    %res2.Statement[*] 
+    {
+            Effect == "Deny"
+            Resource == "arn:aws:s3:::s3-test-123/*"
+    }
 }
+

--- a/guard/resources/validate/functions/rules/json_parse.guard
+++ b/guard/resources/validate/functions/rules/json_parse.guard
@@ -1,0 +1,16 @@
+let template = Resources.*[ Type == 'AWS::New::Service']
+
+let expected = {
+        "Principal": "*",
+        "Actions": ["s3*", "ec2*"]
+}
+
+rule SOME_RULE when %template !empty {
+    %template.Properties.Policy exists
+    let policy = %template.Properties.Policy
+
+    let res = json_parse(%policy)
+
+    %res !empty
+    %res == %expected
+}

--- a/guard/resources/validate/functions/rules/regex_replace.guard
+++ b/guard/resources/validate/functions/rules/regex_replace.guard
@@ -1,0 +1,10 @@
+let template = Resources.*[ Type == 'AWS::New::Service']
+
+rule SOME_RULE when %template !empty {
+    %template.Properties.Arn exists
+    let arn = %template.Properties.Arn
+
+    let res = regex_replace(%arn, "^arn:(\w+):(\w+):([\w0-9-]+):(\d+):(.+)$", "${1}/${4}/${3}/${2}-${5}")
+
+    %res == "aws/123456789012/us-west-2/newservice-Table/extracted"
+}

--- a/guard/resources/validate/functions/rules/regex_replace.guard
+++ b/guard/resources/validate/functions/rules/regex_replace.guard
@@ -1,3 +1,18 @@
+#
+# In this simple example, we will re-format an ARN by moving around some sections in it.
+#
+# We will start with a normal ARN that has the following pattern:
+#    arn:<Partition>:<Service>:<Region>:<AccountID>:<ResourceType>/<ResourceID>
+# and we will try to convert it to:
+#    <Partition>/<AccountID>/<Region>/<Service>-<ResourceType>/<ResourceID>
+#
+# For example:
+#    arn:aws:newservice:us-west-2:123456789012:Table/extracted
+# becomes:
+#    aws/123456789012/us-west-2/newservice-Table/extracted
+#
+
+
 let template = Resources.*[ Type == 'AWS::New::Service']
 
 rule SOME_RULE when %template !empty {

--- a/guard/resources/validate/functions/rules/regex_replace.guard
+++ b/guard/resources/validate/functions/rules/regex_replace.guard
@@ -3,8 +3,10 @@ let template = Resources.*[ Type == 'AWS::New::Service']
 rule SOME_RULE when %template !empty {
     %template.Properties.Arn exists
     let arn = %template.Properties.Arn
-
-    let res = regex_replace(%arn, "^arn:(\w+):(\w+):([\w0-9-]+):(\d+):(.+)$", "${1}/${4}/${3}/${2}-${5}")
+    
+    let arn_partition_regex = "^arn:(\w+):(\w+):([\w0-9-]+):(\d+):(.+)$"
+    let capture_group_reordering = "${1}/${4}/${3}/${2}-${5}"
+    let res = regex_replace(%arn, %arn_partition_regex, %capture_group_reordering)
 
     %res == "aws/123456789012/us-west-2/newservice-Table/extracted"
 }

--- a/guard/resources/validate/functions/rules/string_manip.guard
+++ b/guard/resources/validate/functions/rules/string_manip.guard
@@ -1,0 +1,12 @@
+let template = Resources.*[ Type == 'AWS::New::Service']
+
+let type = Resources.newServer.Type
+
+rule SOME_RULE when %type !empty {
+    let lower = to_lower(%type)
+    %lower == "aws::new::service"
+
+    let upper = to_upper(%type)
+    %upper == "AWS::NEW::SERVICE"
+}
+

--- a/guard/resources/validate/functions/rules/string_manipulation.guard
+++ b/guard/resources/validate/functions/rules/string_manipulation.guard
@@ -5,8 +5,10 @@ let type = Resources.newServer.Type
 rule SOME_RULE when %type !empty {
     let lower = to_lower(%type)
     %lower == "aws::new::service"
+    %lower == /aws::new::service/
 
     let upper = to_upper(%type)
     %upper == "AWS::NEW::SERVICE"
+    %upper == /AWS::NEW::SERVICE/
 }
 

--- a/guard/resources/validate/functions/rules/substring.guard
+++ b/guard/resources/validate/functions/rules/substring.guard
@@ -1,0 +1,10 @@
+let template = Resources.*[ Type == 'AWS::New::Service']
+
+rule SOME_RULE when %template !empty {
+    %template.Properties.Arn exists
+    let arn = %template.Properties.Arn
+
+    let res = substring(%arn, 0, 3)
+
+    %res == "arn"
+}

--- a/guard/resources/validate/functions/rules/substring.guard
+++ b/guard/resources/validate/functions/rules/substring.guard
@@ -3,6 +3,7 @@ let template = Resources.*[ Type == 'AWS::New::Service']
 rule SOME_RULE when %template !empty {
     %template.Properties.Arn exists
     let arn = %template.Properties.Arn
+    let encoded = %template.Properties.Encoded
 
     let res = substring(%arn, 0, 3)
 

--- a/guard/resources/validate/functions/rules/substring.guard
+++ b/guard/resources/validate/functions/rules/substring.guard
@@ -3,7 +3,6 @@ let template = Resources.*[ Type == 'AWS::New::Service']
 rule SOME_RULE when %template !empty {
     %template.Properties.Arn exists
     let arn = %template.Properties.Arn
-    let encoded = %template.Properties.Encoded
 
     let res = substring(%arn, 0, 3)
 

--- a/guard/resources/validate/functions/rules/url_decode.guard
+++ b/guard/resources/validate/functions/rules/url_decode.guard
@@ -1,0 +1,9 @@
+let template = Resources.*[ Type == 'AWS::New::Service']
+
+rule SOME_RULE when %template !empty {
+    %template.Properties.Encoded exists
+    let encoded = %template.Properties.Encoded
+
+    let res = url_decode(%encoded)
+    %res == "This string will be URL encoded"
+}

--- a/guard/src/commands/helper.rs
+++ b/guard/src/commands/helper.rs
@@ -11,6 +11,7 @@ use crate::rules::path_value::PathAwareValue;
 use crate::rules::Result;
 use std::convert::TryFrom;
 use std::io::BufWriter;
+use std::rc::Rc;
 
 pub struct ValidateInput<'a> {
     pub content: &'a str,
@@ -50,7 +51,7 @@ pub fn validate_and_return_json(
             let mut write_output = BufWriter::new(Vec::new());
             let root = input_data.path_value;
             let traversal = Traversal::from(&root);
-            let mut root_scope = root_scope(&rules, &root)?;
+            let mut root_scope = root_scope(&rules, Rc::new(root.clone()))?;
             let status = eval_rules_file(&rules, &mut root_scope, Some(&input_data.name))?;
             let root_record = root_scope.reset_recorder().extract();
 

--- a/guard/src/commands/test.rs
+++ b/guard/src/commands/test.rs
@@ -5,6 +5,7 @@ use std::convert::TryFrom;
 use std::fs::File;
 use std::io::Write;
 use std::path::PathBuf;
+use std::rc::Rc;
 use walkdir::DirEntry;
 
 use validate::validate_path;
@@ -349,7 +350,8 @@ fn test_with_data(
                     let by_result = if new_engine {
                         let mut by_result = HashMap::new();
                         let root = PathAwareValue::try_from(each.input)?;
-                        let mut root_scope = crate::rules::eval_context::root_scope(rules, &root)?;
+                        let mut root_scope =
+                            crate::rules::eval_context::root_scope(rules, Rc::new(root.clone()))?;
                         eval_rules_file(rules, &mut root_scope, None)?; // we never use data file name in the output
                         let top = root_scope.reset_recorder().extract();
 

--- a/guard/src/commands/validate.rs
+++ b/guard/src/commands/validate.rs
@@ -4,6 +4,7 @@ use std::fmt::Debug;
 use std::fs::File;
 use std::io::{BufReader, Read, Write};
 use std::path::{Path, PathBuf};
+use std::rc::Rc;
 use std::str::FromStr;
 
 use clap::{Arg, ArgAction, ArgGroup, ArgMatches};
@@ -934,7 +935,7 @@ fn evaluate_against_data_input<'r>(
                 None => file.path_value.clone(),
             };
             let traversal = Traversal::from(&each);
-            let mut root_scope = root_scope(rules, &each)?;
+            let mut root_scope = root_scope(rules, Rc::new(each.clone()))?;
             let status = eval_rules_file(rules, &mut root_scope, Some(&file.name))?;
 
             let root_record = root_scope.reset_recorder().extract();

--- a/guard/src/commands/validate/structured.rs
+++ b/guard/src/commands/validate/structured.rs
@@ -1,6 +1,7 @@
+use std::rc::Rc;
+
 use crate::commands::validate::{parse_rules, DataFile, OutputFormatType, RuleFileInfo};
 use crate::rules;
-use crate::rules::errors::Error;
 use crate::rules::eval::eval_rules_file;
 use crate::rules::eval_context::{root_scope, simplifed_json_from_root};
 use crate::rules::exprs::RulesFile;
@@ -63,7 +64,7 @@ impl<'eval> StructuredEvaluator<'eval> {
         let mut records = vec![];
         for rule in &rules {
             for each in &merged_data {
-                let mut root_scope = root_scope(rule, &each.path_value)?;
+                let mut root_scope = root_scope(rule, Rc::new(each.path_value.clone()))?;
 
                 if let Status::FAIL = eval_rules_file(rule, &mut root_scope, Some(&each.name))? {
                     self.exit_code = 5;

--- a/guard/src/migrate/parser_tests.rs
+++ b/guard/src/migrate/parser_tests.rs
@@ -1,7 +1,6 @@
 use super::*;
 use crate::rules::parser::{from_str2, Span};
 
-use crate::rules::values::Value::Bool;
 use indexmap::map::IndexMap;
 
 #[test]

--- a/guard/src/rules/eval.rs
+++ b/guard/src/rules/eval.rs
@@ -1584,7 +1584,8 @@ pub(in crate::rules) fn eval_parameterized_rule_call<'value, 'loc: 'value>(
                     resolver.query(&query.query)?,
                 );
             }
-            LetValue::FunctionCall(_) => todo!(),
+            // TODO: when we add inline function support
+            LetValue::FunctionCall(_) => unimplemented!(),
         }
     }
     let mut eval = ResolvedParameterContext {

--- a/guard/src/rules/eval/operators.rs
+++ b/guard/src/rules/eval/operators.rs
@@ -1,88 +1,90 @@
+use std::rc::Rc;
+
 use crate::rules::errors::Error;
 use crate::rules::path_value::*;
 use crate::rules::{CmpOperator, QueryResult, UnResolved};
 
 #[derive(Clone, Debug)]
-pub(crate) enum UnaryResult<'r> {
+pub(crate) enum UnaryResult {
     Success,
     Fail,
-    SuccessWith(&'r PathAwareValue),
-    FailWith(&'r PathAwareValue),
+    SuccessWith(Rc<PathAwareValue>),
+    FailWith(Rc<PathAwareValue>),
 }
 
 #[derive(Clone, Debug)]
-pub(crate) struct LhsRhsPair<'value> {
-    pub(crate) lhs: &'value PathAwareValue,
-    pub(crate) rhs: &'value PathAwareValue,
+pub(crate) struct LhsRhsPair {
+    pub(crate) lhs: Rc<PathAwareValue>,
+    pub(crate) rhs: Rc<PathAwareValue>,
 }
 
-impl<'value> LhsRhsPair<'value> {
-    fn new<'r>(lhs: &'r PathAwareValue, rhs: &'r PathAwareValue) -> LhsRhsPair<'r> {
+impl<'value> LhsRhsPair {
+    fn new(lhs: Rc<PathAwareValue>, rhs: Rc<PathAwareValue>) -> LhsRhsPair {
         LhsRhsPair { lhs, rhs }
     }
 }
 
 #[derive(Clone, Debug)]
-pub(crate) struct QueryIn<'value> {
-    pub(crate) diff: Vec<&'value PathAwareValue>,
-    pub(crate) lhs: Vec<&'value PathAwareValue>,
-    pub(crate) rhs: Vec<&'value PathAwareValue>,
+pub(crate) struct QueryIn {
+    pub(crate) diff: Vec<Rc<PathAwareValue>>,
+    pub(crate) lhs: Vec<Rc<PathAwareValue>>,
+    pub(crate) rhs: Vec<Rc<PathAwareValue>>,
 }
 
-impl<'value> QueryIn<'value> {
-    fn new<'r>(
-        diff: Vec<&'r PathAwareValue>,
-        lhs: Vec<&'r PathAwareValue>,
-        rhs: Vec<&'r PathAwareValue>,
-    ) -> QueryIn<'r> {
+impl<'value> QueryIn {
+    fn new(
+        diff: Vec<Rc<PathAwareValue>>,
+        lhs: Vec<Rc<PathAwareValue>>,
+        rhs: Vec<Rc<PathAwareValue>>,
+    ) -> QueryIn {
         QueryIn { lhs, rhs, diff }
     }
 }
 
 #[derive(Clone, Debug)]
-pub(crate) struct ListIn<'value> {
-    pub(crate) diff: Vec<&'value PathAwareValue>,
-    pub(crate) lhs: &'value PathAwareValue,
-    pub(crate) rhs: &'value PathAwareValue,
+pub(crate) struct ListIn {
+    pub(crate) diff: Vec<Rc<PathAwareValue>>,
+    pub(crate) lhs: Rc<PathAwareValue>,
+    pub(crate) rhs: Rc<PathAwareValue>,
 }
 
-impl<'value> ListIn<'value> {
-    fn new<'r>(
-        diff: Vec<&'r PathAwareValue>,
-        lhs: &'r PathAwareValue,
-        rhs: &'r PathAwareValue,
-    ) -> ListIn<'r> {
+impl ListIn {
+    fn new(
+        diff: Vec<Rc<PathAwareValue>>,
+        lhs: Rc<PathAwareValue>,
+        rhs: Rc<PathAwareValue>,
+    ) -> ListIn {
         ListIn { lhs, rhs, diff }
     }
 }
 
 #[derive(Clone, Debug)]
-pub(crate) enum Compare<'r> {
-    Value(LhsRhsPair<'r>),
-    QueryIn(QueryIn<'r>),
-    ListIn(ListIn<'r>),
-    ValueIn(LhsRhsPair<'r>),
+pub(crate) enum Compare {
+    Value(LhsRhsPair),
+    QueryIn(QueryIn),
+    ListIn(ListIn),
+    ValueIn(LhsRhsPair),
 }
 
 #[derive(Clone, Debug)]
-pub(crate) enum ComparisonResult<'r> {
-    Success(Compare<'r>),
-    Fail(Compare<'r>),
-    NotComparable(NotComparable<'r>),
-    RhsUnresolved(UnResolved<'r>, &'r PathAwareValue),
+pub(crate) enum ComparisonResult {
+    Success(Compare),
+    Fail(Compare),
+    NotComparable(NotComparable),
+    RhsUnresolved(UnResolved, Rc<PathAwareValue>),
 }
 
 #[derive(Clone, Debug)]
-pub(crate) enum ValueEvalResult<'value> {
-    LhsUnresolved(UnResolved<'value>),
-    UnaryResult(UnaryResult<'value>),
-    ComparisonResult(ComparisonResult<'value>),
+pub(crate) enum ValueEvalResult {
+    LhsUnresolved(UnResolved),
+    UnaryResult(UnaryResult),
+    ComparisonResult(ComparisonResult),
 }
 
-impl<'value> ValueEvalResult<'value> {
-    pub(crate) fn success<C>(self, c: C) -> ValueEvalResult<'value>
+impl ValueEvalResult {
+    pub(crate) fn success<C>(self, c: C) -> ValueEvalResult
     where
-        C: FnOnce(ValueEvalResult<'value>) -> ValueEvalResult<'value>,
+        C: FnOnce(ValueEvalResult) -> ValueEvalResult,
     {
         if let ValueEvalResult::ComparisonResult(ComparisonResult::Success(_)) = &self {
             c(self)
@@ -91,9 +93,9 @@ impl<'value> ValueEvalResult<'value> {
         }
     }
 
-    pub(crate) fn fail<C>(self, c: C) -> ValueEvalResult<'value>
+    pub(crate) fn fail<C>(self, c: C) -> ValueEvalResult
     where
-        C: FnOnce(ValueEvalResult<'value>) -> ValueEvalResult<'value>,
+        C: FnOnce(ValueEvalResult) -> ValueEvalResult,
     {
         if let ValueEvalResult::ComparisonResult(ComparisonResult::Success(_)) = &self {
             self
@@ -104,26 +106,23 @@ impl<'value> ValueEvalResult<'value> {
 }
 
 #[derive(Clone, Debug)]
-pub(crate) enum EvalResult<'value> {
+pub(crate) enum EvalResult {
     Skip,
-    Result(Vec<ValueEvalResult<'value>>),
+    Result(Vec<ValueEvalResult>),
 }
 
 #[derive(Clone, Debug)]
-pub(crate) struct NotComparable<'r> {
+pub(crate) struct NotComparable {
     pub(crate) reason: String,
-    pub(crate) pair: LhsRhsPair<'r>,
+    pub(crate) pair: LhsRhsPair,
 }
 
-pub(super) fn resolved<'value, E, R>(
-    qr: &QueryResult<'value>,
-    err: E,
-) -> std::result::Result<&'value PathAwareValue, R>
+pub(super) fn resolved<E, R>(qr: &QueryResult, err: E) -> std::result::Result<Rc<PathAwareValue>, R>
 where
-    E: Fn(UnResolved<'value>) -> R,
+    E: Fn(UnResolved) -> R,
 {
     match qr {
-        QueryResult::Resolved(r) | QueryResult::Literal(r) => Ok(*r),
+        QueryResult::Resolved(r) | QueryResult::Literal(r) => Ok(Rc::clone(r)),
         QueryResult::UnResolved(ur) => Err(err(ur.clone())),
     }
 }
@@ -131,16 +130,13 @@ where
 pub(crate) trait Comparator {
     fn compare<'value>(
         &self,
-        lhs: &[QueryResult<'value>],
-        rhs: &[QueryResult<'value>],
-    ) -> crate::rules::Result<EvalResult<'value>>;
+        lhs: &[QueryResult],
+        rhs: &[QueryResult],
+    ) -> crate::rules::Result<EvalResult>;
 }
 
 pub(crate) trait UnaryComparator {
-    fn compare<'value>(
-        &self,
-        lhs: &[QueryResult<'value>],
-    ) -> crate::rules::Result<EvalResult<'value>>;
+    fn compare<'value>(&self, lhs: &[QueryResult]) -> crate::rules::Result<EvalResult>;
 }
 
 struct CommonOperator {
@@ -150,57 +146,62 @@ struct CommonOperator {
 struct EqOperation {}
 struct InOperation {}
 
-fn selected<'value, U, R>(
-    query_results: &[QueryResult<'value>],
-    mut c: U,
-    mut r: R,
-) -> Vec<&'value PathAwareValue>
+fn selected<U, R>(query_results: &[QueryResult], mut c: U, mut r: R) -> Vec<Rc<PathAwareValue>>
 where
-    U: FnMut(&UnResolved<'value>) -> (),
-    R: FnMut(&mut Vec<&'value PathAwareValue>, &'value PathAwareValue) -> (),
+    U: FnMut(&UnResolved),
+    R: FnMut(&mut Vec<Rc<PathAwareValue>>, Rc<PathAwareValue>),
 {
     let mut aggregated = Vec::with_capacity(query_results.len());
     for each in query_results {
         match each {
-            QueryResult::Literal(l) | QueryResult::Resolved(l) => r(&mut aggregated, *l),
+            QueryResult::Literal(l) => r(&mut aggregated, Rc::clone(l)),
+            QueryResult::Resolved(l) => r(&mut aggregated, Rc::clone(l)),
             QueryResult::UnResolved(ur) => c(ur),
         }
     }
     aggregated
 }
 
-fn flattened<'value, U>(query_results: &[QueryResult<'value>], c: U) -> Vec<&'value PathAwareValue>
+fn flattened<U>(query_results: &[QueryResult], c: U) -> Vec<Rc<PathAwareValue>>
 where
-    U: FnMut(&UnResolved<'value>) -> (),
+    U: FnMut(&UnResolved),
 {
-    selected(query_results, c, |into, p| match p {
+    // TODO: this can probably be improved with less clones..
+    selected(query_results, c, |into, p| match &*p {
         PathAwareValue::List((_, list)) => {
-            into.extend(list.iter().collect::<Vec<&PathAwareValue>>());
+            into.extend(list.iter().cloned().map(Rc::new).collect::<Vec<_>>());
         }
 
-        rest => into.push(rest),
+        rest => into.push(Rc::new(rest.clone())),
     })
 }
 
 impl Comparator for CommonOperator {
     fn compare<'value>(
         &self,
-        lhs: &[QueryResult<'value>],
-        rhs: &[QueryResult<'value>],
-    ) -> crate::rules::Result<EvalResult<'value>> {
+        lhs: &[QueryResult],
+        rhs: &[QueryResult],
+    ) -> crate::rules::Result<EvalResult> {
         let mut results = Vec::with_capacity(lhs.len());
         let lhs_flattened = flattened(lhs, |ur| {
             results.push(ValueEvalResult::LhsUnresolved(ur.clone()))
         });
         let rhs_flattened = flattened(rhs, |ur| {
             results.extend(lhs_flattened.iter().map(|lhs| {
-                ValueEvalResult::ComparisonResult(ComparisonResult::RhsUnresolved(ur.clone(), *lhs))
+                ValueEvalResult::ComparisonResult(ComparisonResult::RhsUnresolved(
+                    ur.clone(),
+                    lhs.clone(),
+                ))
             }))
         });
         let rhs = &rhs_flattened;
         for each_lhs in lhs_flattened {
             for each_rhs in rhs {
-                results.push(match_value(each_lhs, each_rhs, self.comparator));
+                results.push(match_value(
+                    each_lhs.clone(),
+                    each_rhs.clone(),
+                    self.comparator,
+                ));
             }
         }
         Ok(EvalResult::Result(results))
@@ -208,14 +209,14 @@ impl Comparator for CommonOperator {
 }
 
 fn match_value<'value, C>(
-    each_lhs: &'value PathAwareValue,
-    each_rhs: &'value PathAwareValue,
+    each_lhs: Rc<PathAwareValue>,
+    each_rhs: Rc<PathAwareValue>,
     comparator: C,
-) -> ValueEvalResult<'value>
+) -> ValueEvalResult
 where
     C: Fn(&PathAwareValue, &PathAwareValue) -> crate::rules::Result<bool>,
 {
-    match comparator(each_lhs, each_rhs) {
+    match comparator(&each_lhs, &each_rhs) {
         Ok(cmp) => {
             if cmp {
                 success(each_lhs, each_rhs)
@@ -238,20 +239,20 @@ where
     }
 }
 
-fn is_literal<'value>(query_results: &[QueryResult<'value>]) -> Option<&'value PathAwareValue> {
+fn is_literal<'value>(query_results: &[QueryResult]) -> Option<Rc<PathAwareValue>> {
     if query_results.len() == 1 {
-        if let QueryResult::Literal(p) = query_results[0] {
-            return Some(p);
+        if let QueryResult::Literal(p) = &query_results[0] {
+            return Some(Rc::clone(p));
         }
     }
     None
 }
 
 fn string_in<'value>(
-    lhs_value: &'value PathAwareValue,
-    rhs_value: &'value PathAwareValue,
-) -> ValueEvalResult<'value> {
-    match (lhs_value, rhs_value) {
+    lhs_value: Rc<PathAwareValue>,
+    rhs_value: Rc<PathAwareValue>,
+) -> ValueEvalResult {
+    match (&*lhs_value, &*rhs_value) {
         (PathAwareValue::String((_, lhs)), PathAwareValue::String((_, rhs))) => {
             if rhs.contains(lhs) {
                 success(lhs_value, rhs_value)
@@ -264,30 +265,24 @@ fn string_in<'value>(
     }
 }
 
-fn not_comparable<'value>(
-    lhs: &'value PathAwareValue,
-    rhs: &'value PathAwareValue,
-) -> ValueEvalResult<'value> {
+fn not_comparable<'value>(lhs: Rc<PathAwareValue>, rhs: Rc<PathAwareValue>) -> ValueEvalResult {
     ValueEvalResult::ComparisonResult(ComparisonResult::NotComparable(NotComparable {
-        pair: LhsRhsPair { lhs, rhs },
+        pair: LhsRhsPair {
+            lhs: Rc::clone(&lhs),
+            rhs: Rc::clone(&rhs),
+        },
         reason: format!("Type not comparable, {}, {}", lhs, rhs),
     }))
 }
 
-fn success<'value>(
-    lhs: &'value PathAwareValue,
-    rhs: &'value PathAwareValue,
-) -> ValueEvalResult<'value> {
+fn success(lhs: Rc<PathAwareValue>, rhs: Rc<PathAwareValue>) -> ValueEvalResult {
     ValueEvalResult::ComparisonResult(ComparisonResult::Success(Compare::Value(LhsRhsPair {
         lhs,
         rhs,
     })))
 }
 
-fn fail<'value>(
-    lhs: &'value PathAwareValue,
-    rhs: &'value PathAwareValue,
-) -> ValueEvalResult<'value> {
+fn fail(lhs: Rc<PathAwareValue>, rhs: Rc<PathAwareValue>) -> ValueEvalResult {
     ValueEvalResult::ComparisonResult(ComparisonResult::Fail(Compare::Value(LhsRhsPair {
         lhs,
         rhs,
@@ -295,27 +290,34 @@ fn fail<'value>(
 }
 
 fn contained_in<'value>(
-    lhs_value: &'value PathAwareValue,
-    rhs_value: &'value PathAwareValue,
-) -> ValueEvalResult<'value> {
-    match lhs_value {
-        PathAwareValue::List((_, lhsl)) => match rhs_value {
+    lhs_value: Rc<PathAwareValue>,
+    rhs_value: Rc<PathAwareValue>,
+) -> ValueEvalResult {
+    match &*lhs_value {
+        PathAwareValue::List((_, lhsl)) => match &*rhs_value {
             PathAwareValue::List((_, rhsl)) => {
-                if rhsl.len() > 0 && rhsl[0].is_list() {
-                    if rhsl.contains(lhs_value) {
+                if !rhsl.is_empty() && rhsl[0].is_list() {
+                    if rhsl.contains(&*lhs_value) {
                         ValueEvalResult::ComparisonResult(ComparisonResult::Success(
                             Compare::ListIn(ListIn::new(vec![], lhs_value, rhs_value)),
                         ))
                     } else {
                         ValueEvalResult::ComparisonResult(ComparisonResult::Fail(Compare::ListIn(
-                            ListIn::new(vec![lhs_value], lhs_value, rhs_value),
+                            ListIn::new(
+                                vec![Rc::clone(&lhs_value)],
+                                Rc::clone(&lhs_value),
+                                Rc::clone(&rhs_value),
+                            ),
                         )))
                     }
                 } else {
                     let diff = lhsl
                         .iter()
-                        .filter(|each| !rhsl.contains(*each))
+                        .filter(|each| !rhsl.contains(each))
+                        .cloned()
+                        .map(Rc::new)
                         .collect::<Vec<_>>();
+
                     if diff.is_empty() {
                         ValueEvalResult::ComparisonResult(ComparisonResult::Success(
                             Compare::ListIn(ListIn::new(diff, lhs_value, rhs_value)),
@@ -331,28 +333,28 @@ fn contained_in<'value>(
             _ => {
                 ValueEvalResult::ComparisonResult(ComparisonResult::NotComparable(NotComparable {
                     pair: LhsRhsPair {
-                        lhs: lhs_value,
-                        rhs: rhs_value,
+                        lhs: lhs_value.clone(),
+                        rhs: rhs_value.clone(),
                     },
                     reason: format!("Can not compare type {}, {}", lhs_value, rhs_value),
                 }))
             }
         },
 
-        rest => match rhs_value {
+        rest => match &*rhs_value {
             PathAwareValue::List((_, rhsl)) => {
                 if rhsl.contains(rest) {
                     ValueEvalResult::ComparisonResult(ComparisonResult::Success(Compare::ValueIn(
-                        LhsRhsPair::new(rest, rhs_value),
+                        LhsRhsPair::new(Rc::new(rest.clone()), Rc::clone(&rhs_value)),
                     )))
                 } else {
                     ValueEvalResult::ComparisonResult(ComparisonResult::Fail(Compare::ValueIn(
-                        LhsRhsPair::new(rest, rhs_value),
+                        LhsRhsPair::new(Rc::new(rest.clone()), Rc::clone(&rhs_value)),
                     )))
                 }
             }
 
-            rhs_rest => match_value(rest, rhs_rest, compare_eq),
+            rhs_rest => match_value(Rc::new(rest.clone()), Rc::new(rhs_rest.clone()), compare_eq),
         },
     }
 }
@@ -360,21 +362,24 @@ fn contained_in<'value>(
 impl Comparator for InOperation {
     fn compare<'value>(
         &self,
-        lhs: &[QueryResult<'value>],
-        rhs: &[QueryResult<'value>],
-    ) -> crate::rules::Result<EvalResult<'value>> {
+        lhs: &[QueryResult],
+        rhs: &[QueryResult],
+    ) -> crate::rules::Result<EvalResult> {
         let mut results = Vec::with_capacity(lhs.len());
         match (is_literal(lhs), is_literal(rhs)) {
-            (Some(l), Some(r)) => {
-                results.push(string_in(l, r).fail(|_| contained_in(l, r)));
+            (Some(ref l), Some(ref r)) => {
+                results.push(
+                    string_in(Rc::clone(l), Rc::clone(r))
+                        .fail(|_| contained_in(Rc::clone(l), Rc::clone(r))),
+                );
             }
 
-            (Some(l), None) => {
+            (Some(ref l), None) => {
                 let rhs = selected(
                     rhs,
                     |ur| {
                         results.push(ValueEvalResult::ComparisonResult(
-                            ComparisonResult::RhsUnresolved(ur.clone(), l),
+                            ComparisonResult::RhsUnresolved(ur.clone(), Rc::clone(l)),
                         ))
                     },
                     Vec::push,
@@ -382,32 +387,36 @@ impl Comparator for InOperation {
 
                 if rhs.iter().any(|elem| elem.is_list()) {
                     rhs.into_iter()
-                        .for_each(|r| results.push(contained_in(l, r)));
-                } else {
-                    if let PathAwareValue::List((_, list)) = l {
-                        let diff: Vec<&PathAwareValue> =
-                            list.iter().filter(|elem| !rhs.contains(&elem)).collect();
-                        if diff.is_empty() {
-                            results.push(ValueEvalResult::ComparisonResult(
-                                ComparisonResult::Success(Compare::QueryIn(QueryIn {
-                                    diff,
-                                    rhs,
-                                    lhs: vec![l],
-                                })),
-                            ));
-                        } else {
-                            results.push(ValueEvalResult::ComparisonResult(
-                                ComparisonResult::Fail(Compare::QueryIn(QueryIn {
-                                    diff,
-                                    rhs,
-                                    lhs: vec![l],
-                                })),
-                            ));
-                        }
+                        .for_each(|r| results.push(contained_in(Rc::clone(l), r)));
+                } else if let PathAwareValue::List((_, list)) = &**l {
+                    let diff = list
+                        .iter()
+                        .cloned()
+                        .map(Rc::new)
+                        .filter(|elem| !rhs.contains(elem))
+                        .collect::<Vec<_>>();
+
+                    if diff.is_empty() {
+                        results.push(ValueEvalResult::ComparisonResult(
+                            ComparisonResult::Success(Compare::QueryIn(QueryIn {
+                                diff,
+                                rhs,
+                                lhs: vec![Rc::clone(l)],
+                            })),
+                        ));
                     } else {
-                        rhs.iter()
-                            .for_each(|rhs_elem| results.push(contained_in(l, rhs_elem)));
+                        results.push(ValueEvalResult::ComparisonResult(ComparisonResult::Fail(
+                            Compare::QueryIn(QueryIn {
+                                diff,
+                                rhs,
+                                lhs: vec![Rc::clone(l)],
+                            }),
+                        )));
                     }
+                } else {
+                    rhs.iter().for_each(|rhs_elem| {
+                        results.push(contained_in(Rc::clone(l), rhs_elem.clone()))
+                    });
                 }
             }
 
@@ -418,18 +427,18 @@ impl Comparator for InOperation {
                     Vec::push,
                 )
                 .into_iter()
-                .for_each(|l| match r {
-                    PathAwareValue::String(_) => match l {
+                .for_each(|l| match &*r {
+                    PathAwareValue::String(_) => match &*l {
                         PathAwareValue::List((_, lhsl)) => {
                             for eachl in lhsl {
-                                results.push(string_in(eachl, r));
+                                results.push(string_in(Rc::new(eachl.clone()), Rc::clone(&r)));
                             }
                         }
 
-                        rest => results.push(string_in(rest, r)),
+                        rest => results.push(string_in(Rc::new(rest.clone()), Rc::clone(&r))),
                     },
 
-                    rest => results.push(contained_in(l, rest)),
+                    rest => results.push(contained_in(l, Rc::new(rest.clone()))),
                 });
             }
 
@@ -445,7 +454,7 @@ impl Comparator for InOperation {
                         results.extend(lhs_selected.iter().map(|lhs| {
                             ValueEvalResult::ComparisonResult(ComparisonResult::RhsUnresolved(
                                 ur.clone(),
-                                *lhs,
+                                Rc::clone(lhs),
                             ))
                         }))
                     },
@@ -455,14 +464,15 @@ impl Comparator for InOperation {
                 let mut diff = Vec::with_capacity(lhs_selected.len());
                 'each_lhs: for eachl in &lhs_selected {
                     for eachr in &rhs_selected {
-                        match contained_in(*eachl, *eachr) {
+                        match contained_in(Rc::clone(eachl), Rc::clone(eachr)) {
                             ValueEvalResult::ComparisonResult(ComparisonResult::Success(_)) => {
                                 continue 'each_lhs
                             }
                             _ => {}
                         }
                     }
-                    diff.push(*eachl);
+
+                    diff.push(Rc::clone(eachl));
                 }
 
                 results.push(if diff.is_empty() {
@@ -483,13 +493,13 @@ impl Comparator for InOperation {
 impl Comparator for EqOperation {
     fn compare<'value>(
         &self,
-        lhs: &[QueryResult<'value>],
-        rhs: &[QueryResult<'value>],
-    ) -> crate::rules::Result<EvalResult<'value>> {
+        lhs: &[QueryResult],
+        rhs: &[QueryResult],
+    ) -> crate::rules::Result<EvalResult> {
         let mut results = Vec::with_capacity(lhs.len());
         match (is_literal(lhs), is_literal(rhs)) {
-            (Some(l), Some(r)) => {
-                results.push(match_value(l, r, compare_eq));
+            (Some(ref l), Some(ref r)) => {
+                results.push(match_value(Rc::clone(l), Rc::clone(r), compare_eq));
             }
 
             (Some(l), None) => {
@@ -497,34 +507,38 @@ impl Comparator for EqOperation {
                     rhs,
                     |ur| {
                         results.push(ValueEvalResult::ComparisonResult(
-                            ComparisonResult::RhsUnresolved(ur.clone(), l),
+                            ComparisonResult::RhsUnresolved(ur.clone(), Rc::clone(&l)),
                         ))
                     },
                     Vec::push,
                 );
 
-                match l {
+                match &*l {
                     PathAwareValue::List(_) => {
                         for each in rhs {
-                            results.push(match_value(l, each, compare_eq));
+                            results.push(match_value(Rc::clone(&l), each, compare_eq));
                         }
                     }
 
                     single_value => {
                         for eachr in rhs {
-                            match eachr {
+                            match &*eachr {
                                 PathAwareValue::List((_, rhsl)) => {
                                     for each_rhs in rhsl {
                                         results.push(match_value(
-                                            single_value,
-                                            each_rhs,
+                                            Rc::new(single_value.clone()),
+                                            Rc::new(each_rhs.clone()),
                                             compare_eq,
                                         ));
                                     }
                                 }
 
                                 rest_rhs => {
-                                    results.push(match_value(single_value, rest_rhs, compare_eq));
+                                    results.push(match_value(
+                                        Rc::new(single_value.clone()),
+                                        Rc::new(rest_rhs.clone()),
+                                        compare_eq,
+                                    ));
                                 }
                             }
                         }
@@ -538,25 +552,37 @@ impl Comparator for EqOperation {
                     |ur| results.push(ValueEvalResult::LhsUnresolved(ur.clone())),
                     Vec::push,
                 );
-                match r {
+                match &*r {
                     PathAwareValue::List((_, rhsl)) => {
                         for each in lhs_flattened {
                             if each.is_scalar() && rhsl.len() == 1 {
-                                results.push(match_value(each, &rhsl[0], compare_eq))
+                                results.push(match_value(
+                                    each,
+                                    Rc::new(rhsl[0].clone()),
+                                    compare_eq,
+                                ))
                             } else {
-                                results.push(match_value(each, r, compare_eq));
+                                results.push(match_value(each, Rc::clone(&r), compare_eq));
                             }
                         }
                     }
 
                     single_value => {
                         for each in lhs_flattened {
-                            if let PathAwareValue::List((_, lhs_list)) = each {
+                            if let PathAwareValue::List((_, lhs_list)) = &*each {
                                 for each_lhs in lhs_list {
-                                    results.push(match_value(each_lhs, single_value, compare_eq));
+                                    results.push(match_value(
+                                        Rc::new(each_lhs.clone()),
+                                        Rc::new(single_value.clone()),
+                                        compare_eq,
+                                    ));
                                 }
                             } else {
-                                results.push(match_value(each, r, compare_eq));
+                                results.push(match_value(
+                                    each.clone(),
+                                    Rc::clone(&r.clone()),
+                                    compare_eq,
+                                ));
                             }
                         }
                     }
@@ -575,7 +601,7 @@ impl Comparator for EqOperation {
                         results.extend(lhs_selected.iter().map(|lhs| {
                             ValueEvalResult::ComparisonResult(ComparisonResult::RhsUnresolved(
                                 ur.clone(),
-                                *lhs,
+                                Rc::clone(lhs),
                             ))
                         }))
                     },
@@ -586,13 +612,13 @@ impl Comparator for EqOperation {
                     lhs_selected
                         .iter()
                         .filter(|e| !rhs_selected.contains(*e))
-                        .map(|e| *e)
+                        .cloned()
                         .collect::<Vec<_>>()
                 } else {
                     rhs_selected
                         .iter()
                         .filter(|e| !lhs_selected.contains(*e))
-                        .map(|e| *e)
+                        .cloned()
                         .collect::<Vec<_>>()
                 };
 
@@ -614,9 +640,9 @@ impl Comparator for EqOperation {
 impl Comparator for crate::rules::CmpOperator {
     fn compare<'value>(
         &self,
-        lhs: &[QueryResult<'value>],
-        rhs: &[QueryResult<'value>],
-    ) -> crate::rules::Result<EvalResult<'value>> {
+        lhs: &[QueryResult],
+        rhs: &[QueryResult],
+    ) -> crate::rules::Result<EvalResult> {
         if lhs.is_empty() || rhs.is_empty() {
             return Ok(EvalResult::Skip);
         }
@@ -653,9 +679,9 @@ impl Comparator for crate::rules::CmpOperator {
 impl Comparator for (crate::rules::CmpOperator, bool) {
     fn compare<'value>(
         &self,
-        lhs: &[QueryResult<'value>],
-        rhs: &[QueryResult<'value>],
-    ) -> crate::rules::Result<EvalResult<'value>> {
+        lhs: &[QueryResult],
+        rhs: &[QueryResult],
+    ) -> crate::rules::Result<EvalResult> {
         let results = self.0.compare(lhs, rhs)?;
         Ok(match results {
             EvalResult::Skip => EvalResult::Skip,
@@ -671,7 +697,7 @@ impl Comparator for (crate::rules::CmpOperator, bool) {
                                                 Vec::with_capacity(qin.lhs.len());
                                             for each in &qin.lhs {
                                                 if !qin.diff.contains(each) {
-                                                    reverse_diff.push(*each)
+                                                    reverse_diff.push(Rc::clone(each))
                                                 }
                                             }
                                             if reverse_diff.is_empty() {
@@ -698,12 +724,13 @@ impl Comparator for (crate::rules::CmpOperator, bool) {
                                         }
 
                                         Compare::ListIn(lin) => {
-                                            let lhs = match lin.lhs {
+                                            let lhs = match &*lin.lhs {
                                                 PathAwareValue::List((_, v)) => v,
                                                 _ => unreachable!(),
                                             };
                                             let mut reverse_diff = Vec::with_capacity(lhs.len());
                                             for each in lhs {
+                                                let each = Rc::new(each.clone());
                                                 if !lin.diff.contains(&each) {
                                                     reverse_diff.push(each)
                                                 }
@@ -711,13 +738,21 @@ impl Comparator for (crate::rules::CmpOperator, bool) {
                                             if reverse_diff.is_empty() {
                                                 ValueEvalResult::ComparisonResult(
                                                     ComparisonResult::Success(Compare::ListIn(
-                                                        ListIn::new(reverse_diff, lin.lhs, lin.rhs),
+                                                        ListIn::new(
+                                                            reverse_diff,
+                                                            lin.lhs.clone(),
+                                                            lin.rhs,
+                                                        ),
                                                     )),
                                                 )
                                             } else {
                                                 ValueEvalResult::ComparisonResult(
                                                     ComparisonResult::Fail(Compare::ListIn(
-                                                        ListIn::new(reverse_diff, lin.lhs, lin.rhs),
+                                                        ListIn::new(
+                                                            reverse_diff,
+                                                            lin.lhs.clone(),
+                                                            lin.rhs,
+                                                        ),
                                                     )),
                                                 )
                                             }
@@ -740,19 +775,22 @@ impl Comparator for (crate::rules::CmpOperator, bool) {
                                                 )),
                                             )
                                         }
-
                                         Compare::ListIn(lin) => {
-                                            let lhs = match lin.lhs {
+                                            let lhs = match &*lin.lhs {
                                                 PathAwareValue::List((_, v)) => v,
                                                 _ => unreachable!(),
                                             };
                                             let mut reverse_diff = Vec::with_capacity(lhs.len());
                                             for each in lhs {
-                                                reverse_diff.push(each);
+                                                reverse_diff.push(Rc::new(each.clone()));
                                             }
                                             ValueEvalResult::ComparisonResult(
                                                 ComparisonResult::Fail(Compare::ListIn(
-                                                    ListIn::new(reverse_diff, lin.lhs, lin.rhs),
+                                                    ListIn::new(
+                                                        reverse_diff,
+                                                        Rc::clone(&lin.lhs),
+                                                        Rc::clone(&lin.rhs),
+                                                    ),
                                                 )),
                                             )
                                         }

--- a/guard/src/rules/eval/operators_tests.rs
+++ b/guard/src/rules/eval/operators_tests.rs
@@ -386,9 +386,6 @@ fn test_operator_in_list_literal_to_query_ok() -> crate::rules::Result<()> {
             }
 
             ValueEvalResult::ComparisonResult(ComparisonResult::NotComparable(nc)) => {
-                // TODO: verify this is okay...i dont see why it wouldnt. It only fails now cause
-                // of clones we call on the underlying PathAwareValue...but theyre not mutable so
-                // while it may not be the most efficient, it shouldnt be dangerous / buggy?
                 assert_eq!(*nc.pair.lhs, list_literal_value);
                 assert_eq!(&*nc.pair.rhs, &scalar_query_value);
             }

--- a/guard/src/rules/eval_context.rs
+++ b/guard/src/rules/eval_context.rs
@@ -1210,7 +1210,7 @@ pub(crate) fn validate_number_of_params(name: &str, num_args: usize) -> Result<(
     Ok(())
 }
 
-// TODO: look into the possibility of abstracting functions into structs that all implement a trait
+// TODO: look into the possibility of abstracting functions into structs that all implement
 pub(crate) fn try_handle_function_call(
     fn_name: &str,
     args: &[Vec<QueryResult>],
@@ -1672,9 +1672,9 @@ pub(crate) fn cmp_str(cmp: (CmpOperator, bool)) -> &'static str {
         match cmp {
             CmpOperator::Exists => {
                 if not {
-                    "NOT EISTS"
+                    "NOT EXISTS"
                 } else {
-                    "EISTS"
+                    "EXISTS"
                 }
             }
             CmpOperator::Empty => {

--- a/guard/src/rules/eval_context.rs
+++ b/guard/src/rules/eval_context.rs
@@ -1149,7 +1149,7 @@ impl<'value, 'loc: 'value> EvalContext<'value, 'loc> for RootScope<'value, 'loc>
             parameters, name, ..
         }) = self.scope.function_expressions.get(variable_name)
         {
-            validate_function_call(name, parameters.len())?;
+            validate_number_of_params(name, parameters.len())?;
             let args = parameters.iter().try_fold(
                 vec![],
                 |mut args, param| -> Result<Vec<Vec<QueryResult>>> {
@@ -1162,7 +1162,7 @@ impl<'value, 'loc: 'value> EvalContext<'value, 'loc> for RootScope<'value, 'loc>
                             args.push(resolved_query);
                         }
                         // TODO: when we add inline function call support
-                        _ => todo!(),
+                        _ => unimplemented!(),
                     }
 
                     Ok(args)
@@ -1224,7 +1224,7 @@ impl<'value, 'loc: 'value> EvalContext<'value, 'loc> for RootScope<'value, 'loc>
     }
 }
 
-pub(crate) fn validate_function_call(name: &str, num_args: usize) -> Result<()> {
+pub(crate) fn validate_number_of_params(name: &str, num_args: usize) -> Result<()> {
     match name {
         "join" => {
             if num_args != 2 {
@@ -1234,7 +1234,6 @@ pub(crate) fn validate_function_call(name: &str, num_args: usize) -> Result<()> 
             }
         }
         "substring" | "regex_replace" => {
-            println!("FJDKSJFLDSJFLKDJSKLFJKLDSJKLFJSDKLJFKLDSJLKFJDSKLJ");
             if num_args != 3 {
                 return Err(Error::ParseError(format!(
                     "{name} function requires 3 arguments to be passed, but received {num_args}"
@@ -1442,7 +1441,7 @@ impl<'value, 'loc: 'value, 'eval> EvalContext<'value, 'loc> for BlockScope<'valu
             parameters, name, ..
         }) = self.scope.function_expressions.get(variable_name)
         {
-            validate_function_call(name, parameters.len())?;
+            validate_number_of_params(name, parameters.len())?;
             let args = parameters.iter().try_fold(
                 vec![],
                 |mut args, param| -> Result<Vec<Vec<QueryResult>>> {
@@ -1455,7 +1454,7 @@ impl<'value, 'loc: 'value, 'eval> EvalContext<'value, 'loc> for BlockScope<'valu
                             args.push(resolved_query);
                         }
                         // TODO: when we add inline function call support
-                        _ => todo!(),
+                        _ => unimplemented!(),
                     }
 
                     Ok(args)

--- a/guard/src/rules/eval_context.rs
+++ b/guard/src/rules/eval_context.rs
@@ -1193,7 +1193,7 @@ pub(crate) fn validate_number_of_params(name: &str, num_args: usize) -> Result<(
     let expected_num_args = match name {
         "join" => 2,
         "substring" | "regex_replace" => 3,
-        "count" | "json_parse" | "to_upper" | "to_lower" | "url_decode" => 4,
+        "count" | "json_parse" | "to_upper" | "to_lower" | "url_decode" => 1,
         _ => {
             return Err(Error::ParseError(format!(
                 "no such function named {name} exists"

--- a/guard/src/rules/eval_context.rs
+++ b/guard/src/rules/eval_context.rs
@@ -1190,33 +1190,21 @@ impl<'value, 'loc: 'value> EvalContext<'value, 'loc> for RootScope<'value, 'loc>
 }
 
 pub(crate) fn validate_number_of_params(name: &str, num_args: usize) -> Result<()> {
-    match name {
-        "join" => {
-            if num_args != 2 {
-                return Err(Error::ParseError(format!(
-                    "join function requires 2 arguments be passed, but received {num_args}"
-                )));
-            }
-        }
-        "substring" | "regex_replace" => {
-            if num_args != 3 {
-                return Err(Error::ParseError(format!(
-                    "{name} function requires 3 arguments to be passed, but received {num_args}"
-                )));
-            }
-        }
-        "count" | "json_parse" | "to_upper" | "to_lower" | "url_decode" => {
-            if num_args != 1 {
-                return Err(Error::ParseError(format!(
-                    "{name} function requires 1 argument to be passed, but received {num_args}"
-                )));
-            }
-        }
+    let expected_num_args = match name {
+        "join" => 2,
+        "substring" | "regex_replace" => 3,
+        "count" | "json_parse" | "to_upper" | "to_lower" | "url_decode" => 4,
         _ => {
             return Err(Error::ParseError(format!(
                 "no such function named {name} exists"
             )))
         }
+    };
+
+    if expected_num_args != num_args {
+        return Err(Error::ParseError(format!(
+            "{name} function requires {expected_num_args} arguments be passed, but received {num_args}"
+        )));
     }
 
     Ok(())

--- a/guard/src/rules/eval_context.rs
+++ b/guard/src/rules/eval_context.rs
@@ -1,9 +1,13 @@
 use crate::rules::errors::Error;
 use crate::rules::exprs::{
-    AccessQuery, Block, Conjunctions, GuardClause, LetExpr, LetValue, ParameterizedRule, QueryPart,
-    Rule, RulesFile, SliceDisplay,
+    AccessQuery, Block, Conjunctions, FunctionExpr, GuardClause, LetExpr, LetValue,
+    ParameterizedRule, QueryPart, Rule, RulesFile, SliceDisplay,
 };
-use crate::rules::path_value::{MapValue, PathAwareValue};
+use crate::rules::functions::collections::count;
+use crate::rules::functions::strings::{
+    join, json_parse, regex_replace, substring, to_lower, to_upper, url_decode,
+};
+use crate::rules::path_value::{MapValue, Path, PathAwareValue};
 use crate::rules::values::CmpOperator;
 use crate::rules::Result;
 use crate::rules::Status::SKIP;
@@ -16,13 +20,14 @@ use inflector::cases::*;
 use lazy_static::lazy_static;
 use serde::Serialize;
 use std::collections::{HashMap, HashSet};
+use std::rc::Rc;
 
 pub(crate) struct Scope<'value, 'loc: 'value> {
-    root: &'value PathAwareValue,
-    //resolved_variables: std::cell::RefCell<HashMap<&'value str, Vec<QueryResult<'value>>>>,
-    resolved_variables: HashMap<&'value str, Vec<QueryResult<'value>>>,
-    literals: HashMap<&'value str, &'value PathAwareValue>,
+    root: Rc<PathAwareValue>,
+    resolved_variables: HashMap<&'value str, Vec<QueryResult>>,
+    literals: HashMap<&'value str, Rc<PathAwareValue>>,
     variable_queries: HashMap<&'value str, &'value AccessQuery<'loc>>,
+    function_expressions: HashMap<&'value str, &'value FunctionExpr<'loc>>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Default)]
@@ -41,12 +46,13 @@ pub(crate) struct RootScope<'value, 'loc: 'value> {
 }
 
 impl<'value, 'loc: 'value> RootScope<'value, 'loc> {
-    pub fn reset_root(self, new_root: &'value PathAwareValue) -> Result<RootScope<'value, 'loc>> {
+    pub fn reset_root(self, new_root: Rc<PathAwareValue>) -> Result<RootScope<'value, 'loc>> {
         root_scope_with(
             self.scope.literals,
             self.scope.variable_queries,
             self.rules,
             self.parameterized_rules,
+            self.scope.function_expressions,
             new_root,
         )
     }
@@ -62,81 +68,59 @@ impl<'value, 'loc: 'value> RootScope<'value, 'loc> {
     }
 }
 
-pub(crate) fn reset_with<'value, 'loc: 'value>(
-    mut root_scope: RootScope<'value, 'loc>,
-    new_value: &'value PathAwareValue,
-) -> RootScope<'value, 'loc> {
-    let variables = std::mem::replace(&mut root_scope.scope.variable_queries, HashMap::new());
-    let literals = std::mem::replace(&mut root_scope.scope.literals, HashMap::new());
-    let rules = std::mem::replace(&mut root_scope.rules, HashMap::new());
-    let parameterized_rules =
-        std::mem::replace(&mut root_scope.parameterized_rules, HashMap::new());
-    let scope = Scope {
-        root: new_value,
-        //resolved_variables: std::cell::RefCell::new(HashMap::new()),
-        resolved_variables: HashMap::new(),
-        literals: literals,
-        variable_queries: variables,
-    };
-    RootScope {
-        scope,
-        rules,
-        parameterized_rules,
-        rules_status: HashMap::new(),
-        recorder: RecordTracker {
-            final_event: None,
-            events: vec![],
-        },
-    }
-}
-
 pub(crate) struct BlockScope<'value, 'loc: 'value, 'eval> {
     scope: Scope<'value, 'loc>,
     parent: &'eval mut dyn EvalContext<'value, 'loc>,
 }
 
 pub(crate) struct ValueScope<'value, 'eval, 'loc: 'value> {
-    pub(crate) root: &'value PathAwareValue,
+    pub(crate) root: Rc<PathAwareValue>,
     pub(crate) parent: &'eval mut dyn EvalContext<'value, 'loc>,
 }
 
+type ExtractVariableResult<'value, 'loc> = Result<(
+    HashMap<&'value str, Rc<PathAwareValue>>,
+    HashMap<&'value str, &'value AccessQuery<'loc>>,
+    HashMap<&'value str, &'value FunctionExpr<'loc>>,
+)>;
+
 fn extract_variables<'value, 'loc: 'value>(
     expressions: &'value Vec<LetExpr<'loc>>,
-) -> Result<(
-    HashMap<&'value str, &'value PathAwareValue>,
-    HashMap<&'value str, &'value AccessQuery<'loc>>,
-)> {
+) -> ExtractVariableResult<'value, 'loc> {
     let mut literals = HashMap::with_capacity(expressions.len());
     let mut queries = HashMap::with_capacity(expressions.len());
+    let mut functions = HashMap::with_capacity(expressions.len());
     for each in expressions {
         match &each.value {
             LetValue::Value(v) => {
-                literals.insert(each.var.as_str(), v);
+                literals.insert(each.var.as_str(), Rc::new(v.clone()));
             }
 
             LetValue::AccessClause(query) => {
                 queries.insert(each.var.as_str(), query);
             }
-
-            LetValue::FunctionCall(_) => todo!(),
+            LetValue::FunctionCall(function) => {
+                functions.insert(each.var.as_str(), function);
+            }
         }
     }
-    Ok((literals, queries))
+
+    Ok((literals, queries, functions))
 }
 
-fn retrieve_index<'value>(
-    parent: &'value PathAwareValue,
+fn retrieve_index(
+    parent: Rc<PathAwareValue>,
     index: i32,
-    elements: &'value Vec<PathAwareValue>,
+    elements: &Vec<PathAwareValue>,
     query: &[QueryPart<'_>],
-) -> QueryResult<'value> {
+) -> QueryResult {
     let check = if index >= 0 { index } else { -index } as usize;
     if check < elements.len() {
-        QueryResult::Resolved(&elements[check])
+        QueryResult::Resolved(Rc::new(elements[check].clone()))
     } else {
         QueryResult::UnResolved(
             UnResolved {
-                traversed_to: parent,
+                traversed_to: Rc::clone(&parent),
                 remaining_query: format!("{}", SliceDisplay(query)),
                 reason: Some(
                     format!("Array Index out of bounds for path = {} on index = {} inside Array = {:?}, remaining query = {}",
@@ -148,20 +132,20 @@ fn retrieve_index<'value>(
 }
 
 fn accumulate<'value, 'loc: 'value>(
-    parent: &'value PathAwareValue,
+    parent: Rc<PathAwareValue>,
     query_index: usize,
     query: &'value [QueryPart<'loc>],
-    elements: &'value Vec<PathAwareValue>,
+    elements: &[PathAwareValue],
     resolver: &mut dyn EvalContext<'value, 'loc>,
     converter: Option<&dyn Fn(&str) -> String>,
-) -> Result<Vec<QueryResult<'value>>> {
+) -> Result<Vec<QueryResult>> {
     //
     // We are here when we are doing [*] for a list. It is an error if there are no
     // elements
     //
     if elements.is_empty() {
         return to_unresolved_result(
-            parent,
+            Rc::clone(&parent),
             format!(
                 "No more entries for value at path = {} on type = {} ",
                 parent.self_path(),
@@ -176,7 +160,7 @@ fn accumulate<'value, 'loc: 'value>(
         accumulated.extend(query_retrieval_with_converter(
             query_index + 1,
             query,
-            each,
+            Rc::new(each.clone()),
             resolver,
             converter,
         )?);
@@ -185,23 +169,23 @@ fn accumulate<'value, 'loc: 'value>(
 }
 
 fn accumulate_map<'value, 'loc: 'value, F>(
-    parent: &'value PathAwareValue,
-    map: &'value MapValue,
+    parent: Rc<PathAwareValue>,
+    map: &MapValue,
     query_index: usize,
     query: &'value [QueryPart<'loc>],
     resolver: &mut dyn EvalContext<'value, 'loc>,
     converter: Option<&dyn Fn(&str) -> String>,
     func: F,
-) -> Result<Vec<QueryResult<'value>>>
+) -> Result<Vec<QueryResult>>
 where
     F: Fn(
         usize,
         &'value [QueryPart<'loc>],
-        &'value PathAwareValue,
-        &'value PathAwareValue,
+        Rc<PathAwareValue>,
+        Rc<PathAwareValue>,
         &mut dyn EvalContext<'value, 'loc>,
         Option<&dyn Fn(&str) -> String>,
-    ) -> Result<Vec<QueryResult<'value>>>,
+    ) -> Result<Vec<QueryResult>>,
 {
     //
     // We are here when we are doing * all values for map. It is an error if there are no
@@ -209,7 +193,7 @@ where
     //
     if map.is_empty() {
         return to_unresolved_result(
-            parent,
+            Rc::clone(&parent),
             format!(
                 "No more entries for value at path = {} on type = {} ",
                 parent.self_path(),
@@ -220,50 +204,52 @@ where
     }
 
     let mut resolved = Vec::with_capacity(map.values.len());
+
     for (key, each) in map.keys.iter().zip(map.values.values()) {
         let mut val_resolver = ValueScope {
-            root: each,
+            root: Rc::new(each.clone()),
             parent: resolver,
         };
         resolved.extend(func(
             query_index + 1,
             query,
-            key,
-            each,
+            Rc::new(key.clone()),
+            Rc::new(each.clone()),
             &mut val_resolver,
             converter,
         )?)
     }
+
     Ok(resolved)
 }
 
-fn to_unresolved_value<'value>(
-    current: &'value PathAwareValue,
+fn to_unresolved_value(
+    current: Rc<PathAwareValue>,
     reason: String,
     query: &[QueryPart<'_>],
-) -> QueryResult<'value> {
+) -> QueryResult {
     QueryResult::UnResolved(UnResolved {
-        traversed_to: current,
+        traversed_to: Rc::clone(&current),
         reason: Some(reason),
         remaining_query: format!("{}", SliceDisplay(query)),
     })
 }
 
-fn to_unresolved_result<'value>(
-    current: &'value PathAwareValue,
+fn to_unresolved_result(
+    current: Rc<PathAwareValue>,
     reason: String,
-    query: &[QueryPart<'_>],
-) -> Result<Vec<QueryResult<'value>>> {
+    query: &[QueryPart],
+) -> Result<Vec<QueryResult>> {
     Ok(vec![to_unresolved_value(current, reason, query)])
 }
 
-fn map_resolved<'value, F>(
-    _current: &'value PathAwareValue,
-    query_result: QueryResult<'value>,
+fn map_resolved<F>(
+    _current: &PathAwareValue,
+    query_result: QueryResult,
     func: F,
-) -> Result<Vec<QueryResult<'value>>>
+) -> Result<Vec<QueryResult>>
 where
-    F: FnOnce(&'value PathAwareValue) -> Result<Vec<QueryResult<'value>>>,
+    F: FnOnce(Rc<PathAwareValue>) -> Result<Vec<QueryResult>>,
 {
     match query_result {
         QueryResult::Resolved(res) => func(res),
@@ -277,11 +263,11 @@ fn check_and_delegate<'value, 'loc: 'value>(
 ) -> impl Fn(
     usize,
     &'value [QueryPart<'loc>],
-    &'value PathAwareValue,
-    &'value PathAwareValue,
+    Rc<PathAwareValue>,
+    Rc<PathAwareValue>,
     &mut dyn EvalContext<'value, 'loc>,
     Option<&dyn Fn(&str) -> String>,
-) -> Result<Vec<QueryResult<'value>>> {
+) -> Result<Vec<QueryResult>> {
     move |index, query, key, value, eval_context, converter| {
         let context = format!("Filter/Map#{}", conjunctions.len());
         eval_context.start_record(&context)?;
@@ -294,13 +280,18 @@ fn check_and_delegate<'value, 'loc: 'value>(
                 eval_context.end_record(&context, RecordType::Filter(status))?;
                 if let Some(key_name) = name {
                     if status == Status::PASS {
-                        eval_context.add_variable_capture_key(key_name.as_ref(), key)?;
+                        eval_context
+                            .add_variable_capture_key(key_name.as_ref(), Rc::clone(&key))?;
                     }
                 }
                 match status {
-                    Status::PASS => {
-                        query_retrieval_with_converter(index, query, value, eval_context, converter)
-                    }
+                    Status::PASS => query_retrieval_with_converter(
+                        index,
+                        query,
+                        Rc::clone(&value),
+                        eval_context,
+                        converter,
+                    ),
                     _ => Ok(vec![]),
                 }
             }
@@ -328,32 +319,32 @@ lazy_static! {
 fn query_retrieval<'value, 'loc: 'value>(
     query_index: usize,
     query: &'value [QueryPart<'loc>],
-    current: &'value PathAwareValue,
+    current: Rc<PathAwareValue>,
     resolver: &mut dyn EvalContext<'value, 'loc>,
-) -> Result<Vec<QueryResult<'value>>> {
+) -> Result<Vec<QueryResult>> {
     query_retrieval_with_converter(query_index, query, current, resolver, None)
 }
 
 fn query_retrieval_with_converter<'value, 'loc: 'value>(
     query_index: usize,
     query: &'value [QueryPart<'loc>],
-    current: &'value PathAwareValue,
+    current: Rc<PathAwareValue>,
     resolver: &mut dyn EvalContext<'value, 'loc>,
     converter: Option<&dyn Fn(&str) -> String>,
-) -> Result<Vec<QueryResult<'value>>> {
+) -> Result<Vec<QueryResult>> {
     if query_index >= query.len() {
-        return Ok(vec![QueryResult::Resolved(current)]);
+        return Ok(vec![QueryResult::Resolved(Rc::clone(&current))]);
     }
 
     if query_index == 0 && query[query_index].is_variable() {
         let retrieved = resolver.resolve_variable(query[query_index].variable().unwrap())?;
         let mut resolved = Vec::with_capacity(retrieved.len());
         for each in retrieved {
-            match each {
+            match &each {
                 QueryResult::UnResolved(ur) => {
-                    resolved.push(QueryResult::UnResolved(ur));
+                    resolved.push(QueryResult::UnResolved(ur.clone()));
                 }
-                QueryResult::Literal(value) | QueryResult::Resolved(value) => {
+                QueryResult::Resolved(value) => {
                     let index = if query_index + 1 < query.len() {
                         match &query[query_index + 1] {
                             QueryPart::AllIndices(_name) => query_index + 2,
@@ -365,11 +356,41 @@ fn query_retrieval_with_converter<'value, 'loc: 'value>(
 
                     if index < query.len() {
                         let mut scope = ValueScope {
-                            root: value,
+                            root: Rc::clone(value),
                             parent: resolver,
                         };
                         resolved.extend(query_retrieval_with_converter(
-                            index, query, value, &mut scope, converter,
+                            index,
+                            query,
+                            Rc::clone(value),
+                            &mut scope,
+                            converter,
+                        )?);
+                    } else {
+                        resolved.push(each.clone())
+                    }
+                }
+                QueryResult::Literal(value) => {
+                    let index = if query_index + 1 < query.len() {
+                        match &query[query_index + 1] {
+                            QueryPart::AllIndices(_name) => query_index + 2,
+                            _ => query_index + 1,
+                        }
+                    } else {
+                        query_index + 1
+                    };
+
+                    if index < query.len() {
+                        let mut scope = ValueScope {
+                            root: Rc::clone(value),
+                            parent: resolver,
+                        };
+                        resolved.extend(query_retrieval_with_converter(
+                            index,
+                            query,
+                            Rc::clone(value),
+                            &mut scope,
+                            converter,
                         )?);
                     } else {
                         resolved.push(each)
@@ -386,9 +407,11 @@ fn query_retrieval_with_converter<'value, 'loc: 'value>(
         }
 
         QueryPart::Key(key) => match key.parse::<i32>() {
-            Ok(idx) => match current {
-                PathAwareValue::List((_, list)) => {
-                    map_resolved(current, retrieve_index(current, idx, list, query), |val| {
+            Ok(idx) => match &*current {
+                PathAwareValue::List((_, list)) => map_resolved(
+                    &current,
+                    retrieve_index(Rc::clone(&current), idx, list, query),
+                    |val| {
                         query_retrieval_with_converter(
                             query_index + 1,
                             query,
@@ -396,22 +419,22 @@ fn query_retrieval_with_converter<'value, 'loc: 'value>(
                             resolver,
                             converter,
                         )
-                    })
-                }
+                    },
+                ),
 
                 _ => to_unresolved_result(
-                    current,
+                    Rc::clone(&current),
                     format!(
                         "Attempting to retrieve from index {} but type is not an array at path {}",
                         idx,
-                        current.self_path()
+                        (*current).self_path()
                     ),
                     query,
                 ),
             },
 
             Err(_) => {
-                if let PathAwareValue::Map((path, map)) = current {
+                if let PathAwareValue::Map((path, map)) = &*current {
                     if query[query_index].is_variable() {
                         let var = query[query_index].variable().unwrap();
                         let keys = resolver.resolve_variable(var)?;
@@ -446,7 +469,7 @@ fn query_retrieval_with_converter<'value, 'loc: 'value>(
                                 QueryResult::UnResolved(ur) => {
                                     acc.extend(
                                             to_unresolved_result(
-                                                current,
+                                                Rc::clone(&current),
                                                 format!("Keys returned for variable {} could not completely resolve. Path traversed until {}{}",
                                                         var, ur.traversed_to.self_path(), ur.reason.map_or("".to_string(), |msg| msg)
                                                 ),
@@ -454,36 +477,35 @@ fn query_retrieval_with_converter<'value, 'loc: 'value>(
                                             )?
                                         );
                                 }
-
-                                QueryResult::Literal(key) | QueryResult::Resolved(key) => {
-                                    if let PathAwareValue::String((_, k)) = key {
+                                QueryResult::Resolved(key) | QueryResult::Literal(key) => {
+                                    if let PathAwareValue::String((_, k)) = &*key {
                                         if let Some(next) = map.values.get(k) {
                                             acc.extend(query_retrieval_with_converter(
                                                 query_index + 1,
                                                 query,
-                                                next,
+                                                Rc::new(next.clone()),
                                                 resolver,
                                                 converter,
                                             )?);
                                         } else {
                                             acc.extend(
                                                     to_unresolved_result(
-                                                        current,
+                                                Rc::clone(&current),
                                                         format!("Could not locate key = {} inside struct at path = {}", k, path),
                                                         &query[query_index..]
                                                     )?
                                                 );
                                         }
-                                    } else if let PathAwareValue::List((_, inner)) = key {
+                                    } else if let PathAwareValue::List((_, inner)) = &*key {
                                         for each_key in inner {
-                                            match each_key {
+                                            match &each_key {
                                                     PathAwareValue::String((path, key_to_match)) => {
                                                         if let Some(next) = map.values.get(key_to_match) {
-                                                            acc.extend(query_retrieval_with_converter(query_index + 1, query, next, resolver, converter)?);
+                                                            acc.extend(query_retrieval_with_converter(query_index + 1, query, Rc::new(next.clone()), resolver, converter)?);
                                                         } else {
                                                             acc.extend(
                                                                 to_unresolved_result(
-                                                                    current,
+                                                                Rc::clone(&current),
                                                                     format!("Could not locate key = {} inside struct at path = {}", key_to_match, path),
                                                                     &query[query_index..]
                                                                 )?
@@ -491,7 +513,7 @@ fn query_retrieval_with_converter<'value, 'loc: 'value>(
                                                         }
                                                     },
 
-                                                    rest => {
+                                                    _rest => {
                                                         return Err(Error
                                                             ::NotComparable(
                                                                 format!("Variable projections inside Query {}, is returning a non-string value for key {}, {:?}",
@@ -525,7 +547,7 @@ fn query_retrieval_with_converter<'value, 'loc: 'value>(
                                 return query_retrieval_with_converter(
                                     query_index + 1,
                                     query,
-                                    val,
+                                    Rc::new(val.clone()),
                                     resolver,
                                     converter,
                                 )
@@ -538,7 +560,7 @@ fn query_retrieval_with_converter<'value, 'loc: 'value>(
                                         return query_retrieval_with_converter(
                                             query_index + 1,
                                             query,
-                                            val,
+                                            Rc::new(val.clone()),
                                             resolver,
                                             converter,
                                         );
@@ -553,7 +575,7 @@ fn query_retrieval_with_converter<'value, 'loc: 'value>(
                                             return query_retrieval_with_converter(
                                                 query_index + 1,
                                                 query,
-                                                val,
+                                                Rc::new(val.clone()),
                                                 resolver,
                                                 Some(each_converter),
                                             );
@@ -564,14 +586,14 @@ fn query_retrieval_with_converter<'value, 'loc: 'value>(
                         }
 
                         to_unresolved_result(
-                            current,
+                            Rc::clone(&current),
                             format!("Could not find key {} inside struct at path {}", key, path),
                             &query[query_index..],
                         )
                     }
                 } else {
                     to_unresolved_result(
-                            current,
+                            Rc::clone(&current),
                             format!("Attempting to retrieve from key {} but type is not an struct type at path {}, Type = {}, Value = {:?}",
                                     key, current.self_path(), current.type_info(), current),
                             &query[query_index..])
@@ -579,17 +601,17 @@ fn query_retrieval_with_converter<'value, 'loc: 'value>(
             }
         },
 
-        QueryPart::Index(index) => match current {
+        QueryPart::Index(index) => match &*current {
             PathAwareValue::List((_, list)) => map_resolved(
-                current,
-                retrieve_index(current, *index, list, query),
+                &current,
+                retrieve_index(Rc::clone(&current), *index, list, query),
                 |val| {
                     query_retrieval_with_converter(query_index + 1, query, val, resolver, converter)
                 },
             ),
 
             _ => to_unresolved_result(
-                current,
+                Rc::clone(&current),
                 format!(
                     "Attempting to retrieve from index {} but type is not an array at path {}",
                     index,
@@ -600,33 +622,42 @@ fn query_retrieval_with_converter<'value, 'loc: 'value>(
         },
 
         QueryPart::AllIndices(name) => {
-            match current {
-                PathAwareValue::List((_path, elements)) => {
-                    accumulate(current, query_index, query, elements, resolver, converter)
-                }
+            match &*current {
+                PathAwareValue::List((_, elements)) => accumulate(
+                    Rc::clone(&current),
+                    query_index,
+                    query,
+                    elements,
+                    resolver,
+                    converter,
+                ),
 
                 PathAwareValue::Map((_, map)) => {
                     if name.is_none() {
                         query_retrieval_with_converter(
                             query_index + 1,
                             query,
-                            current,
+                            Rc::clone(&current),
                             resolver,
                             converter,
                         )
                     } else {
                         let name = name.as_ref().unwrap().as_str();
                         accumulate_map(
-                            current,
+                            Rc::clone(&current),
                             map,
                             query_index,
                             query,
                             resolver,
                             converter,
                             |index, query, key, value, context, converter| {
-                                context.add_variable_capture_key(name, key)?;
+                                context.add_variable_capture_key(name, Rc::clone(&key))?;
                                 query_retrieval_with_converter(
-                                    index, query, value, context, converter,
+                                    index,
+                                    query,
+                                    Rc::clone(&value),
+                                    context,
+                                    converter,
                                 )
                             },
                         )
@@ -641,7 +672,7 @@ fn query_retrieval_with_converter<'value, 'loc: 'value>(
                 rest => query_retrieval_with_converter(
                     query_index + 1,
                     query,
-                    rest,
+                    Rc::new(rest.clone()),
                     resolver,
                     converter,
                 ),
@@ -649,13 +680,18 @@ fn query_retrieval_with_converter<'value, 'loc: 'value>(
         }
 
         QueryPart::AllValues(name) => {
-            match current {
+            match &*current {
                 //
                 // Supporting old format
                 //
-                PathAwareValue::List((_path, elements)) => {
-                    accumulate(current, query_index, query, elements, resolver, converter)
-                }
+                PathAwareValue::List((_path, elements)) => accumulate(
+                    Rc::clone(&current),
+                    query_index,
+                    query,
+                    elements,
+                    resolver,
+                    converter,
+                ),
 
                 PathAwareValue::Map((_path, map)) => {
                     let (report, name) = match name {
@@ -663,7 +699,7 @@ fn query_retrieval_with_converter<'value, 'loc: 'value>(
                         None => (false, ""),
                     };
                     accumulate_map(
-                        current,
+                        Rc::clone(&current),
                         map,
                         query_index,
                         query,
@@ -671,9 +707,15 @@ fn query_retrieval_with_converter<'value, 'loc: 'value>(
                         converter,
                         |index, query, key, value, context, converter| {
                             if report {
-                                context.add_variable_capture_key(name, key)?;
+                                context.add_variable_capture_key(name, Rc::clone(&key))?;
                             }
-                            query_retrieval_with_converter(index, query, value, context, converter)
+                            query_retrieval_with_converter(
+                                index,
+                                query,
+                                Rc::clone(&value),
+                                context,
+                                converter,
+                            )
                         },
                     )
                 }
@@ -686,153 +728,134 @@ fn query_retrieval_with_converter<'value, 'loc: 'value>(
                 rest => query_retrieval_with_converter(
                     query_index + 1,
                     query,
-                    rest,
+                    Rc::new(rest.clone()),
                     resolver,
                     converter,
                 ),
             }
         }
 
-        QueryPart::Filter(name, conjunctions) => {
-            match current {
-                PathAwareValue::Map((_path, map)) => {
-                    match &query[query_index - 1] {
-                        QueryPart::AllValues(_name) | QueryPart::AllIndices(_name) => {
-                            check_and_delegate(conjunctions, &None)(
-                                query_index + 1,
-                                query,
-                                current,
-                                current,
-                                resolver,
-                                converter,
-                            )
-                        }
+        QueryPart::Filter(name, conjunctions) => match &*current {
+            PathAwareValue::Map((_path, map)) => match &query[query_index - 1] {
+                QueryPart::AllValues(_name) | QueryPart::AllIndices(_name) => {
+                    check_and_delegate(conjunctions, &None)(
+                        query_index + 1,
+                        query,
+                        Rc::clone(&current),
+                        Rc::clone(&current),
+                        resolver,
+                        converter,
+                    )
+                }
 
-                        QueryPart::Key(_) => {
-                            //
-                            //                            Ideal solution, see https://github.com/rust-lang/rust/issues/41078
-                            //
-                            //                            accumulate_map(
-                            //                                map, query_index, query, resolver,
-                            //                                |index, query:&'value [QueryPart<'_>], value:&'value PathAwareValue, context: &dyn EvalContext<'value>| {
-                            //                                    match super::eval::eval_conjunction_clauses(
-                            //                                        conjunctions, resolver, super::eval::eval_guard_clause)? {
-                            //                                        Status::PASS => query_retrieval_with_converter(index+1, query, current, resolver, converter),
-                            //                                        _ => Ok(vec![])
-                            //                                    }
-                            //                                })
-                            if !map.is_empty() {
-                                accumulate_map(
-                                    current,
-                                    map,
-                                    query_index,
-                                    query,
-                                    resolver,
-                                    converter,
-                                    check_and_delegate(conjunctions, name),
-                                )
-                            } else {
-                                Ok(vec![])
-                            }
-                        }
-
-                        _ => unreachable!(),
+                QueryPart::Key(_) => {
+                    if !map.is_empty() {
+                        accumulate_map(
+                            Rc::clone(&current),
+                            map,
+                            query_index,
+                            query,
+                            resolver,
+                            converter,
+                            check_and_delegate(conjunctions, name),
+                        )
+                    } else {
+                        Ok(vec![])
                     }
                 }
 
-                PathAwareValue::List((_path, list)) => {
-                    let mut selected = Vec::with_capacity(list.len());
-                    for each in list {
-                        let context = format!("Filter/List#{}", conjunctions.len());
-                        resolver.start_record(&context)?;
-                        let mut val_resolver = ValueScope {
-                            root: each,
-                            parent: resolver,
-                        };
-                        let result = match super::eval::eval_conjunction_clauses(
-                            conjunctions,
-                            &mut val_resolver,
-                            super::eval::eval_guard_clause,
-                        ) {
-                            Ok(status) => {
-                                resolver.end_record(&context, RecordType::Filter(status))?;
-                                match status {
-                                    Status::PASS => query_retrieval_with_converter(
-                                        query_index + 1,
-                                        query,
-                                        each,
-                                        resolver,
-                                        converter,
-                                    )?,
-                                    _ => vec![],
-                                }
-                            }
+                _ => unreachable!(),
+            },
 
-                            Err(e) => {
-                                resolver.end_record(&context, RecordType::Filter(Status::FAIL))?;
-                                return Err(e);
-                            }
-                        };
-                        selected.extend(result);
-                    }
-                    Ok(selected)
-                }
-
-                _ => {
-                    if let QueryPart::AllIndices(_) = &query[query_index - 1] {
-                        let mut val_resolver = ValueScope {
-                            root: current,
-                            parent: resolver,
-                        };
-                        match super::eval::eval_conjunction_clauses(
-                            conjunctions,
-                            &mut val_resolver,
-                            super::eval::eval_guard_clause,
-                        ) {
-                            Ok(status) => match status {
+            PathAwareValue::List((_path, list)) => {
+                let mut selected = Vec::with_capacity(list.len());
+                for each in list {
+                    let context = format!("Filter/List#{}", conjunctions.len());
+                    resolver.start_record(&context)?;
+                    let mut val_resolver = ValueScope {
+                        root: Rc::new(each.clone()),
+                        parent: resolver,
+                    };
+                    let result = match super::eval::eval_conjunction_clauses(
+                        conjunctions,
+                        &mut val_resolver,
+                        super::eval::eval_guard_clause,
+                    ) {
+                        Ok(status) => {
+                            resolver.end_record(&context, RecordType::Filter(status))?;
+                            match status {
                                 Status::PASS => query_retrieval_with_converter(
                                     query_index + 1,
                                     query,
-                                    current,
+                                    Rc::new(each.clone()),
                                     resolver,
                                     converter,
-                                ),
-                                _ => Ok(vec![]),
-                            },
-                            Err(e) => return Err(e),
+                                )?,
+                                _ => vec![],
+                            }
                         }
-                    } else {
-                        to_unresolved_result(
-                            current,
-                            format!(
-                                "Filter on value type that was not a struct or array {} {}",
-                                current.type_info(),
-                                current.self_path()
+
+                        Err(e) => {
+                            resolver.end_record(&context, RecordType::Filter(Status::FAIL))?;
+                            return Err(e);
+                        }
+                    };
+                    selected.extend(result);
+                }
+                Ok(selected)
+            }
+
+            _ => {
+                if let QueryPart::AllIndices(_) = &query[query_index - 1] {
+                    let mut val_resolver = ValueScope {
+                        root: Rc::clone(&current),
+                        parent: resolver,
+                    };
+                    match super::eval::eval_conjunction_clauses(
+                        conjunctions,
+                        &mut val_resolver,
+                        super::eval::eval_guard_clause,
+                    ) {
+                        Ok(status) => match status {
+                            Status::PASS => query_retrieval_with_converter(
+                                query_index + 1,
+                                query,
+                                Rc::clone(&current),
+                                resolver,
+                                converter,
                             ),
-                            &query[query_index..],
-                        )
+                            _ => Ok(vec![]),
+                        },
+                        Err(e) => Err(e),
                     }
+                } else {
+                    to_unresolved_result(
+                        Rc::clone(&current),
+                        format!(
+                            "Filter on value type that was not a struct or array {} {}",
+                            current.type_info(),
+                            current.self_path()
+                        ),
+                        &query[query_index..],
+                    )
                 }
             }
-        }
+        },
 
-        QueryPart::MapKeyFilter(_name, map_key_filter) => match current {
+        QueryPart::MapKeyFilter(_name, map_key_filter) => match &*current {
             PathAwareValue::Map((_path, map)) => {
                 let mut selected = Vec::with_capacity(map.values.len());
                 let rhs = match &map_key_filter.compare_with {
-                    LetValue::AccessClause(acc_query) => {
-                        let values = query_retrieval_with_converter(
-                            0,
-                            &acc_query.query,
-                            current,
-                            resolver,
-                            converter,
-                        )?;
-                        values
-                    }
+                    LetValue::AccessClause(acc_query) => query_retrieval_with_converter(
+                        0,
+                        &acc_query.query,
+                        Rc::clone(&current),
+                        resolver,
+                        converter,
+                    )?,
 
                     LetValue::Value(path_value) => {
-                        vec![QueryResult::Literal(path_value)]
+                        vec![QueryResult::Literal(Rc::new(path_value.clone()))]
                     }
 
                     LetValue::FunctionCall(_) => todo!(),
@@ -841,8 +864,10 @@ fn query_retrieval_with_converter<'value, 'loc: 'value>(
                 let lhs = map
                     .keys
                     .iter()
-                    .map(|p| QueryResult::Resolved(p))
-                    .collect::<Vec<QueryResult<'_>>>();
+                    .cloned()
+                    .map(Rc::new)
+                    .map(QueryResult::Resolved)
+                    .collect::<Vec<QueryResult>>();
 
                 let results = super::eval::real_binary_operation(
                     &lhs,
@@ -861,10 +886,10 @@ fn query_retrieval_with_converter<'value, 'loc: 'value>(
                 for each_result in results {
                     match each_result {
                         (QueryResult::Resolved(key), Status::PASS) => {
-                            if let PathAwareValue::String((_, key_name)) = key {
-                                selected.push(QueryResult::Resolved(
-                                    map.values.get(key_name.as_str()).unwrap(),
-                                ));
+                            if let PathAwareValue::String((_, key_name)) = &*key {
+                                selected.push(QueryResult::Resolved(Rc::new(
+                                    map.values.get(key_name.as_str()).unwrap().clone(),
+                                )));
                             }
                         }
 
@@ -881,7 +906,7 @@ fn query_retrieval_with_converter<'value, 'loc: 'value>(
                 let mut extended = Vec::with_capacity(selected.len());
                 for each in selected {
                     match each {
-                        QueryResult::Literal(r) | QueryResult::Resolved(r) => {
+                        QueryResult::Literal(r) => {
                             extended.extend(query_retrieval_with_converter(
                                 query_index + 1,
                                 query,
@@ -890,7 +915,15 @@ fn query_retrieval_with_converter<'value, 'loc: 'value>(
                                 converter,
                             )?);
                         }
-
+                        QueryResult::Resolved(r) => {
+                            extended.extend(query_retrieval_with_converter(
+                                query_index + 1,
+                                query,
+                                r,
+                                resolver,
+                                converter,
+                            )?);
+                        }
                         QueryResult::UnResolved(ur) => {
                             extended.push(QueryResult::UnResolved(ur));
                         }
@@ -900,7 +933,7 @@ fn query_retrieval_with_converter<'value, 'loc: 'value>(
             }
 
             _ => to_unresolved_result(
-                current,
+                Rc::clone(&current),
                 format!(
                     "Map Filter for keys was not a struct {} {}",
                     current.type_info(),
@@ -914,9 +947,9 @@ fn query_retrieval_with_converter<'value, 'loc: 'value>(
 
 pub(crate) fn root_scope<'value, 'loc: 'value>(
     rules_file: &'value RulesFile<'loc>,
-    root: &'value PathAwareValue,
+    root: Rc<PathAwareValue>,
 ) -> Result<RootScope<'value, 'loc>> {
-    let (literals, queries) = extract_variables(&rules_file.assignments)?;
+    let (literals, queries, function_expressions) = extract_variables(&rules_file.assignments)?;
     let mut lookup_cache = HashMap::with_capacity(rules_file.guard_rules.len());
     for rule in &rules_file.guard_rules {
         lookup_cache
@@ -929,15 +962,23 @@ pub(crate) fn root_scope<'value, 'loc: 'value>(
     for pr in rules_file.parameterized_rules.iter() {
         parameterized_rules.insert(pr.rule.rule_name.as_str(), pr);
     }
-    root_scope_with(literals, queries, lookup_cache, parameterized_rules, root)
+    root_scope_with(
+        literals,
+        queries,
+        lookup_cache,
+        parameterized_rules,
+        function_expressions,
+        root,
+    )
 }
 
 pub(crate) fn root_scope_with<'value, 'loc: 'value>(
-    literals: HashMap<&'value str, &'value PathAwareValue>,
+    literals: HashMap<&'value str, Rc<PathAwareValue>>,
     queries: HashMap<&'value str, &'value AccessQuery<'loc>>,
     lookup_cache: HashMap<&'value str, Vec<&'value Rule<'loc>>>,
     parameterized_rules: HashMap<&'value str, &'value ParameterizedRule<'loc>>,
-    root: &'value PathAwareValue,
+    function_expressions: HashMap<&'value str, &'value FunctionExpr<'loc>>,
+    root: Rc<PathAwareValue>,
 ) -> Result<RootScope<'value, 'loc>> {
     Ok(RootScope {
         scope: Scope {
@@ -945,6 +986,7 @@ pub(crate) fn root_scope_with<'value, 'loc: 'value>(
             literals,
             variable_queries: queries,
             //resolved_variables: std::cell::RefCell::new(HashMap::new()),
+            function_expressions,
             resolved_variables: HashMap::new(),
         },
         rules: lookup_cache,
@@ -959,10 +1001,10 @@ pub(crate) fn root_scope_with<'value, 'loc: 'value>(
 
 pub(crate) fn block_scope<'value, 'block, 'loc: 'value, 'eval, T>(
     block: &'value Block<'loc, T>,
-    root: &'value PathAwareValue,
+    root: Rc<PathAwareValue>,
     parent: &'eval mut dyn EvalContext<'value, 'loc>,
 ) -> Result<BlockScope<'value, 'loc, 'eval>> {
-    let (literals, variable_queries) = extract_variables(&block.assignments)?;
+    let (literals, variable_queries, function_expressions) = extract_variables(&block.assignments)?;
     Ok(BlockScope {
         scope: Scope {
             literals,
@@ -970,6 +1012,7 @@ pub(crate) fn block_scope<'value, 'block, 'loc: 'value, 'eval, T>(
             root,
             //resolved_variables: std::cell::RefCell::new(HashMap::new()),
             resolved_variables: HashMap::new(),
+            function_expressions,
         },
         parent,
     })
@@ -981,6 +1024,7 @@ pub(crate) struct RecordTracker<'value> {
 }
 
 impl<'value> RecordTracker<'value> {
+    #[cfg(test)]
     pub(crate) fn new() -> RecordTracker<'value> {
         RecordTracker {
             events: vec![],
@@ -1005,7 +1049,7 @@ impl<'value> RecordTracer<'value> for RecordTracker<'value> {
     fn end_record(&mut self, context: &str, record: RecordType<'value>) -> Result<()> {
         let matched = match self.events.pop() {
             Some(mut event) => {
-                if &event.context != context {
+                if event.context != context {
                     return Err(Error::IncompatibleError(format!(
                         "Event Record context start and end does not match {}",
                         context
@@ -1038,8 +1082,9 @@ impl<'value> RecordTracer<'value> for RecordTracker<'value> {
 }
 
 impl<'value, 'loc: 'value> EvalContext<'value, 'loc> for RootScope<'value, 'loc> {
-    fn query(&mut self, query: &'value [QueryPart<'loc>]) -> Result<Vec<QueryResult<'value>>> {
-        query_retrieval(0, query, self.scope.root, self)
+    fn query(&mut self, query: &'value [QueryPart<'loc>]) -> Result<Vec<QueryResult>> {
+        let root = self.root();
+        query_retrieval(0, query, root, self)
     }
 
     fn find_parameterized_rule(
@@ -1056,10 +1101,11 @@ impl<'value, 'loc: 'value> EvalContext<'value, 'loc> for RootScope<'value, 'loc>
         }
     }
 
-    fn root(&mut self) -> &'value PathAwareValue {
-        self.scope.root
+    fn root(&mut self) -> Rc<PathAwareValue> {
+        Rc::clone(&self.scope.root)
     }
 
+    #[allow(clippy::never_loop)]
     fn rule_status(&mut self, rule_name: &'value str) -> Result<Status> {
         if let Some(status) = self.rules_status.get(rule_name) {
             return Ok(*status);
@@ -1086,26 +1132,54 @@ impl<'value, 'loc: 'value> EvalContext<'value, 'loc> for RootScope<'value, 'loc>
             break SKIP;
         };
 
-        // let status = super::eval::eval_rule(rule, self)?;
         self.rules_status.insert(rule_name, status);
         Ok(status)
-
-        //        self.rules.get(rule_name).map_or_else(
-        //            || Err(Error::new(ErrorKind::MissingValue(
-        //                format!("Rule {} by that name does not exist, Rule Names = {:?}",
-        //                        rule_name, self.rules.keys())
-        //            ))),
-        //            |rule| super::eval::eval_rule(*rule, self)
-        //        )
     }
 
-    fn resolve_variable(&mut self, variable_name: &'value str) -> Result<Vec<QueryResult<'value>>> {
+    fn resolve_variable(&mut self, variable_name: &'value str) -> Result<Vec<QueryResult>> {
         if let Some(val) = self.scope.literals.get(variable_name) {
-            return Ok(vec![QueryResult::Literal(*val)]);
+            return Ok(vec![QueryResult::Literal(Rc::clone(val))]);
         }
 
         if let Some(values) = self.scope.resolved_variables.get(variable_name) {
             return Ok(values.clone());
+        }
+
+        if let Some(FunctionExpr {
+            parameters, name, ..
+        }) = self.scope.function_expressions.get(variable_name)
+        {
+            let args = parameters.iter().try_fold(
+                vec![],
+                |mut args, param| -> Result<Vec<QueryResult>> {
+                    match param {
+                        LetValue::Value(value) => {
+                            args.push(QueryResult::Literal(Rc::new(value.clone())))
+                        }
+                        LetValue::AccessClause(clause) => {
+                            let resolved_query = self.query(&clause.query)?;
+                            args.extend(resolved_query);
+                        }
+                        // TODO: do we want to allow for function expressions to be params?
+                        _ => todo!(),
+                    }
+
+                    Ok(args)
+                },
+            )?;
+
+            let result = try_handle_function_call(name, &args)?
+                .into_iter()
+                .flatten()
+                .map(Rc::new)
+                .map(QueryResult::Resolved)
+                .collect::<Vec<_>>();
+
+            self.scope
+                .resolved_variables
+                .insert(variable_name, result.clone());
+
+            return Ok(result);
         }
 
         let query = match self.scope.variable_queries.get(variable_name) {
@@ -1120,7 +1194,7 @@ impl<'value, 'loc: 'value> EvalContext<'value, 'loc> for RootScope<'value, 'loc>
 
         let match_all = query.match_all;
 
-        let result = query_retrieval(0, &query.query, self.scope.root, self)?;
+        let result = query_retrieval(0, &query.query, self.root(), self)?;
         let result = if !match_all {
             result
                 .into_iter()
@@ -1132,21 +1206,149 @@ impl<'value, 'loc: 'value> EvalContext<'value, 'loc> for RootScope<'value, 'loc>
         self.scope
             .resolved_variables
             .insert(variable_name, result.clone());
-        return Ok(result);
+        Ok(result)
     }
 
     fn add_variable_capture_key(
         &mut self,
         variable_name: &'value str,
-        key: &'value PathAwareValue,
+        key: Rc<PathAwareValue>,
     ) -> Result<()> {
         self.scope
             .resolved_variables
             .entry(variable_name)
             .or_default()
-            .push(QueryResult::Resolved(key));
+            .push(QueryResult::Resolved(Rc::clone(&key)));
         Ok(())
     }
+}
+
+fn try_handle_function_call(
+    fn_name: &str,
+    args: &[QueryResult],
+) -> Result<Vec<Option<PathAwareValue>>> {
+    let value = match fn_name {
+        "count" => vec![Some(PathAwareValue::Int((
+            Path::root(),
+            count(args) as i64,
+        )))],
+        "json_parse" => json_parse(args)?,
+        "regex_replace" => match args.len() {
+            0..=2 => {
+                return Err(Error::ParseError(String::from(
+                    "regex_replace function requires 3 arguments",
+                )))
+            }
+
+            num => {
+                // TODO: Verify the validation for this function call
+                if !matches!(args[0], QueryResult::Resolved(_)) {
+                    return Err(Error::ParseError(String::from(
+                        "regex_replace function requires the first argument to be variable, but received a literal"
+                    )));
+                }
+
+                let extracted_expr =  match &args[num - 2] {
+                    QueryResult::Resolved(r) | QueryResult::Literal(r) => match &**r {
+                        PathAwareValue::String((_, s)) => s,
+                    _ => return Err(Error::ParseError(String::from(
+                            "regex_replace function requires the third argument to be string literal, but received a variable"
+                        )))
+                    }
+                    _ => return Err(Error::ParseError(String::from(
+                        "regex_replace function requires the third argument to be string literal, but received a variable"
+                    )))
+                };
+
+                let replaced_expr =  match &args[num - 1] {
+                    QueryResult::Resolved(r) | QueryResult::Literal(r) => match &**r {
+                        PathAwareValue::String((_, s)) => s,
+                        _ => return Err(Error::ParseError(String::from(
+                            "regex_replace function requires the second argument to be string literal, but received a variable"
+                        )))
+                    }
+                    _ => return Err(Error::ParseError(String::from(
+                        "regex_replace function requires the second argument to be string literal, but received a variable"
+                    )))
+                };
+                regex_replace(&args[0..num - 2], extracted_expr, replaced_expr)?
+            }
+        },
+        "substring" => {
+            match args.len() {
+                0..=2 => {
+                    return Err(Error::ParseError(String::from(
+                        "substring function requires 3 arguments",
+                    )))
+                }
+
+                num => {
+                    let from = match &args[num - 2] {
+                        QueryResult::Literal(r) | QueryResult::Resolved(r) => match &**r {
+                            PathAwareValue::Int((_, n)) => usize::from(*n as u16),
+                            PathAwareValue::Float((_, n)) => usize::from(*n as u16),
+                            _ => return Err(Error::ParseError(String::from(
+                                "substring function requires the second argument to be a number",
+                            ))),
+                        },
+                        _ => {
+                            return Err(Error::ParseError(String::from(
+                                "substring function requires the second argument to be a number",
+                            )))
+                        }
+                    };
+
+                    let to =
+                        match &args[num - 1] {
+                            QueryResult::Literal(r) | QueryResult::Resolved(r) => match &**r {
+                                PathAwareValue::Int((_, n)) => usize::from(*n as u16),
+                                PathAwareValue::Float((_, n)) => usize::from(*n as u16),
+                                _ => return Err(Error::ParseError(String::from(
+                                    "substring function requires the first argument to be a number",
+                                ))),
+                            },
+                            _ => {
+                                return Err(Error::ParseError(String::from(
+                                    "substring function requires the first argument to be a number",
+                                )))
+                            }
+                        };
+
+                    substring(&args[0..num - 2], from, to)?
+                }
+            }
+        }
+        "to_upper" => to_upper(args)?,
+        "to_lower" => to_lower(args)?,
+        "join" => match args.len() {
+            0..=1 => {
+                return Err(Error::ParseError(String::from(
+                    "join function requires 2 arguments",
+                )))
+            }
+            num => {
+                let delimiter = match &args[num - 1] {
+                    QueryResult::Resolved(r) | QueryResult::Literal(r) => match &**r {
+                        PathAwareValue::String((_, s)) => s,
+                        _ => return Err(Error::ParseError(String::from(
+                            "join function requires the 2nd argument to be either a char or string",
+                        ))),
+                    },
+                    _ => {
+                        return Err(Error::ParseError(String::from(
+                            "join function requires the 2nd argument to be either a char or string",
+                        )))
+                    }
+                };
+
+                vec![Some(join(&args[0..num - 1], delimiter)?)]
+            }
+        },
+        "url_decode" => url_decode(args)?,
+        function => return Err(Error::ParseError(format!("No function named {function}"))),
+    };
+
+    Ok(value)
 }
 
 impl<'value, 'loc: 'value> RecordTracer<'value> for RootScope<'value, 'loc> {
@@ -1160,8 +1362,8 @@ impl<'value, 'loc: 'value> RecordTracer<'value> for RootScope<'value, 'loc> {
 }
 
 impl<'value, 'loc: 'value, 'eval> EvalContext<'value, 'loc> for ValueScope<'value, 'eval, 'loc> {
-    fn query(&mut self, query: &'value [QueryPart<'loc>]) -> Result<Vec<QueryResult<'value>>> {
-        query_retrieval(0, query, self.root, self.parent)
+    fn query(&mut self, query: &'value [QueryPart<'loc>]) -> Result<Vec<QueryResult>> {
+        query_retrieval(0, query, self.root(), self.parent)
     }
 
     fn find_parameterized_rule(
@@ -1171,22 +1373,22 @@ impl<'value, 'loc: 'value, 'eval> EvalContext<'value, 'loc> for ValueScope<'valu
         self.parent.find_parameterized_rule(rule_name)
     }
 
-    fn root(&mut self) -> &'value PathAwareValue {
-        self.root
+    fn root(&mut self) -> Rc<PathAwareValue> {
+        Rc::clone(&self.root)
     }
 
     fn rule_status(&mut self, rule_name: &'value str) -> Result<Status> {
         self.parent.rule_status(rule_name)
     }
 
-    fn resolve_variable(&mut self, variable_name: &'value str) -> Result<Vec<QueryResult<'value>>> {
+    fn resolve_variable(&mut self, variable_name: &'value str) -> Result<Vec<QueryResult>> {
         self.parent.resolve_variable(variable_name)
     }
 
     fn add_variable_capture_key(
         &mut self,
         variable_name: &'value str,
-        key: &'value PathAwareValue,
+        key: Rc<PathAwareValue>,
     ) -> Result<()> {
         self.parent.add_variable_capture_key(variable_name, key)
     }
@@ -1203,8 +1405,8 @@ impl<'value, 'loc: 'value, 'eval> RecordTracer<'value> for ValueScope<'value, 'e
 }
 
 impl<'value, 'loc: 'value, 'eval> EvalContext<'value, 'loc> for BlockScope<'value, 'loc, 'eval> {
-    fn query(&mut self, query: &'value [QueryPart<'loc>]) -> Result<Vec<QueryResult<'value>>> {
-        query_retrieval(0, query, self.scope.root, self)
+    fn query(&mut self, query: &'value [QueryPart<'loc>]) -> Result<Vec<QueryResult>> {
+        query_retrieval(0, query, self.root(), self)
     }
 
     fn find_parameterized_rule(
@@ -1214,21 +1416,58 @@ impl<'value, 'loc: 'value, 'eval> EvalContext<'value, 'loc> for BlockScope<'valu
         self.parent.find_parameterized_rule(rule_name)
     }
 
-    fn root(&mut self) -> &'value PathAwareValue {
-        self.scope.root
+    fn root(&mut self) -> Rc<PathAwareValue> {
+        Rc::clone(&self.scope.root)
     }
 
     fn rule_status(&mut self, rule_name: &'value str) -> Result<Status> {
         self.parent.rule_status(rule_name)
     }
 
-    fn resolve_variable(&mut self, variable_name: &'value str) -> Result<Vec<QueryResult<'value>>> {
+    fn resolve_variable(&mut self, variable_name: &'value str) -> Result<Vec<QueryResult>> {
         if let Some(val) = self.scope.literals.get(variable_name) {
-            return Ok(vec![QueryResult::Literal(*val)]);
+            return Ok(vec![QueryResult::Literal(Rc::clone(val))]);
         }
 
         if let Some(values) = self.scope.resolved_variables.get(variable_name) {
             return Ok(values.clone());
+        }
+
+        if let Some(FunctionExpr {
+            parameters, name, ..
+        }) = self.scope.function_expressions.get(variable_name)
+        {
+            let args = parameters.iter().try_fold(
+                vec![],
+                |mut args, param| -> Result<Vec<QueryResult>> {
+                    match param {
+                        LetValue::Value(value) => {
+                            args.push(QueryResult::Literal(Rc::new(value.clone())))
+                        }
+                        LetValue::AccessClause(clause) => {
+                            let resolved_query = self.query(&clause.query)?;
+                            args.extend(resolved_query);
+                        }
+                        // TODO: do we want to allow for function expressions to be params?
+                        _ => todo!(),
+                    }
+
+                    Ok(args)
+                },
+            )?;
+
+            let result = try_handle_function_call(name, &args)?
+                .into_iter()
+                .flatten()
+                .map(Rc::new)
+                .map(QueryResult::Resolved)
+                .collect::<Vec<_>>();
+
+            self.scope
+                .resolved_variables
+                .insert(variable_name, result.clone());
+
+            return Ok(result);
         }
 
         let query = match self.scope.variable_queries.get(variable_name) {
@@ -1238,7 +1477,7 @@ impl<'value, 'loc: 'value, 'eval> EvalContext<'value, 'loc> for BlockScope<'valu
 
         let match_all = query.match_all;
 
-        let result = query_retrieval(0, &query.query, self.scope.root, self)?;
+        let result = query_retrieval(0, &query.query, self.root(), self)?;
         let result = if !match_all {
             result
                 .into_iter()
@@ -1250,13 +1489,14 @@ impl<'value, 'loc: 'value, 'eval> EvalContext<'value, 'loc> for BlockScope<'valu
         self.scope
             .resolved_variables
             .insert(variable_name, result.clone());
-        return Ok(result);
+
+        Ok(result)
     }
 
     fn add_variable_capture_key(
         &mut self,
         variable_name: &'value str,
-        key: &'value PathAwareValue,
+        key: Rc<PathAwareValue>,
     ) -> Result<()> {
         self.parent.add_variable_capture_key(variable_name, key)
     }
@@ -1300,108 +1540,108 @@ pub(crate) struct RuleReport<'value> {
 }
 
 #[derive(Clone, Debug, Serialize)]
-pub(crate) struct UnaryComparison<'value> {
-    pub(crate) value: &'value PathAwareValue,
+pub(crate) struct UnaryComparison {
+    pub(crate) value: Rc<PathAwareValue>,
     pub(crate) comparison: (CmpOperator, bool),
 }
 
 #[derive(Clone, Debug, Serialize)]
-pub(crate) struct ValueUnResolved<'value> {
-    pub(crate) value: UnResolved<'value>,
+pub(crate) struct ValueUnResolved {
+    pub(crate) value: UnResolved,
     pub(crate) comparison: (CmpOperator, bool),
 }
 
 #[derive(Clone, Debug, Serialize)]
-pub(crate) enum UnaryCheck<'value> {
-    UnResolved(ValueUnResolved<'value>),
-    Resolved(UnaryComparison<'value>),
+pub(crate) enum UnaryCheck {
+    UnResolved(ValueUnResolved),
+    Resolved(UnaryComparison),
     UnResolvedContext(String),
 }
 
-impl<'value> ValueComparisons<'value> for UnaryCheck<'value> {
-    fn value_from(&self) -> Option<&'value PathAwareValue> {
+impl ValueComparisons for UnaryCheck {
+    fn value_from(&self) -> Option<Rc<PathAwareValue>> {
         match self {
-            UnaryCheck::UnResolved(ur) => Some(ur.value.traversed_to),
-            UnaryCheck::Resolved(uc) => Some(uc.value),
+            UnaryCheck::UnResolved(ur) => Some(ur.value.traversed_to.clone()),
+            UnaryCheck::Resolved(uc) => Some(uc.value.clone()),
             UnaryCheck::UnResolvedContext(_) => None,
         }
     }
 }
 
 #[derive(Clone, Debug, Serialize)]
-pub(crate) struct UnaryReport<'value> {
+pub(crate) struct UnaryReport {
     pub(crate) context: String,
     pub(crate) messages: Messages,
-    pub(crate) check: UnaryCheck<'value>,
+    pub(crate) check: UnaryCheck,
 }
 
 #[derive(Clone, Debug, Serialize)]
-pub(crate) struct BinaryComparison<'value> {
-    pub(crate) from: &'value PathAwareValue,
-    pub(crate) to: &'value PathAwareValue,
+pub(crate) struct BinaryComparison {
+    pub(crate) from: Rc<PathAwareValue>,
+    pub(crate) to: Rc<PathAwareValue>,
     pub(crate) comparison: (CmpOperator, bool),
 }
 
 #[derive(Clone, Debug, Serialize)]
-pub(crate) struct InComparison<'value> {
-    pub(crate) from: &'value PathAwareValue,
-    pub(crate) to: Vec<&'value PathAwareValue>,
+pub(crate) struct InComparison {
+    pub(crate) from: Rc<PathAwareValue>,
+    pub(crate) to: Vec<Rc<PathAwareValue>>,
     pub(crate) comparison: (CmpOperator, bool),
 }
 
 #[derive(Clone, Debug, Serialize)]
-pub(crate) enum BinaryCheck<'value> {
-    UnResolved(ValueUnResolved<'value>),
-    Resolved(BinaryComparison<'value>),
-    InResolved(InComparison<'value>),
+pub(crate) enum BinaryCheck {
+    UnResolved(ValueUnResolved),
+    Resolved(BinaryComparison),
+    InResolved(InComparison),
 }
 
-impl<'value> ValueComparisons<'value> for BinaryCheck<'value> {
-    fn value_from(&self) -> Option<&'value PathAwareValue> {
+impl ValueComparisons for BinaryCheck {
+    fn value_from(&self) -> Option<Rc<PathAwareValue>> {
         match self {
-            BinaryCheck::UnResolved(vur) => Some(vur.value.traversed_to),
-            BinaryCheck::Resolved(res) => Some(res.from),
-            BinaryCheck::InResolved(inr) => Some(inr.from),
+            BinaryCheck::UnResolved(vur) => Some(vur.value.traversed_to.clone()),
+            BinaryCheck::Resolved(res) => Some(res.from.clone()),
+            BinaryCheck::InResolved(inr) => Some(inr.from.clone()),
         }
     }
 
-    fn value_to(&self) -> Option<&'value PathAwareValue> {
+    fn value_to(&self) -> Option<Rc<PathAwareValue>> {
         match self {
-            BinaryCheck::Resolved(bc) => Some(bc.to),
+            BinaryCheck::Resolved(bc) => Some(bc.to.clone()),
             _ => None,
         }
     }
 }
 
 #[derive(Clone, Debug, Serialize)]
-pub(crate) struct BinaryReport<'value> {
+pub(crate) struct BinaryReport {
     pub(crate) context: String,
     pub(crate) messages: Messages,
-    pub(crate) check: BinaryCheck<'value>,
+    pub(crate) check: BinaryCheck,
 }
 
 #[derive(Clone, Debug, Serialize)]
-pub(crate) enum GuardClauseReport<'value> {
-    Unary(UnaryReport<'value>),
-    Binary(BinaryReport<'value>),
+pub(crate) enum GuardClauseReport {
+    Unary(UnaryReport),
+    Binary(BinaryReport),
 }
 
-pub(crate) trait ValueComparisons<'from> {
-    fn value_from(&self) -> Option<&'from PathAwareValue>;
-    fn value_to(&self) -> Option<&'from PathAwareValue> {
+pub(crate) trait ValueComparisons {
+    fn value_from(&self) -> Option<Rc<PathAwareValue>>;
+    fn value_to(&self) -> Option<Rc<PathAwareValue>> {
         None
     }
 }
 
-impl<'value> ValueComparisons<'value> for GuardClauseReport<'value> {
-    fn value_from(&self) -> Option<&'value PathAwareValue> {
+impl ValueComparisons for GuardClauseReport {
+    fn value_from(&self) -> Option<Rc<PathAwareValue>> {
         match self {
             GuardClauseReport::Binary(br) => br.check.value_from(),
             GuardClauseReport::Unary(ur) => ur.check.value_from(),
         }
     }
 
-    fn value_to(&self) -> Option<&'value PathAwareValue> {
+    fn value_to(&self) -> Option<Rc<PathAwareValue>> {
         match self {
             GuardClauseReport::Binary(br) => br.check.value_to(),
             GuardClauseReport::Unary(ur) => ur.check.value_to(),
@@ -1415,16 +1655,16 @@ pub(crate) struct DisjunctionsReport<'value> {
 }
 
 #[derive(Clone, Debug, Serialize)]
-pub(crate) struct GuardBlockReport<'value> {
+pub(crate) struct GuardBlockReport {
     pub(crate) context: String,
     pub(crate) messages: Messages,
-    pub(crate) unresolved: Option<UnResolved<'value>>,
+    pub(crate) unresolved: Option<UnResolved>,
 }
 
-impl<'value> ValueComparisons<'value> for GuardBlockReport<'value> {
-    fn value_from(&self) -> Option<&'value PathAwareValue> {
+impl ValueComparisons for GuardBlockReport {
+    fn value_from(&self) -> Option<Rc<PathAwareValue>> {
         if let Some(ur) = &self.unresolved {
-            return Some(ur.traversed_to);
+            return Some(ur.traversed_to.clone());
         }
         None
     }
@@ -1433,76 +1673,12 @@ impl<'value> ValueComparisons<'value> for GuardBlockReport<'value> {
 #[derive(Clone, Debug, Serialize)]
 pub(crate) enum ClauseReport<'value> {
     Rule(RuleReport<'value>),
-    Block(GuardBlockReport<'value>),
+    Block(GuardBlockReport),
     Disjunctions(DisjunctionsReport<'value>),
-    Clause(GuardClauseReport<'value>),
+    Clause(GuardClauseReport),
 }
 
 impl<'value> ClauseReport<'value> {
-    pub(crate) fn is_rule(&self) -> bool {
-        if let Self::Rule(_) = self {
-            true
-        } else {
-            false
-        }
-    }
-
-    pub(crate) fn is_block(&self) -> bool {
-        if let Self::Block(_) = self {
-            true
-        } else {
-            false
-        }
-    }
-
-    pub(crate) fn is_disjunctions(&self) -> bool {
-        if let Self::Disjunctions(_) = self {
-            true
-        } else {
-            false
-        }
-    }
-
-    pub(crate) fn is_clause(&self) -> bool {
-        if let Self::Clause(_) = self {
-            true
-        } else {
-            false
-        }
-    }
-
-    pub(crate) fn rule(&self) -> Option<&RuleReport> {
-        if let Self::Rule(rr) = self {
-            Some(rr)
-        } else {
-            None
-        }
-    }
-
-    pub(crate) fn block(&self) -> Option<&GuardBlockReport> {
-        if let Self::Block(rr) = self {
-            Some(rr)
-        } else {
-            None
-        }
-    }
-
-    pub(crate) fn disjunctions(&self) -> Option<&DisjunctionsReport> {
-        if let Self::Disjunctions(rr) = self {
-            Some(rr)
-        } else {
-            None
-        }
-    }
-
-    pub(crate) fn clause(&self) -> Option<&GuardClauseReport> {
-        if let Self::Clause(gc) = self {
-            Some(gc)
-        } else {
-            None
-        }
-    }
-
     pub(crate) fn key(&self, parent: &str) -> String {
         match self {
             Self::Rule(RuleReport { name, .. }) => format!("{}/{}", parent, name),
@@ -1513,8 +1689,8 @@ impl<'value> ClauseReport<'value> {
     }
 }
 
-impl<'value> ValueComparisons<'value> for ClauseReport<'value> {
-    fn value_from(&self) -> Option<&'value PathAwareValue> {
+impl<'value> ValueComparisons for ClauseReport<'value> {
+    fn value_from(&self) -> Option<Rc<PathAwareValue>> {
         match self {
             Self::Block(b) => b.value_from(),
             Self::Clause(c) => c.value_from(),
@@ -1522,7 +1698,7 @@ impl<'value> ValueComparisons<'value> for ClauseReport<'value> {
         }
     }
 
-    fn value_to(&self) -> Option<&'value PathAwareValue> {
+    fn value_to(&self) -> Option<Rc<PathAwareValue>> {
         match self {
             Self::Block(b) => b.value_to(),
             Self::Clause(c) => c.value_to(),
@@ -1537,9 +1713,9 @@ pub(crate) fn cmp_str(cmp: (CmpOperator, bool)) -> &'static str {
         match cmp {
             CmpOperator::Exists => {
                 if not {
-                    "NOT EXISTS"
+                    "NOT EISTS"
                 } else {
-                    "EXISTS"
+                    "EISTS"
                 }
             }
             CmpOperator::Empty => {
@@ -1633,7 +1809,7 @@ fn report_all_failed_clauses_for_rules<'value>(
                 message,
             })) => {
                 clauses.push(ClauseReport::Rule(RuleReport {
-                    name: *name,
+                    name,
                     checks: report_all_failed_clauses_for_rules(&current.children),
                     messages: Messages {
                         custom_message: message.clone(),
@@ -1696,7 +1872,7 @@ fn report_all_failed_clauses_for_rules<'value>(
                 ClauseCheck::NoValueForEmptyCheck(msg) => {
                     let custom_message = msg
                         .as_ref()
-                        .map_or("".to_string(), |s| format!("{}", s.replace("\n", ";")));
+                        .map_or("".to_string(), |s| s.replace('\n', ";"));
 
                     let error_message = format!(
                         "Check was not compliant as variable in context [{}] was not empty",
@@ -1738,7 +1914,7 @@ fn report_all_failed_clauses_for_rules<'value>(
                 ClauseCheck::MissingBlockValue(missing) => {
                     let (property, far, ur) = match &missing.from {
                         QueryResult::UnResolved(ur) => {
-                            (ur.remaining_query.as_str(), ur.traversed_to, ur)
+                            (ur.remaining_query.as_str(), ur.traversed_to.clone(), ur)
                         }
                         _ => unreachable!(),
                     };
@@ -1819,19 +1995,18 @@ fn report_all_failed_clauses_for_rules<'value>(
                                 "was not bool"
                             }
                         }
-                        IsFloat => {
+                        _ => {
                             if *not {
                                 "was float"
                             } else {
                                 "was not float"
                             }
                         }
-                        Eq | In | Gt | Lt | Le | Ge => unreachable!(),
                     };
 
                     let custom_message = custom_message
                         .as_ref()
-                        .map_or("".to_string(), |s| format!("{}", s.replace("\n", ";")));
+                        .map_or("".to_string(), |s| s.replace('\n', ";"));
 
                     let error_message = message
                         .as_ref()
@@ -1849,7 +2024,7 @@ fn report_all_failed_clauses_for_rules<'value>(
                                     ),
                                     UnaryCheck::Resolved(UnaryComparison {
                                         comparison: (*cmp, *not),
-                                        value: *res,
+                                        value: res.clone(),
                                     })
                                 )
 
@@ -1893,7 +2068,7 @@ fn report_all_failed_clauses_for_rules<'value>(
                 }) => {
                     let custom_message = custom_message
                         .as_ref()
-                        .map_or("".to_string(), |s| format!("{}", s.replace("\n", ";")));
+                        .map_or("".to_string(), |s| s.replace('\n', ";"));
 
                     let error_message = message
                         .as_ref()
@@ -1934,7 +2109,7 @@ fn report_all_failed_clauses_for_rules<'value>(
                                                 to=to_res,
                                                 op_msg=match cmp {
                                                     CmpOperator::Eq => if *not { "equal to" } else { "not equal to" },
-                                                    CmpOperator::Le => if *not { "less than equal to" } else { "less than equal to" },
+                                                    CmpOperator::Le => if *not { "less than equal to" } else { "not less than equal to" },
                                                     CmpOperator::Lt => if *not { "less than" } else { "not less than" },
                                                     CmpOperator::Ge => if *not { "greater than equal to" } else { "not greater than equal" },
                                                     CmpOperator::Gt => if *not { "greater than" } else { "not greater than" },
@@ -1946,8 +2121,8 @@ fn report_all_failed_clauses_for_rules<'value>(
                                         clauses.push(ClauseReport::Clause(
                                             GuardClauseReport::Binary(BinaryReport {
                                                 check: BinaryCheck::Resolved(BinaryComparison {
-                                                    to: *to_res,
-                                                    from: res,
+                                                    to: to_res.clone(),
+                                                    from: res.clone(),
                                                     comparison: (*cmp, *not),
                                                 }),
                                                 context: current.context.to_string(),
@@ -2007,22 +2182,25 @@ fn report_all_failed_clauses_for_rules<'value>(
                                 error_message: Some(error_message),
                             },
                             check: BinaryCheck::InResolved(InComparison {
-                                from: from.resolved().map_or_else(
-                                    || from.unresolved_traversed_to().unwrap(),
-                                    std::convert::identity,
-                                ),
+                                // from: from.resolved().map_or_else(
+                                //     || match from.unresolved_traversed_to().unwrap(),
+                                //     std::convert::identity,
+                                // ),
+                                from: match from.resolved() {
+                                    Some(val) => val,
+                                    None => match from.unresolved_traversed_to() {
+                                        Some(val) => val,
+                                        None => unreachable!(),
+                                    },
+                                },
                                 to: to
                                     .iter()
-                                    .filter(|t| match t {
-                                        QueryResult::Resolved(_) => true,
-                                        _ => false,
-                                    })
+                                    .filter(|t| matches!(t, QueryResult::Resolved(_)))
                                     .map(|t| match t {
-                                        QueryResult::Resolved(v) => v,
-                                        QueryResult::UnResolved(ur) => ur.traversed_to,
-                                        QueryResult::Literal(l) => *l,
+                                        QueryResult::Resolved(v) => v.clone(),
+                                        _ => unreachable!(),
                                     })
-                                    .collect(),
+                                    .collect::<Vec<_>>(),
                                 comparison: *comparison,
                             }),
                         },
@@ -2042,48 +2220,34 @@ pub(crate) fn simplifed_json_from_root<'value>(
     root: &EventRecord<'value>,
 ) -> Result<FileReport<'value>> {
     Ok(match &root.container {
-        Some(file_status) => match file_status {
-            RecordType::FileCheck(NamedStatus {
-                name,
-                status,
-                message,
-            }) => {
-                let mut pass = HashSet::with_capacity(root.children.len());
-                let mut skip = HashSet::with_capacity(root.children.len());
-                for each in &root.children {
-                    if let Some(rule) = &each.container {
-                        if let RecordType::RuleCheck(NamedStatus {
-                            status,
-                            message,
-                            name,
-                        }) = rule
-                        {
-                            match *status {
-                                Status::PASS => {
-                                    pass.insert(name.to_string());
-                                }
-                                Status::SKIP => {
-                                    skip.insert(name.to_string());
-                                }
-                                _ => {}
-                            }
+        Some(RecordType::FileCheck(NamedStatus { name, status, .. })) => {
+            let mut pass = HashSet::with_capacity(root.children.len());
+            let mut skip = HashSet::with_capacity(root.children.len());
+            for each in &root.children {
+                if let Some(RecordType::RuleCheck(NamedStatus { status, name, .. })) =
+                    &each.container
+                {
+                    match *status {
+                        Status::PASS => {
+                            pass.insert(name.to_string());
                         }
+                        SKIP => {
+                            skip.insert(name.to_string());
+                        }
+                        _ => {}
                     }
                 }
-                FileReport {
-                    status: *status,
-                    name: *name,
-                    not_compliant: report_all_failed_clauses_for_rules(&root.children),
-                    not_applicable: skip,
-                    compliant: pass,
-                    ..Default::default()
-                }
             }
-
-            _ => unreachable!(),
-        },
-
-        None => unreachable!(),
+            FileReport {
+                status: *status,
+                name,
+                not_compliant: report_all_failed_clauses_for_rules(&root.children),
+                not_applicable: skip,
+                compliant: pass,
+                ..Default::default()
+            }
+        }
+        _ => unreachable!(),
     })
 }
 

--- a/guard/src/rules/eval_context.rs
+++ b/guard/src/rules/eval_context.rs
@@ -1210,6 +1210,7 @@ pub(crate) fn validate_number_of_params(name: &str, num_args: usize) -> Result<(
     Ok(())
 }
 
+// TODO: look into the possibility of abstracting functions into structs that all implement a trait
 pub(crate) fn try_handle_function_call(
     fn_name: &str,
     args: &[Vec<QueryResult>],

--- a/guard/src/rules/eval_context_tests.rs
+++ b/guard/src/rules/eval_context_tests.rs
@@ -453,6 +453,7 @@ fn test_with_converter() -> Result<()> {
     Ok(())
 }
 
+// FIXME: break this up into multiple tests
 #[test]
 fn test_handle_function_call() -> Result<()> {
     let path_value = PathAwareValue::try_from(serde_yaml::from_str::<serde_yaml::Value>(

--- a/guard/src/rules/eval_context_tests.rs
+++ b/guard/src/rules/eval_context_tests.rs
@@ -28,11 +28,7 @@ fn extraction_test() -> Result<()> {
             .rules
             .get("aws_route53_recordset")
             .map(|s| s.get(0))
-            .map(|s| match s {
-                Some(r) => Some(*r),
-                None => None,
-            })
-            .flatten(),
+            .and_then(|s| s.copied()),
         rules.guard_rules.get(0)
     );
 
@@ -93,7 +89,7 @@ fn no_query_return_root() -> Result<()> {
         recorder: None,
     };
     let query_results = eval.query(&[])?;
-    assert_eq!(query_results.is_empty(), false);
+    assert!(!query_results.is_empty());
     assert_eq!(query_results.len(), 1);
     let path_ref = match &query_results[0] {
         QueryResult::Resolved(r) => r,
@@ -112,7 +108,7 @@ fn empty_value_return_unresolved() -> Result<()> {
     };
     let query = AccessQuery::try_from("Resources.*")?.query;
     let query_results = eval.query(&query)?;
-    assert_eq!(query_results.is_empty(), false);
+    assert!(!query_results.is_empty());
     assert_eq!(query_results.len(), 1);
     let path_ref = match &query_results[0] {
         QueryResult::UnResolved(ur) => &ur.traversed_to,
@@ -138,15 +134,15 @@ fn non_empty_value_return_results() -> Result<()> {
         "#,
     )?)?;
     let mut eval = BasicQueryTesting {
-        root: Rc::new(path_value.clone()),
+        root: Rc::new(path_value),
         recorder: None,
     };
     let query = AccessQuery::try_from("Resources.*")?.query;
     let query_results = eval.query(&query)?;
-    assert_eq!(query_results.is_empty(), false);
+    assert!(!query_results.is_empty());
     assert_eq!(query_results.len(), 2); // 2 resources
     for each in query_results {
-        assert_eq!(matches!(each, QueryResult::Resolved(_)), true);
+        assert!(matches!(each, QueryResult::Resolved(_)));
     }
 
     let paths = [
@@ -155,14 +151,14 @@ fn non_empty_value_return_results() -> Result<()> {
     ];
     let query = AccessQuery::try_from("Resources.*.Properties.Tags")?.query;
     let query_results = eval.query(&query)?;
-    assert_eq!(query_results.is_empty(), false);
+    assert!(!query_results.is_empty());
     assert_eq!(query_results.len(), 2); // 2 resources
     for each in query_results {
         match each {
             QueryResult::UnResolved(ur) => {
                 let path = ur.traversed_to.self_path();
                 println!("{}", path);
-                assert_eq!(paths.contains(path), true);
+                assert!(paths.contains(path));
             }
 
             _ => unreachable!(),
@@ -191,18 +187,18 @@ fn non_empty_value_mixed_results() -> Result<()> {
         "#,
     )?)?;
     let mut eval = BasicQueryTesting {
-        root: Rc::new(path_value.clone()),
+        root: Rc::new(path_value),
         recorder: None,
     };
     let query_results = eval.query(&query)?;
-    assert_eq!(query_results.is_empty(), false);
+    assert!(!query_results.is_empty());
     assert_eq!(query_results.len(), 2); // 2 resources
     for each in query_results {
         match each {
             QueryResult::Literal(_) => unreachable!(),
             QueryResult::Resolved(res) => {
                 assert_eq!(res.self_path().0.as_str(), "/Resources/s3/Properties/Tags");
-                assert_eq!(res.is_list(), true);
+                assert!(res.is_list());
             }
 
             QueryResult::UnResolved(ur) => {
@@ -235,12 +231,12 @@ fn non_empty_value_with_missing_list_property() -> Result<()> {
         "#,
     )?)?;
     let mut eval = BasicQueryTesting {
-        root: Rc::new(path_value.clone()),
+        root: Rc::new(path_value),
         recorder: None,
     };
     let query = AccessQuery::try_from("Resources.*.Properties.Tags[*].Value")?.query;
     let query_results = eval.query(&query)?;
-    assert_eq!(query_results.is_empty(), false);
+    assert!(!query_results.is_empty());
     assert_eq!(query_results.len(), 2); // 2 resources
     for each in query_results {
         match each {
@@ -250,7 +246,7 @@ fn non_empty_value_with_missing_list_property() -> Result<()> {
                     res.self_path().0.as_str(),
                     "/Resources/s3/Properties/Tags/0/Value"
                 );
-                assert_eq!(res.is_scalar(), true);
+                assert!(res.is_scalar());
             }
 
             QueryResult::UnResolved(ur) => {
@@ -284,12 +280,12 @@ fn non_empty_value_with_empty_list_property() -> Result<()> {
         "#,
     )?)?;
     let mut eval = BasicQueryTesting {
-        root: Rc::new(path_value.clone()),
+        root: Rc::new(path_value),
         recorder: None,
     };
     let query = AccessQuery::try_from("Resources.*.Properties.Tags[*].Value")?.query;
     let query_results = eval.query(&query)?;
-    assert_eq!(query_results.is_empty(), false);
+    assert!(!query_results.is_empty());
     assert_eq!(query_results.len(), 2); // 2 resources
     for each in query_results {
         match each {
@@ -299,7 +295,7 @@ fn non_empty_value_with_empty_list_property() -> Result<()> {
                     res.self_path().0.as_str(),
                     "/Resources/s3/Properties/Tags/0/Value"
                 );
-                assert_eq!(res.is_scalar(), true);
+                assert!(res.is_scalar());
             }
 
             QueryResult::UnResolved(ur) => {
@@ -333,18 +329,18 @@ fn map_filter_keys() -> Result<()> {
         "#,
     )?)?;
     let mut eval = BasicQueryTesting {
-        root: Rc::new(path_value.clone()),
+        root: Rc::new(path_value),
         recorder: None,
     };
     let query = AccessQuery::try_from("Resources[ keys == /s3/ ]")?.query;
     let query_results = eval.query(&query)?;
-    assert_eq!(query_results.is_empty(), false);
+    assert!(!query_results.is_empty());
     assert_eq!(query_results.len(), 1); // 2 resources
     for each in query_results {
         match each {
             QueryResult::Resolved(res) => {
                 assert_eq!(res.self_path().0.as_str(), "/Resources/s3Bucket");
-                assert_eq!(res.is_map(), true);
+                assert!(res.is_map());
             }
 
             _ => unreachable!(),
@@ -361,11 +357,8 @@ fn map_filter_keys() -> Result<()> {
         match each {
             QueryResult::Resolved(res) => {
                 let path = res.self_path().0.as_str();
-                assert_eq!(
-                    path == "/Resources/s3Bucket" || path == "/Resources/ec2",
-                    true
-                );
-                assert_eq!(res.is_map(), true);
+                assert!(path == "/Resources/s3Bucket" || path == "/Resources/ec2",);
+                assert!(res.is_map());
             }
 
             _ => unreachable!(),
@@ -382,8 +375,8 @@ fn map_filter_keys() -> Result<()> {
         match each {
             QueryResult::Resolved(res) => {
                 let path = res.self_path().0.as_str();
-                assert_eq!(path == "/Resources/s3Bucket", true);
-                assert_eq!(res.is_map(), true);
+                assert!(path == "/Resources/s3Bucket");
+                assert!(res.is_map());
             }
 
             _ => unreachable!(),
@@ -400,8 +393,8 @@ fn map_filter_keys() -> Result<()> {
         match each {
             QueryResult::Resolved(res) => {
                 let path = res.self_path().0.as_str();
-                assert_eq!(path == "/Resources/s3Bucket", true);
-                assert_eq!(res.is_map(), true);
+                assert!(path == "/Resources/s3Bucket");
+                assert!(res.is_map());
             }
 
             _ => unreachable!(),
@@ -430,12 +423,12 @@ fn test_with_converter() -> Result<()> {
         "#,
     )?)?;
     let mut eval = BasicQueryTesting {
-        root: Rc::new(path_value.clone()),
+        root: Rc::new(path_value),
         recorder: None,
     };
     let query = AccessQuery::try_from("resources.*.properties.tags[*].value")?.query;
     let query_results = eval.query(&query)?;
-    assert_eq!(query_results.is_empty(), false);
+    assert!(!query_results.is_empty());
     assert_eq!(query_results.len(), 2); // 2 resources
     for each in query_results {
         match each {
@@ -445,7 +438,7 @@ fn test_with_converter() -> Result<()> {
                     res.self_path().0.as_str(),
                     "/Resources/s3/Properties/Tags/0/Value"
                 );
-                assert_eq!(res.is_scalar(), true);
+                assert!(res.is_scalar());
             }
 
             QueryResult::UnResolved(ur) => {
@@ -456,6 +449,215 @@ fn test_with_converter() -> Result<()> {
             }
         }
     }
+
+    Ok(())
+}
+
+#[test]
+fn test_handle_function_call() -> Result<()> {
+    let path_value = PathAwareValue::try_from(serde_yaml::from_str::<serde_yaml::Value>(
+        r#"
+        Resources:
+           s3:
+             Type: AWS::S3::Bucket
+             Properties:
+               Tags:
+                 - Key: 1
+                   Value: 1
+           ec2:
+             Type: AWS::EC2::Instance
+             Properties:
+               Arn: arn:aws:newservice:us-west-2:123456789012:Table/extracted
+               ImageId: ami-123456789012
+               Tags: []
+               Policy: |
+                {
+                   "Principal": "*",
+                   "Actions": ["s3*", "ec2*"]
+                }
+        "#,
+    )?)?;
+    let mut eval = BasicQueryTesting {
+        root: Rc::new(path_value),
+        recorder: None,
+    };
+    let query = AccessQuery::try_from("resources.*.properties.tags[*].value")?.query;
+    let query_results = eval.query(&query)?;
+    assert!(!query_results.is_empty());
+    assert_eq!(query_results.len(), 2); // 2 resources
+
+    // regex_replace
+    let query = AccessQuery::try_from("resources.ec2.properties.Arn")?.query;
+    let query_results = eval.query(&query)?;
+    let path = Path::new("Literal".to_string(), 0, 0);
+
+    let extracted_expr = PathAwareValue::String((
+        path.clone(),
+        "^arn:(\\w+):(\\w+):([\\w0-9-]+):(\\d+):(.+)$".to_string(),
+    ));
+    let extracted = QueryResult::Literal(Rc::new(extracted_expr));
+
+    let replaced_expr =
+        PathAwareValue::String((path.clone(), "${1}/${4}/${3}/${2}-${5}".to_string()));
+    let replaced = QueryResult::Literal(Rc::new(replaced_expr));
+
+    let args = vec![
+        query_results[0].clone(),
+        extracted.clone(),
+        replaced.clone(),
+    ];
+
+    let res = try_handle_function_call("regex_replace", &args)?;
+    let path_value = res[0].as_ref().unwrap();
+    if let PathAwareValue::String((_, val)) = path_value {
+        assert_eq!("aws/123456789012/us-west-2/newservice-Table/extracted", val);
+    }
+
+    // too few args
+    let res = try_handle_function_call("regex_replace", &args[0..=1]);
+    assert!(res.is_err());
+    assert!(matches!(res.unwrap_err(), Error::ParseError(_)));
+
+    // extracted expr is invalid
+    let not_a_string = AccessQuery::try_from("resources.ec2.properties.tags")?.query;
+    let query_results2 = eval.query(&not_a_string)?;
+    let args = vec![
+        query_results[0].clone(),
+        query_results2[0].clone(),
+        replaced.clone(),
+    ];
+    let res = try_handle_function_call("regex_replace", &args);
+    assert!(res.is_err());
+    let err = res.unwrap_err();
+    assert!(matches!(err, Error::ParseError(_)));
+    assert_eq!(
+        err.to_string(),
+        String::from("Parser Error when parsing `regex_replace function requires the second argument to be a string`")
+    );
+
+    // extracted expr is invalid
+    let not_a_string = AccessQuery::try_from("resources.ec2.properties.tags")?.query;
+    let query_results2 = eval.query(&not_a_string)?;
+    let args = vec![
+        query_results[0].clone(),
+        extracted.clone(),
+        query_results2[0].clone(),
+    ];
+    let res = try_handle_function_call("regex_replace", &args);
+    assert!(res.is_err());
+    let err = res.unwrap_err();
+    assert!(matches!(err, Error::ParseError(_)));
+    assert_eq!(
+        err.to_string(),
+        String::from("Parser Error when parsing `regex_replace function requires the third argument to be a string`")
+    );
+
+    // first argument is not a string type so res is an Ok(None)
+    let not_a_string = AccessQuery::try_from("resources.ec2.properties.tags")?.query;
+    let query_results2 = eval.query(&not_a_string)?;
+    let args = vec![query_results2[0].clone(), extracted.clone(), replaced];
+    let res = try_handle_function_call("regex_replace", &args)?;
+    assert_eq!(res.len(), 1);
+    assert!(res[0].is_none());
+
+    let from_query = PathAwareValue::Int((path.clone(), 0));
+    let from = QueryResult::Literal(Rc::new(from_query));
+
+    let to_query = PathAwareValue::Int((path.clone(), 3));
+    let to = QueryResult::Literal(Rc::new(to_query));
+
+    // substring - happy path
+    let args = vec![query_results[0].clone(), from.clone(), to.clone()];
+    let res = try_handle_function_call("substring", &args)?;
+
+    let path_value = res[0].as_ref().unwrap();
+    if let PathAwareValue::String((_, val)) = path_value {
+        assert_eq!("arn", val);
+    }
+
+    // first argument is not a string type so res is an Ok(None)
+    let not_a_string = AccessQuery::try_from("resources.ec2.properties.tags")?.query;
+    let query_results2 = eval.query(&not_a_string)?;
+    let args = vec![query_results2[0].clone(), from.clone(), to.clone()];
+    let res = try_handle_function_call("substring", &args)?;
+    assert_eq!(res.len(), 1);
+    assert!(res[0].is_none());
+
+    // second argument is not a number
+    let args = vec![query_results[0].clone(), extracted.clone(), to];
+    let res = try_handle_function_call("substring", &args);
+    assert!(res.is_err());
+    let err = res.unwrap_err();
+    assert!(matches!(err, Error::ParseError(_)));
+    assert_eq!(
+        err.to_string(),
+        String::from("Parser Error when parsing `substring function requires the second argument to be a number`")
+    );
+
+    // third argument is not a number
+    let args = vec![query_results[0].clone(), from.clone(), extracted];
+    let res = try_handle_function_call("substring", &args);
+    assert!(res.is_err());
+    let err = res.unwrap_err();
+    assert!(matches!(err, Error::ParseError(_)));
+    assert_eq!(
+        err.to_string(),
+        String::from("Parser Error when parsing `substring function requires the third argument to be a number`")
+    );
+
+    // invalid fn name
+    let res = try_handle_function_call("fn", &query_results);
+    assert!(res.is_err());
+    let err = res.unwrap_err();
+    assert!(matches!(err, Error::ParseError(_)));
+    assert_eq!(
+        err.to_string(),
+        String::from("Parser Error when parsing `No function named fn`")
+    );
+
+    // join happy path
+    let image_id_query = AccessQuery::try_from("resources.ec2.properties.Arn")?.query;
+    let image_id_result = eval.query(&image_id_query)?;
+
+    let char_delim_query = PathAwareValue::Char((path.clone(), ','));
+    let char_delim = QueryResult::Literal(Rc::new(char_delim_query));
+    let string_delim_query = PathAwareValue::Char((path, ','));
+    let string_delim = QueryResult::Literal(Rc::new(string_delim_query));
+
+    let args = vec![
+        query_results[0].clone(),
+        image_id_result[0].clone(),
+        char_delim,
+    ];
+    let res = try_handle_function_call("join", &args)?;
+    let path_value = res[0].as_ref().unwrap();
+    if let PathAwareValue::String((_, val)) = path_value {
+        assert_eq!(
+            "arn:aws:newservice:us-west-2:123456789012:Table/extracted,arn:aws:newservice:us-west-2:123456789012:Table/extracted",
+            val
+        );
+    }
+
+    let args = vec![
+        query_results[0].clone(),
+        image_id_result[0].clone(),
+        string_delim,
+    ];
+    let res = try_handle_function_call("join", &args)?;
+    let path_value = res[0].as_ref().unwrap();
+    if let PathAwareValue::String((_, val)) = path_value {
+        assert_eq!(
+            "arn:aws:newservice:us-west-2:123456789012:Table/extracted,arn:aws:newservice:us-west-2:123456789012:Table/extracted",
+            val
+        );
+    }
+
+    let args = vec![query_results[0].clone(), image_id_result[0].clone(), from];
+    let res = try_handle_function_call("join", &args);
+    assert!(res.is_err());
+    let err = res.unwrap_err();
+    assert!(matches!(err, Error::ParseError(_)));
+    assert_eq!(err.to_string(), "Parser Error when parsing `join function requires the final argument to be either a char or string`", );
 
     Ok(())
 }

--- a/guard/src/rules/eval_tests.rs
+++ b/guard/src/rules/eval_tests.rs
@@ -3,8 +3,7 @@ use std::io::{stderr, stdout};
 
 use crate::utils::writer::Writer;
 use grep_searcher::SearcherBuilder;
-use indoc::{formatdoc, indoc};
-use rstest::rstest;
+use indoc::formatdoc;
 
 use crate::rules::eval_context::eval_context_tests::BasicQueryTesting;
 use crate::rules::eval_context::{root_scope, EventRecord, RecordTracker};
@@ -44,9 +43,9 @@ fn test_all_unary_functions() -> Result<()> {
     let float_range_value = PathAwareValue::try_from(r#"r(10.0, 20.5]"#)?;
 
     type UnaryTest<'test> = Vec<(
-        Box<dyn Fn(&QueryResult<'_>) -> Result<bool>>,
-        Vec<QueryResult<'test>>,
-        Vec<QueryResult<'test>>,
+        Box<dyn Fn(&QueryResult) -> Result<bool>>,
+        Vec<QueryResult>,
+        Vec<QueryResult>,
     )>;
 
     let tests: UnaryTest = vec![
@@ -54,12 +53,12 @@ fn test_all_unary_functions() -> Result<()> {
             Box::new(exists_operation),
             // Successful tests
             vec![
-                QueryResult::Resolved(&path_value),
-                QueryResult::Resolved(&non_empty_path_value),
+                QueryResult::Resolved(Rc::new(path_value.clone())),
+                QueryResult::Resolved(Rc::new(non_empty_path_value.clone())),
             ],
             // Failure tests
             vec![QueryResult::UnResolved(UnResolved {
-                traversed_to: &path_value,
+                traversed_to: Rc::new(path_value.clone()),
                 reason: None,
                 remaining_query: "".to_string(),
             })],
@@ -68,34 +67,34 @@ fn test_all_unary_functions() -> Result<()> {
             Box::new(element_empty_operation),
             // Successful Tests
             vec![
-                QueryResult::Resolved(&path_value),
-                QueryResult::Resolved(&empty_string_value), // we do check for string empty as well
-                QueryResult::Resolved(&empty_list_value),
+                QueryResult::Resolved(Rc::new(path_value.clone())),
+                QueryResult::Resolved(Rc::new(empty_string_value)), // we do check for string empty as well
+                QueryResult::Resolved(Rc::new(empty_list_value.clone())),
                 QueryResult::UnResolved(UnResolved {
                     remaining_query: "".to_string(),
                     reason: None,
-                    traversed_to: &path_value,
+                    traversed_to: Rc::new(path_value.clone()),
                 }),
             ],
             // Failure tests
             vec![
-                QueryResult::Resolved(&non_empty_path_value),
-                QueryResult::Resolved(&list_value),
-                QueryResult::Resolved(&string_value),
+                QueryResult::Resolved(Rc::new(non_empty_path_value.clone())),
+                QueryResult::Resolved(Rc::new(list_value.clone())),
+                QueryResult::Resolved(Rc::new(string_value.clone())),
             ],
         ),
         (
             Box::new(is_string_operation),
             // Success Case
-            vec![QueryResult::Resolved(&string_value)],
+            vec![QueryResult::Resolved(Rc::new(string_value.clone()))],
             // Failure Cases
             vec![
-                QueryResult::Resolved(&path_value),
-                QueryResult::Resolved(&list_value),
-                QueryResult::Resolved(&int_value),
-                QueryResult::Resolved(&non_empty_path_value),
+                QueryResult::Resolved(Rc::new(path_value.clone())),
+                QueryResult::Resolved(Rc::new(list_value.clone())),
+                QueryResult::Resolved(Rc::new(int_value.clone())),
+                QueryResult::Resolved(Rc::new(non_empty_path_value.clone())),
                 QueryResult::UnResolved(UnResolved {
-                    traversed_to: &path_value,
+                    traversed_to: Rc::new(path_value.clone()),
                     reason: None,
                     remaining_query: "".to_string(),
                 }),
@@ -104,15 +103,15 @@ fn test_all_unary_functions() -> Result<()> {
         (
             Box::new(is_int_operation),
             // Success Case
-            vec![QueryResult::Resolved(&int_value)],
+            vec![QueryResult::Resolved(Rc::new(int_value.clone()))],
             // Failure Cases
             vec![
-                QueryResult::Resolved(&path_value),
-                QueryResult::Resolved(&list_value),
-                QueryResult::Resolved(&string_value),
-                QueryResult::Resolved(&non_empty_path_value),
+                QueryResult::Resolved(Rc::new(path_value.clone())),
+                QueryResult::Resolved(Rc::new(list_value.clone())),
+                QueryResult::Resolved(Rc::new(string_value.clone())),
+                QueryResult::Resolved(Rc::new(non_empty_path_value.clone())),
                 QueryResult::UnResolved(UnResolved {
-                    traversed_to: &path_value,
+                    traversed_to: Rc::new(path_value.clone()),
                     reason: None,
                     remaining_query: "".to_string(),
                 }),
@@ -122,18 +121,18 @@ fn test_all_unary_functions() -> Result<()> {
             Box::new(is_list_operation),
             // Success Case
             vec![
-                QueryResult::Resolved(&list_value),
-                QueryResult::Resolved(&empty_list_value),
+                QueryResult::Resolved(Rc::new(list_value.clone())),
+                QueryResult::Resolved(Rc::new(empty_list_value.clone())),
             ],
             // Failure Cases
             vec![
-                QueryResult::Resolved(&path_value),
-                QueryResult::Resolved(&int_value),
-                QueryResult::Resolved(&int_range_value),
-                QueryResult::Resolved(&string_value),
-                QueryResult::Resolved(&non_empty_path_value),
+                QueryResult::Resolved(Rc::new(path_value.clone())),
+                QueryResult::Resolved(Rc::new(int_value.clone())),
+                QueryResult::Resolved(Rc::new(int_range_value.clone())),
+                QueryResult::Resolved(Rc::new(string_value.clone())),
+                QueryResult::Resolved(Rc::new(non_empty_path_value.clone())),
                 QueryResult::UnResolved(UnResolved {
-                    traversed_to: &path_value,
+                    traversed_to: Rc::new(path_value.clone()),
                     reason: None,
                     remaining_query: "".to_string(),
                 }),
@@ -143,18 +142,18 @@ fn test_all_unary_functions() -> Result<()> {
             Box::new(is_struct_operation),
             // Success Case
             vec![
-                QueryResult::Resolved(&path_value),
-                QueryResult::Resolved(&non_empty_path_value),
+                QueryResult::Resolved(Rc::new(path_value.clone())),
+                QueryResult::Resolved(Rc::new(non_empty_path_value.clone())),
             ],
             // Failure Cases
             vec![
-                QueryResult::Resolved(&int_value),
-                QueryResult::Resolved(&list_value),
-                QueryResult::Resolved(&string_value),
-                QueryResult::Resolved(&empty_list_value),
-                QueryResult::Resolved(&float_value),
+                QueryResult::Resolved(Rc::new(int_value.clone())),
+                QueryResult::Resolved(Rc::new(list_value.clone())),
+                QueryResult::Resolved(Rc::new(string_value.clone())),
+                QueryResult::Resolved(Rc::new(empty_list_value)),
+                QueryResult::Resolved(Rc::new(float_value.clone())),
                 QueryResult::UnResolved(UnResolved {
-                    traversed_to: &path_value,
+                    traversed_to: Rc::new(path_value.clone()),
                     reason: None,
                     remaining_query: "".to_string(),
                 }),
@@ -163,15 +162,15 @@ fn test_all_unary_functions() -> Result<()> {
         (
             Box::new(is_bool_operation),
             // Success Case
-            vec![QueryResult::Resolved(&bool_value)],
+            vec![QueryResult::Resolved(Rc::new(bool_value))],
             // Failure Cases
             vec![
-                QueryResult::Resolved(&path_value),
-                QueryResult::Resolved(&list_value),
-                QueryResult::Resolved(&string_value),
-                QueryResult::Resolved(&non_empty_path_value),
+                QueryResult::Resolved(Rc::new(path_value.clone())),
+                QueryResult::Resolved(Rc::new(list_value.clone())),
+                QueryResult::Resolved(Rc::new(string_value.clone())),
+                QueryResult::Resolved(Rc::new(non_empty_path_value.clone())),
                 QueryResult::UnResolved(UnResolved {
-                    traversed_to: &path_value,
+                    traversed_to: Rc::new(path_value.clone()),
                     reason: None,
                     remaining_query: "".to_string(),
                 }),
@@ -180,16 +179,16 @@ fn test_all_unary_functions() -> Result<()> {
         (
             Box::new(is_float_operation),
             // Success Case
-            vec![QueryResult::Resolved(&float_value)],
+            vec![QueryResult::Resolved(Rc::new(float_value))],
             // Failure Cases
             vec![
-                QueryResult::Resolved(&path_value),
-                QueryResult::Resolved(&list_value),
-                QueryResult::Resolved(&string_value),
-                QueryResult::Resolved(&int_value),
-                QueryResult::Resolved(&non_empty_path_value),
+                QueryResult::Resolved(Rc::new(path_value.clone())),
+                QueryResult::Resolved(Rc::new(list_value.clone())),
+                QueryResult::Resolved(Rc::new(string_value.clone())),
+                QueryResult::Resolved(Rc::new(int_value.clone())),
+                QueryResult::Resolved(Rc::new(non_empty_path_value.clone())),
                 QueryResult::UnResolved(UnResolved {
-                    traversed_to: &path_value,
+                    traversed_to: Rc::new(path_value.clone()),
                     reason: None,
                     remaining_query: "".to_string(),
                 }),
@@ -198,18 +197,18 @@ fn test_all_unary_functions() -> Result<()> {
         (
             Box::new(is_char_range_operation),
             // Success Case
-            vec![QueryResult::Resolved(&char_range_value)],
+            vec![QueryResult::Resolved(Rc::new(char_range_value.clone()))],
             // Failure Cases
             vec![
-                QueryResult::Resolved(&path_value),
-                QueryResult::Resolved(&list_value),
-                QueryResult::Resolved(&string_value),
-                QueryResult::Resolved(&int_value),
-                QueryResult::Resolved(&non_empty_path_value),
-                QueryResult::Resolved(&float_range_value),
-                QueryResult::Resolved(&int_range_value),
+                QueryResult::Resolved(Rc::new(path_value.clone())),
+                QueryResult::Resolved(Rc::new(list_value.clone())),
+                QueryResult::Resolved(Rc::new(string_value.clone())),
+                QueryResult::Resolved(Rc::new(int_value.clone())),
+                QueryResult::Resolved(Rc::new(non_empty_path_value.clone())),
+                QueryResult::Resolved(Rc::new(float_range_value.clone())),
+                QueryResult::Resolved(Rc::new(int_range_value.clone())),
                 QueryResult::UnResolved(UnResolved {
-                    traversed_to: &path_value,
+                    traversed_to: Rc::new(path_value.clone()),
                     reason: None,
                     remaining_query: "".to_string(),
                 }),
@@ -218,18 +217,18 @@ fn test_all_unary_functions() -> Result<()> {
         (
             Box::new(is_int_range_operation),
             // Success Case
-            vec![QueryResult::Resolved(&int_range_value)],
+            vec![QueryResult::Resolved(Rc::new(int_range_value))],
             // Failure Cases
             vec![
-                QueryResult::Resolved(&path_value),
-                QueryResult::Resolved(&list_value),
-                QueryResult::Resolved(&string_value),
-                QueryResult::Resolved(&int_value),
-                QueryResult::Resolved(&non_empty_path_value),
-                QueryResult::Resolved(&float_range_value),
-                QueryResult::Resolved(&char_range_value),
+                QueryResult::Resolved(Rc::new(path_value.clone())),
+                QueryResult::Resolved(Rc::new(list_value.clone())),
+                QueryResult::Resolved(Rc::new(string_value.clone())),
+                QueryResult::Resolved(Rc::new(int_value.clone())),
+                QueryResult::Resolved(Rc::new(non_empty_path_value.clone())),
+                QueryResult::Resolved(Rc::new(float_range_value.clone())),
+                QueryResult::Resolved(Rc::new(char_range_value.clone())),
                 QueryResult::UnResolved(UnResolved {
-                    traversed_to: &path_value,
+                    traversed_to: Rc::new(path_value.clone()),
                     reason: None,
                     remaining_query: "".to_string(),
                 }),
@@ -238,18 +237,18 @@ fn test_all_unary_functions() -> Result<()> {
         (
             Box::new(is_float_range_operation),
             // Success Case
-            vec![QueryResult::Resolved(&float_range_value)],
+            vec![QueryResult::Resolved(Rc::new(float_range_value))],
             // Failure Cases
             vec![
-                QueryResult::Resolved(&path_value),
-                QueryResult::Resolved(&list_value),
-                QueryResult::Resolved(&string_value),
-                QueryResult::Resolved(&int_value),
-                QueryResult::Resolved(&non_empty_path_value),
-                QueryResult::Resolved(&char_range_value),
-                QueryResult::Resolved(&char_range_value),
+                QueryResult::Resolved(Rc::new(path_value.clone())),
+                QueryResult::Resolved(Rc::new(list_value)),
+                QueryResult::Resolved(Rc::new(string_value)),
+                QueryResult::Resolved(Rc::new(int_value)),
+                QueryResult::Resolved(Rc::new(non_empty_path_value)),
+                QueryResult::Resolved(Rc::new(char_range_value.clone())),
+                QueryResult::Resolved(Rc::new(char_range_value)),
                 QueryResult::UnResolved(UnResolved {
-                    traversed_to: &path_value,
+                    traversed_to: Rc::new(path_value),
                     reason: None,
                     remaining_query: "".to_string(),
                 }),
@@ -286,7 +285,7 @@ fn query_empty_and_non_empty() -> Result<()> {
         "#,
     )?)?;
     let mut eval = BasicQueryTesting {
-        root: &path_value,
+        root: Rc::new(path_value.clone()),
         recorder: None,
     };
 
@@ -353,20 +352,20 @@ fn each_lhs_value_not_comparable() -> Result<()> {
         "#,
     )?)?;
     let mut eval = BasicQueryTesting {
-        root: &path_value,
+        root: Rc::new(path_value.clone()),
         recorder: None,
     };
 
     let query_ec2 = AccessQuery::try_from("Resources.ec2.Properties.ImageId")?.query;
     let lhs = eval.query(&query_ec2)?;
     assert_eq!(lhs.len(), 1);
-    let lhs = match lhs[0] {
+    let lhs = match &lhs[0] {
         QueryResult::Resolved(val) => val,
         _ => unreachable!(),
     };
     let rhs_query = AccessQuery::try_from("Parameters.allowed_images")?.query;
     let rhs = eval.query(&rhs_query)?;
-    let result = each_lhs_compare(compare_eq, lhs, &rhs)?;
+    let result = each_lhs_compare(compare_eq, Rc::clone(lhs), &rhs)?;
 
     assert_eq!(result.len(), 1);
     let cmp_result = &result[0];
@@ -376,10 +375,11 @@ fn each_lhs_value_not_comparable() -> Result<()> {
             ..
         }) => {
             let rhs_ptr = match &rhs[0] {
-                QueryResult::Resolved(ptr) => *ptr,
+                QueryResult::Resolved(ptr) => &*ptr,
                 _ => unreachable!(),
             };
-            assert!(std::ptr::eq(rhs_ptr, *value));
+
+            assert_eq!(&**rhs_ptr, &**value);
         }
 
         _ => unreachable!(),
@@ -387,7 +387,7 @@ fn each_lhs_value_not_comparable() -> Result<()> {
 
     let result = each_lhs_compare(
         in_cmp(true), // not in operation
-        lhs,
+        Rc::clone(lhs),
         &rhs,
     )?;
 
@@ -403,7 +403,7 @@ fn each_lhs_value_not_comparable() -> Result<()> {
 
     let result = each_lhs_compare(
         in_cmp(false), // in operation
-        lhs,
+        Rc::clone(lhs),
         &rhs,
     )?;
 
@@ -436,21 +436,21 @@ fn each_lhs_value_eq_compare() -> Result<()> {
         "#,
     )?)?;
     let mut eval = BasicQueryTesting {
-        root: &path_value,
+        root: Rc::new(path_value.clone()),
         recorder: None,
     };
 
     let query_ec2 = AccessQuery::try_from("Resources.ec2.Properties.ImageId")?.query;
     let lhs = eval.query(&query_ec2)?;
     assert_eq!(lhs.len(), 1);
-    let lhs = match lhs[0] {
+    let lhs = match &lhs[0] {
         QueryResult::Resolved(val) => val,
         _ => unreachable!(),
     };
     let rhs_query = AccessQuery::try_from("Parameters.allowed_images[*]")?.query;
     let rhs = eval.query(&rhs_query)?;
     assert_eq!(rhs.len(), 2);
-    let result = each_lhs_compare(compare_eq, lhs, &rhs)?;
+    let result = each_lhs_compare(compare_eq, Rc::clone(lhs), &rhs)?;
 
     assert_eq!(result.len(), 2);
     for cmp_result in result {
@@ -460,7 +460,7 @@ fn each_lhs_value_eq_compare() -> Result<()> {
                 outcome,
             }) => {
                 if outcome {
-                    match (lhs, rhs) {
+                    match (&**lhs, &*rhs) {
                         (PathAwareValue::String((_, s1)), PathAwareValue::String((_, s2))) => {
                             assert_eq!(s1, s2);
                             assert!(!std::ptr::eq(s1, s2));
@@ -469,7 +469,7 @@ fn each_lhs_value_eq_compare() -> Result<()> {
                         (_, _) => unreachable!(),
                     }
                 } else {
-                    match (lhs, rhs) {
+                    match (&**lhs, &*rhs) {
                         (PathAwareValue::String((_, s1)), PathAwareValue::String((_, s2))) => {
                             assert_ne!(s1, s2);
                             assert!(!std::ptr::eq(s1, s2));
@@ -509,7 +509,7 @@ fn each_lhs_value_eq_compare_mixed_comparable() -> Result<()> {
         "#,
     )?)?;
     let mut eval = BasicQueryTesting {
-        root: &path_value,
+        root: Rc::new(path_value.clone()),
         recorder: None,
     };
 
@@ -523,13 +523,15 @@ fn each_lhs_value_eq_compare_mixed_comparable() -> Result<()> {
     assert_eq!(selected_lhs.len(), 2); // 2 statements present
 
     let rhs_value = PathAwareValue::try_from(r#""*""#)?;
-    let rhs_query_result = vec![QueryResult::Resolved(&rhs_value)];
+    let rhs_query_result = vec![QueryResult::Resolved(Rc::new(rhs_value))];
     for each_lhs in selected_lhs {
-        match each_lhs {
+        match &each_lhs {
             QueryResult::Resolved(lhs) => {
-                for cmp_result in
-                    each_lhs_compare(not_compare(compare_eq, true), lhs, &rhs_query_result)?
-                {
+                for cmp_result in each_lhs_compare(
+                    not_compare(compare_eq, true),
+                    Rc::clone(lhs),
+                    &rhs_query_result,
+                )? {
                     match cmp_result {
                         ComparisonResult::Comparable(ComparisonWithRhs { outcome, .. }) => {
                             if !outcome {
@@ -572,7 +574,7 @@ fn each_lhs_value_eq_compare_mixed_single_plus_array_form_correct_exec() -> Resu
         "#,
     )?)?;
     let mut eval = BasicQueryTesting {
-        root: &path_value,
+        root: Rc::new(path_value.clone()),
         recorder: None,
     };
 
@@ -586,11 +588,12 @@ fn each_lhs_value_eq_compare_mixed_single_plus_array_form_correct_exec() -> Resu
     assert_eq!(selected_lhs.len(), 3); // 3 selected values
 
     let rhs_value = PathAwareValue::try_from(r#""*""#)?;
-    let rhs_query_result = vec![QueryResult::Resolved(&rhs_value)];
+    let rhs_query_result = vec![QueryResult::Resolved(Rc::new(rhs_value.clone()))];
     for each_lhs in selected_lhs {
         match each_lhs {
             QueryResult::Resolved(lhs) => {
-                for cmp_result in each_lhs_compare(compare_eq, lhs, &rhs_query_result)? {
+                for cmp_result in each_lhs_compare(compare_eq, Rc::clone(&lhs), &rhs_query_result)?
+                {
                     match cmp_result {
                         ComparisonResult::Comparable(ComparisonWithRhs { outcome, .. }) => {
                             if outcome {
@@ -624,9 +627,11 @@ macro_rules! test_case {
         for each_lhs in values {
             match each_lhs {
                 QueryResult::Resolved(res) => {
-                    for cmp_result in
-                        each_lhs_compare($func, res, &[QueryResult::Resolved(&rhs_value)])?
-                    {
+                    for cmp_result in each_lhs_compare(
+                        $func,
+                        res,
+                        &[QueryResult::Resolved(Rc::new(rhs_value.clone()))],
+                    )? {
                         match cmp_result {
                             ComparisonResult::Comparable(ComparisonWithRhs { outcome, .. }) => {
                                 assert_eq!(outcome, $assert);
@@ -656,7 +661,7 @@ fn binary_comparisons_gt_ge() -> Result<()> {
     "#,
     )?)?;
     let mut eval = BasicQueryTesting {
-        root: &path_value,
+        root: Rc::new(path_value.clone()),
         recorder: None,
     };
 
@@ -766,7 +771,7 @@ fn binary_comparisons_lt_le() -> Result<()> {
     "#,
     )?)?;
     let mut eval = BasicQueryTesting {
-        root: &path_value,
+        root: Rc::new(path_value.clone()),
         recorder: None,
     };
 
@@ -890,7 +895,7 @@ Resources:
     "###;
     let rules = RulesFile::try_from(rulegen_created)?;
     let value = PathAwareValue::try_from(serde_yaml::from_str::<serde_yaml::Value>(template)?)?;
-    let mut root = root_scope(&rules, &value)?;
+    let mut root = root_scope(&rules, Rc::new(value.clone()))?;
     //let mut tracker = RecordTracker::new(&mut root);
     let status = eval_rules_file(&rules, &mut root, None)?;
     assert_eq!(status, Status::PASS);
@@ -932,7 +937,7 @@ fn block_guard_pass() -> Result<()> {
 
     let mut tracker = RecordTracker::new();
     let mut eval = BasicQueryTesting {
-        root: &path_value,
+        root: Rc::new(path_value.clone()),
         recorder: Some(&mut tracker),
     };
     let status = eval_guard_clause(&block_clauses, &mut eval)?;
@@ -1024,7 +1029,7 @@ fn test_guard_10_compatibility_and_diff() -> Result<()> {
     "###;
     let value = PathAwareValue::try_from(serde_yaml::from_str::<serde_yaml::Value>(value_str)?)?;
     let mut eval = BasicQueryTesting {
-        root: &value,
+        root: Rc::new(value.clone()),
         recorder: None,
     };
 
@@ -1079,7 +1084,7 @@ fn test_guard_10_compatibility_and_diff() -> Result<()> {
     "###;
     let value = PathAwareValue::try_from(serde_yaml::from_str::<serde_yaml::Value>(value_str)?)?;
     let mut eval = BasicQueryTesting {
-        root: &value,
+        root: Rc::new(value.clone()),
         recorder: None,
     };
     //
@@ -1122,7 +1127,7 @@ fn block_evaluation() -> Result<()> {
     "#;
     let clause = GuardClause::try_from(clause_str)?;
     let mut eval = BasicQueryTesting {
-        root: &value,
+        root: Rc::new(value.clone()),
         recorder: None,
     };
     let status = eval_guard_clause(&clause, &mut eval)?;
@@ -1160,7 +1165,7 @@ fn block_evaluation_fail() -> Result<()> {
     let value = serde_yaml::from_str::<serde_yaml::Value>(value_str)?;
     let value = PathAwareValue::try_from(value)?;
     let mut eval = BasicQueryTesting {
-        root: &value,
+        root: Rc::new(value.clone()),
         recorder: None,
     };
     let clause_str = r#"Resources.*[ Type == 'AWS::ApiGateway::RestApi' ].Properties {
@@ -1210,7 +1215,7 @@ fn variable_projections() -> Result<()> {
     }
     "#,
     )?;
-    let mut root_scope = root_scope(&rules_file, &path_value)?;
+    let mut root_scope = root_scope(&rules_file, Rc::new(path_value.clone()))?;
     let status = eval_rules_file(&rules_file, &mut root_scope, None)?;
     assert_eq!(status, Status::PASS);
 
@@ -1250,7 +1255,7 @@ fn variable_projections_failures() -> Result<()> {
     }
     "#,
     )?;
-    let mut root_scope = root_scope(&rules_file, &path_value)?;
+    let mut root_scope = root_scope(&rules_file, Rc::new(path_value.clone()))?;
     let status = eval_rules_file(&rules_file, &mut root_scope, None)?;
     assert_eq!(status, Status::FAIL); // for s3_bucket_policy_2.Properties.Bucket == ""
 
@@ -1335,7 +1340,7 @@ fn query_cross_joins() -> Result<()> {
     }
     "#,
     )?;
-    let mut root_scope = root_scope(&rules_files, &path_value)?;
+    let mut root_scope = root_scope(&rules_files, Rc::new(path_value.clone()))?;
     let status = eval_rules_file(&rules_files, &mut root_scope, None)?;
     assert_eq!(status, Status::PASS);
 
@@ -1349,7 +1354,7 @@ fn query_cross_joins() -> Result<()> {
     }
     "#,
     )?;
-    let mut root_scope = eval_context::root_scope(&rules_files, &path_value)?;
+    let mut root_scope = eval_context::root_scope(&rules_files, Rc::new(path_value.clone()))?;
     let status = eval_rules_file(&rules_files, &mut root_scope, None)?;
     assert_eq!(status, Status::SKIP);
 
@@ -1383,7 +1388,7 @@ fn query_cross_joins() -> Result<()> {
     }
     "#,
     )?;
-    let mut root_scope = eval_context::root_scope(&rules_files, &path_value)?;
+    let mut root_scope = eval_context::root_scope(&rules_files, Rc::new(path_value.clone()))?;
     let status = eval_rules_file(&rules_files, &mut root_scope, None)?;
     assert_eq!(status, Status::FAIL);
 
@@ -1401,7 +1406,7 @@ fn query_cross_joins() -> Result<()> {
     }
     "#,
     )?;
-    let mut root_scope = eval_context::root_scope(&rules_files, &path_value)?;
+    let mut root_scope = eval_context::root_scope(&rules_files, Rc::new(path_value.clone()))?;
     let status = eval_rules_file(&rules_files, &mut root_scope, None)?;
     assert_eq!(status, Status::PASS);
 
@@ -1419,7 +1424,7 @@ fn query_cross_joins() -> Result<()> {
     }
     "#,
     )?;
-    let mut root_scope = eval_context::root_scope(&rules_files, &path_value)?;
+    let mut root_scope = eval_context::root_scope(&rules_files, Rc::new(path_value.clone()))?;
     let status = eval_rules_file(&rules_files, &mut root_scope, None)?;
     assert_eq!(status, Status::PASS);
 
@@ -1462,7 +1467,7 @@ fn cross_rule_clause_when_checks() -> Result<()> {
 
     let resources = PathAwareValue::try_from(input)?;
     let rules = RulesFile::try_from(rules_skipped)?;
-    let mut root = root_scope(&rules, &resources)?;
+    let mut root = root_scope(&rules, Rc::new(resources.clone()))?;
     let status = eval_rules_file(&rules, &mut root, None)?;
     assert_eq!(status, Status::PASS);
     let mut expectations = HashMap::with_capacity(4);
@@ -1496,7 +1501,7 @@ fn cross_rule_clause_when_checks() -> Result<()> {
     "#;
 
     let resources = PathAwareValue::try_from(input)?;
-    let mut root = root_scope(&rules, &resources)?;
+    let mut root = root_scope(&rules, Rc::new(resources.clone()))?;
     let status = eval_rules_file(&rules, &mut root, None)?;
     assert_eq!(status, Status::PASS);
     expectations.clear();
@@ -1537,7 +1542,7 @@ fn test_field_type_array_or_single() -> Result<()> {
     let path_value = PathAwareValue::try_from(statements)?;
     let clause = GuardClause::try_from(r#"Statement[*].Action != '*'"#)?;
     let mut eval = BasicQueryTesting {
-        root: &path_value,
+        root: Rc::new(path_value.clone()),
         recorder: None,
     };
     let status = eval_guard_clause(&clause, &mut eval)?;
@@ -1553,7 +1558,7 @@ fn test_field_type_array_or_single() -> Result<()> {
     "#;
     let path_value = PathAwareValue::try_from(statements)?;
     let mut eval = BasicQueryTesting {
-        root: &path_value,
+        root: Rc::new(path_value.clone()),
         recorder: None,
     };
     let status = eval_guard_clause(&clause, &mut eval)?;
@@ -1595,7 +1600,7 @@ fn test_for_in_and_not_in() -> Result<()> {
 
     let value = PathAwareValue::try_from(serde_yaml::from_str::<serde_yaml::Value>(statments)?)?;
     let mut eval = BasicQueryTesting {
-        root: &value,
+        root: Rc::new(value.clone()),
         recorder: None,
     };
 
@@ -1639,7 +1644,7 @@ fn test_rule_with_range_test_and_this() -> Result<()> {
     "#;
     let value = PathAwareValue::try_from(serde_yaml::from_str::<serde_yaml::Value>(value_str)?)?;
     let mut eval = BasicQueryTesting {
-        root: &value,
+        root: Rc::new(value.clone()),
         recorder: None,
     };
     let status = eval_rule(&rule, &mut eval)?;
@@ -1655,7 +1660,7 @@ fn test_rule_with_range_test_and_this() -> Result<()> {
     "#;
     let value = PathAwareValue::try_from(serde_yaml::from_str::<serde_yaml::Value>(value_str)?)?;
     let mut eval = BasicQueryTesting {
-        root: &value,
+        root: Rc::new(value.clone()),
         recorder: None,
     };
     let status = eval_rule(&rule, &mut eval)?;
@@ -1706,7 +1711,7 @@ fn test_inner_when_skipped() -> Result<()> {
     "#;
     let value = PathAwareValue::try_from(serde_yaml::from_str::<serde_yaml::Value>(value_str)?)?;
     let mut eval = BasicQueryTesting {
-        root: &value,
+        root: Rc::new(value.clone()),
         recorder: None,
     };
     let status = eval_rule(&rule, &mut eval)?;
@@ -1728,7 +1733,7 @@ fn test_inner_when_skipped() -> Result<()> {
     "#;
     let value = PathAwareValue::try_from(serde_yaml::from_str::<serde_yaml::Value>(value_str)?)?;
     let mut eval = BasicQueryTesting {
-        root: &value,
+        root: Rc::new(value.clone()),
         recorder: None,
     };
     let status = eval_rule(&rule, &mut eval)?;
@@ -1739,7 +1744,7 @@ fn test_inner_when_skipped() -> Result<()> {
     "#;
     let value = PathAwareValue::try_from(serde_yaml::from_str::<serde_yaml::Value>(value_str)?)?;
     let mut eval = BasicQueryTesting {
-        root: &value,
+        root: Rc::new(value.clone()),
         recorder: None,
     };
     let status = eval_rule(&rule, &mut eval)?;
@@ -1748,7 +1753,7 @@ fn test_inner_when_skipped() -> Result<()> {
     let value_str = r#"{}"#;
     let value = PathAwareValue::try_from(serde_yaml::from_str::<serde_yaml::Value>(value_str)?)?;
     let mut eval = BasicQueryTesting {
-        root: &value,
+        root: Rc::new(value.clone()),
         recorder: None,
     };
     let status = eval_rule(&rule, &mut eval)?;
@@ -1840,7 +1845,7 @@ fn test_multiple_valued_clause_reporting() -> Result<()> {
     let values = PathAwareValue::try_from(serde_yaml::from_str::<serde_yaml::Value>(value)?)?;
     let mut asserter = ReportAssertions {};
     let mut root = BasicQueryTesting {
-        root: &values,
+        root: Rc::new(values.clone()),
         recorder: Some(&mut asserter),
     };
     let status = eval_rule(&rules, &mut root)?;
@@ -1852,7 +1857,7 @@ fn test_multiple_valued_clause_reporting() -> Result<()> {
     "###;
 
     let rules = RulesFile::try_from(rule)?;
-    let mut root = root_scope(&rules, &values)?;
+    let mut root = root_scope(&rules, Rc::new(values.clone()))?;
     let status = eval_rules_file(&rules, &mut root, None)?;
     assert_eq!(status, Status::FAIL);
 
@@ -1905,7 +1910,7 @@ fn test_in_comparison_operator_for_list_of_lists(
 
     let value = PathAwareValue::try_from(serde_yaml::from_str::<serde_yaml::Value>(&template)?)?;
     let rule_eval = RulesFile::try_from(rules)?;
-    let mut context = root_scope(&rule_eval, &value)?;
+    let mut context = root_scope(&rule_eval, Rc::new(value.clone()))?;
     let status = eval_rules_file(&rule_eval, &mut context, None)?;
     assert_eq!(status, status_arg);
 
@@ -1939,7 +1944,7 @@ fn test_type_conversions(#[case] ttl_arg: &str, #[case] status_arg: Status) -> R
 
     let value = PathAwareValue::try_from(serde_yaml::from_str::<serde_yaml::Value>(&template)?)?;
     let rule_eval = RulesFile::try_from(rules)?;
-    let mut context = root_scope(&rule_eval, &value)?;
+    let mut context = root_scope(&rule_eval, Rc::new(value.clone()))?;
     let status = eval_rules_file(&rule_eval, &mut context, None)?;
     assert_eq!(status, status_arg);
 
@@ -1963,7 +1968,7 @@ fn is_bool() -> Result<()> {
     let value = PathAwareValue::try_from(resources_str)?;
     let rules_file = RulesFile::try_from(rule_str)?;
     println!("{:?}", rules_file);
-    let mut eval = root_scope(&rules_file, &value)?;
+    let mut eval = root_scope(&rules_file, Rc::new(value.clone()))?;
     let status = eval_rules_file(&rules_file, &mut eval, None)?;
     assert_eq!(status, Status::PASS);
 
@@ -1973,7 +1978,7 @@ fn is_bool() -> Result<()> {
     }
     "###;
     let value = PathAwareValue::try_from(resources_str)?;
-    let mut eval = root_scope(&rules_file, &value)?;
+    let mut eval = root_scope(&rules_file, Rc::new(value.clone()))?;
     let status = eval_rules_file(&rules_file, &mut eval, None)?;
     assert_eq!(status, Status::FAIL);
 
@@ -1997,7 +2002,7 @@ fn is_int() -> Result<()> {
     let value = PathAwareValue::try_from(resources_str)?;
     let rules_file = RulesFile::try_from(rule_str)?;
     println!("{:?}", rules_file);
-    let mut eval = root_scope(&rules_file, &value)?;
+    let mut eval = root_scope(&rules_file, Rc::new(value.clone()))?;
     let status = eval_rules_file(&rules_file, &mut eval, None)?;
     assert_eq!(status, Status::PASS);
 
@@ -2007,7 +2012,7 @@ fn is_int() -> Result<()> {
     }
     "###;
     let value = PathAwareValue::try_from(resources_str)?;
-    let mut eval = root_scope(&rules_file, &value)?;
+    let mut eval = root_scope(&rules_file, Rc::new(value.clone()))?;
     let status = eval_rules_file(&rules_file, &mut eval, None)?;
     assert_eq!(status, Status::FAIL);
 
@@ -2069,7 +2074,7 @@ fn double_projection_tests() -> Result<()> {
 
     let value = PathAwareValue::try_from(resources_str)?;
     let rules_file = RulesFile::try_from(rule_str)?;
-    let mut eval = root_scope(&rules_file, &value)?;
+    let mut eval = root_scope(&rules_file, Rc::new(value.clone()))?;
     let status = eval_rules_file(&rules_file, &mut eval, None)?;
     assert_eq!(status, Status::PASS);
 
@@ -2086,7 +2091,7 @@ fn double_projection_tests() -> Result<()> {
     }
     "###;
     let value = PathAwareValue::try_from(resources_str)?;
-    let mut eval = root_scope(&rules_file, &value)?;
+    let mut eval = root_scope(&rules_file, Rc::new(value))?;
     let status = eval_rules_file(&rules_file, &mut eval, None)?;
     assert_eq!(status, Status::FAIL);
 
@@ -2163,7 +2168,7 @@ fn test_rules_with_some_clauses() -> Result<()> {
     "#;
     let value = PathAwareValue::try_from(resources)?;
     let parsed = RulesFile::try_from(query)?;
-    let mut eval = root_scope(&parsed, &value)?;
+    let mut eval = root_scope(&parsed, Rc::new(value.clone()))?;
     let selected = eval.resolve_variable("x")?;
     println!("{:?}", selected);
     assert_eq!(selected.len(), 1);
@@ -2194,7 +2199,7 @@ fn test_support_for_atleast_one_match_clause() -> Result<()> {
     "#;
     let values = PathAwareValue::try_from(values_str)?;
     let mut eval = BasicQueryTesting {
-        root: &values,
+        root: Rc::new(values.clone()),
         recorder: None,
     };
 
@@ -2207,7 +2212,7 @@ fn test_support_for_atleast_one_match_clause() -> Result<()> {
     let values_str = r#"{ Tags: [] }"#;
     let values = PathAwareValue::try_from(values_str)?;
     let mut eval = BasicQueryTesting {
-        root: &values,
+        root: Rc::new(values.clone()),
         recorder: None,
     };
     let status = eval_guard_clause(&clause_some, &mut eval)?;
@@ -2219,7 +2224,7 @@ fn test_support_for_atleast_one_match_clause() -> Result<()> {
     let values_str = r#"{ }"#;
     let values = PathAwareValue::try_from(values_str)?;
     let mut eval = BasicQueryTesting {
-        root: &values,
+        root: Rc::new(values.clone()),
         recorder: None,
     };
     let status = eval_guard_clause(&clause_some, &mut eval)?;
@@ -2256,7 +2261,7 @@ fn test_support_for_atleast_one_match_clause() -> Result<()> {
     let _resources = PathAwareValue::try_from(resources_str)?;
     let selection_query = AccessQuery::try_from(selection_str)?;
     let mut eval = BasicQueryTesting {
-        root: &values,
+        root: Rc::new(values.clone()),
         recorder: None,
     };
     let selected = eval.query(&selection_query.query)?;
@@ -2294,7 +2299,7 @@ rule check_rest_api_is_private_and_has_access {
     }
 }"#;
     let rule = RulesFile::try_from(rule_str)?;
-    let mut root = root_scope(&rule, &value)?;
+    let mut root = root_scope(&rule, Rc::new(value.clone()))?;
     let status = eval_rules_file(&rule, &mut root, None)?;
     assert_eq!(status, Status::FAIL);
 
@@ -2315,7 +2320,7 @@ rule check_rest_api_is_private_and_has_access {
     "#;
     let value = serde_yaml::from_str::<serde_yaml::Value>(value_str)?;
     let value = PathAwareValue::try_from(value)?;
-    let mut root = root_scope(&rule, &value)?;
+    let mut root = root_scope(&rule, Rc::new(value.clone()))?;
     let status = eval_rules_file(&rule, &mut root, None)?;
     assert_eq!(status, Status::PASS);
 
@@ -2328,7 +2333,7 @@ fn ensure_all_list_value_access_on_empty_fails() -> Result<()> {
     let values = PathAwareValue::try_from(serde_yaml::from_str::<serde_yaml::Value>(resources)?)?;
     let claused_failure_spec = GuardClause::try_from(r#"Tags[*].Key == /Name/"#)?;
     let mut eval = BasicQueryTesting {
-        root: &values,
+        root: Rc::new(values.clone()),
         recorder: None,
     };
     let status = eval_guard_clause(&claused_failure_spec, &mut eval)?;
@@ -2336,7 +2341,7 @@ fn ensure_all_list_value_access_on_empty_fails() -> Result<()> {
 
     let claused_failure_spec = GuardClause::try_from(r#"some Tags[*].Key == /Name/"#)?;
     let mut eval = BasicQueryTesting {
-        root: &values,
+        root: Rc::new(values.clone()),
         recorder: None,
     };
     let status = eval_guard_clause(&claused_failure_spec, &mut eval)?;
@@ -2344,7 +2349,7 @@ fn ensure_all_list_value_access_on_empty_fails() -> Result<()> {
 
     let claused_failure_spec = GuardClause::try_from(r#"Tags[*] { Key == /Name/ }"#)?;
     let mut eval = BasicQueryTesting {
-        root: &values,
+        root: Rc::new(values.clone()),
         recorder: None,
     };
     let status = eval_guard_clause(&claused_failure_spec, &mut eval)?;
@@ -2352,7 +2357,7 @@ fn ensure_all_list_value_access_on_empty_fails() -> Result<()> {
 
     let claused_failure_spec = GuardClause::try_from(r#"some Tags[*] { Key == /Name/ }"#)?;
     let mut eval = BasicQueryTesting {
-        root: &values,
+        root: Rc::new(values.clone()),
         recorder: None,
     };
     let status = eval_guard_clause(&claused_failure_spec, &mut eval)?;
@@ -2360,7 +2365,7 @@ fn ensure_all_list_value_access_on_empty_fails() -> Result<()> {
 
     let claused_failure_spec = GuardClause::try_from(r#"Tags !empty"#)?;
     let mut eval = BasicQueryTesting {
-        root: &values,
+        root: Rc::new(values.clone()),
         recorder: None,
     };
     let status = eval_guard_clause(&claused_failure_spec, &mut eval)?;
@@ -2368,7 +2373,7 @@ fn ensure_all_list_value_access_on_empty_fails() -> Result<()> {
 
     let claused_failure_spec = GuardClause::try_from(r#"Tags empty"#)?;
     let mut eval = BasicQueryTesting {
-        root: &values,
+        root: Rc::new(values.clone()),
         recorder: None,
     };
     let status = eval_guard_clause(&claused_failure_spec, &mut eval)?;
@@ -2376,7 +2381,7 @@ fn ensure_all_list_value_access_on_empty_fails() -> Result<()> {
 
     let claused_failure_spec = GuardClause::try_from(r#"Tags[*] !empty"#)?;
     let mut eval = BasicQueryTesting {
-        root: &values,
+        root: Rc::new(values.clone()),
         recorder: None,
     };
     let status = eval_guard_clause(&claused_failure_spec, &mut eval)?;
@@ -2384,7 +2389,7 @@ fn ensure_all_list_value_access_on_empty_fails() -> Result<()> {
 
     let claused_failure_spec = GuardClause::try_from(r#"Tags[*] empty"#)?;
     let mut eval = BasicQueryTesting {
-        root: &values,
+        root: Rc::new(values.clone()),
         recorder: None,
     };
     let status = eval_guard_clause(&claused_failure_spec, &mut eval)?;
@@ -2398,7 +2403,7 @@ fn ensure_all_map_values_access_on_empty_fails() -> Result<()> {
     let resources = r#"Resources: {}"#;
     let values = PathAwareValue::try_from(serde_yaml::from_str::<serde_yaml::Value>(resources)?)?;
     let mut eval = BasicQueryTesting {
-        root: &values,
+        root: Rc::new(values.clone()),
         recorder: None,
     };
 
@@ -2434,7 +2439,7 @@ fn ensure_all_map_values_access_on_empty_fails() -> Result<()> {
     "#;
     let _value = PathAwareValue::try_from(serde_yaml::from_str::<serde_yaml::Value>(resources)?)?;
     let mut eval = BasicQueryTesting {
-        root: &values,
+        root: Rc::new(values.clone()),
         recorder: None,
     };
     let status = eval_guard_clause(&clause_failure_spec, &mut eval)?;
@@ -2446,7 +2451,7 @@ fn ensure_all_map_values_access_on_empty_fails() -> Result<()> {
     let resources = r#"{}"#;
     let values = PathAwareValue::try_from(serde_yaml::from_str::<serde_yaml::Value>(resources)?)?;
     let mut eval = BasicQueryTesting {
-        root: &values,
+        root: Rc::new(values.clone()),
         recorder: None,
     };
     let clause_failure_spec = GuardClause::try_from(r#"Resources exists"#)?;
@@ -2527,7 +2532,7 @@ fn filter_based_join_clauses_failures_and_skips() -> Result<()> {
     let rules_file = RulesFile::try_from(rules)?;
     let path_value =
         PathAwareValue::try_from(serde_yaml::from_str::<serde_yaml::Value>(resources)?)?;
-    let mut eval = root_scope(&rules_file, &path_value)?;
+    let mut eval = root_scope(&rules_file, Rc::new(path_value.clone()))?;
     let status = eval_rules_file(&rules_file, &mut eval, None)?;
     assert_eq!(status, Status::FAIL);
 
@@ -2580,7 +2585,7 @@ fn filter_based_join_clauses_failures_and_skips() -> Result<()> {
     "#;
     let path_value =
         PathAwareValue::try_from(serde_yaml::from_str::<serde_yaml::Value>(resources)?)?;
-    let mut eval = root_scope(&rules_file, &path_value)?;
+    let mut eval = root_scope(&rules_file, Rc::new(path_value.clone()))?;
     let status = eval_rules_file(&rules_file, &mut eval, None)?;
     assert_eq!(status, Status::SKIP);
 
@@ -2606,7 +2611,7 @@ fn filter_based_join_clauses_failures_and_skips() -> Result<()> {
     "#;
     let path_value =
         PathAwareValue::try_from(serde_yaml::from_str::<serde_yaml::Value>(resources)?)?;
-    let mut eval = eval.reset_root(&path_value)?;
+    let mut eval = eval.reset_root(Rc::new(path_value.clone()))?;
     let status = eval_rules_file(&rules_file, &mut eval, None)?;
     assert_eq!(status, Status::SKIP);
 
@@ -2634,7 +2639,9 @@ fn filter_based_join_clauses_failures_and_skips() -> Result<()> {
     "###;
     let path_value =
         PathAwareValue::try_from(serde_yaml::from_str::<serde_yaml::Value>(resources)?)?;
-    let mut eval = eval.reset_root(&path_value)?;
+
+    let mut eval = eval.reset_root(Rc::new(path_value.clone()))?;
+
     //
     // Let us track failures and assert on what must be observed
     //
@@ -2706,7 +2713,7 @@ fn filter_based_with_join_pass_use_cases() -> Result<()> {
     let path_value =
         PathAwareValue::try_from(serde_yaml::from_str::<serde_yaml::Value>(resources)?)?;
     let rules_file = RulesFile::try_from(rules)?;
-    let mut eval = root_scope(&rules_file, &path_value)?;
+    let mut eval = root_scope(&rules_file, Rc::new(path_value.clone()))?;
     let status = eval_rules_file(&rules_file, &mut eval, None)?;
     assert_eq!(status, Status::PASS);
 
@@ -2745,7 +2752,7 @@ fn rule_clause_tests() -> Result<()> {
     "#;
 
     let value = PathAwareValue::try_from(v)?;
-    let mut eval = root_scope(&rule, &value)?;
+    let mut eval = root_scope(&rule, Rc::new(value.clone()))?;
     let status = eval_rules_file(&rule, &mut eval, None)?;
     assert_eq!(Status::PASS, status);
 
@@ -2767,7 +2774,7 @@ fn rule_clause_tests() -> Result<()> {
     "#;
 
     let value = PathAwareValue::try_from(v)?;
-    let mut eval = eval.reset_root(&value)?;
+    let mut eval = eval.reset_root(Rc::new(value.clone()))?;
     let status = eval_rules_file(&rule, &mut eval, None)?;
     assert_eq!(Status::FAIL, status);
 
@@ -2828,7 +2835,7 @@ fn rule_test_type_blocks() -> Result<()> {
 
     let root = PathAwareValue::try_from(serde_yaml::from_str::<serde_yaml::Value>(value)?)?;
     let rules_file = RulesFile::try_from(r)?;
-    let mut root_context = root_scope(&rules_file, &root)?;
+    let mut root_context = root_scope(&rules_file, Rc::new(root.clone()))?;
     let status = eval_rules_file(&rules_file, &mut root_context, None)?;
     assert_eq!(Status::FAIL, status);
 
@@ -2921,7 +2928,7 @@ rule iam_basic_checks when iam_resources_exists {
 
     let root = PathAwareValue::try_from(value)?;
     let rules_file = RulesFile::try_from(file)?;
-    let mut root_context = root_scope(&rules_file, &root)?;
+    let mut root_context = root_scope(&rules_file, Rc::new(root.clone()))?;
     let status = eval_rules_file(&rules_file, &mut root_context, None)?;
     assert_eq!(Status::PASS, status);
 
@@ -2989,7 +2996,7 @@ rule iam_basic_checks {
 
     let root = PathAwareValue::try_from(value)?;
     let rules_file = RulesFile::try_from(file)?;
-    let mut root_context = root_scope(&rules_file, &root)?;
+    let mut root_context = root_scope(&rules_file, Rc::new(root.clone()))?;
 
     let status = eval_rules_file(&rules_file, &mut root_context, None)?;
     assert_eq!(Status::FAIL, status);
@@ -3057,7 +3064,7 @@ rule iam_basic_checks {
     "###;
 
     let root = PathAwareValue::try_from(value)?;
-    let mut root_context = root_context.reset_root(&root)?;
+    let mut root_context = root_context.reset_root(Rc::new(root.clone()))?;
     let status = eval_rules_file(&rules_file, &mut root_context, None)?;
     assert_eq!(Status::FAIL, status);
 
@@ -3145,7 +3152,7 @@ fn test_iam_statement_clauses() -> Result<()> {
     "###;
     let values = PathAwareValue::try_from(sample)?;
     let mut eval = BasicQueryTesting {
-        root: &values,
+        root: Rc::new(values.clone()),
         recorder: None,
     };
 
@@ -3182,7 +3189,7 @@ fn test_iam_statement_clauses() -> Result<()> {
     }"###;
     let value = PathAwareValue::try_from(sample)?;
     let mut eval = BasicQueryTesting {
-        root: &value,
+        root: Rc::new(value.clone()),
         recorder: None,
     };
     let status = eval_guard_clause(&parsed, &mut eval)?;
@@ -3203,7 +3210,7 @@ fn test_iam_statement_clauses() -> Result<()> {
     }"###;
     let value = PathAwareValue::try_from(sample)?;
     let mut eval = BasicQueryTesting {
-        root: &value,
+        root: Rc::new(value.clone()),
         recorder: None,
     };
     let status = eval_guard_clause(&parsed, &mut eval)?;
@@ -3225,7 +3232,7 @@ fn test_iam_statement_clauses() -> Result<()> {
     }"###;
     let value = PathAwareValue::try_from(sample)?;
     let mut eval = BasicQueryTesting {
-        root: &value,
+        root: Rc::new(value.clone()),
         recorder: None,
     };
     let status = eval_guard_clause(&parsed, &mut eval)?;
@@ -3234,7 +3241,7 @@ fn test_iam_statement_clauses() -> Result<()> {
     let value = PathAwareValue::try_from(SAMPLE)?;
     let parsed = GuardClause::try_from(clause)?;
     let mut eval = BasicQueryTesting {
-        root: &value,
+        root: Rc::new(value.clone()),
         recorder: None,
     };
     let status = eval_guard_clause(&parsed, &mut eval)?;
@@ -3297,7 +3304,7 @@ rule check_rest_api_private {
 
     let values = PathAwareValue::try_from(resources)?;
     let mut eval = BasicQueryTesting {
-        root: &values,
+        root: Rc::new(values.clone()),
         recorder: None,
     };
     let status = eval_rule(&rule, &mut eval)?;
@@ -3362,7 +3369,7 @@ rule check_rest_api_private {
 
     let values = PathAwareValue::try_from(resources)?;
     let mut eval = BasicQueryTesting {
-        root: &values,
+        root: Rc::new(values.clone()),
         recorder: None,
     };
     let status = eval_rule(&rule, &mut eval)?;
@@ -3406,7 +3413,7 @@ rule check_rest_api_private {
 
     let values = PathAwareValue::try_from(resources)?;
     let mut eval = BasicQueryTesting {
-        root: &values,
+        root: Rc::new(values.clone()),
         recorder: None,
     };
     let status = eval_rule(&rule, &mut eval)?;
@@ -3470,7 +3477,7 @@ rule deny_task_role_no_permission_boundary when %ecs_tasks !EMPTY {
 
     let rules_file = RulesFile::try_from(rules)?;
     let value = PathAwareValue::try_from(resources)?;
-    let mut eval = root_scope(&rules_file, &value)?;
+    let mut eval = root_scope(&rules_file, Rc::new(value.clone()))?;
     let status = eval_rules_file(&rules_file, &mut eval, None)?;
 
     println!("{}", status);
@@ -3587,7 +3594,7 @@ rule deny_egress when %sgs NOT EMPTY {
     };
 
     for (index, each) in samples.iter().enumerate() {
-        let mut root_context = root_scope(&rules_file, each)?;
+        let mut root_context = root_scope(&rules_file, Rc::new(each.clone()))?;
         let status = eval_rules_file(&rules_file, &mut root_context, None)?;
         println!("{}", format!("Status {} = {}", index, status).underline());
     }
@@ -3787,7 +3794,7 @@ fn test_s3_bucket_pro_serv() -> Result<()> {
     ];
 
     for (idx, each) in parsed_values.iter().enumerate() {
-        let mut root_scope = root_scope(&s3_rule, each)?;
+        let mut root_scope = root_scope(&s3_rule, Rc::new(each.clone()))?;
         let status = eval_rules_file(&s3_rule, &mut root_scope, None)?;
         assert_eq!(status, expectations[idx]);
     }
@@ -3801,7 +3808,7 @@ fn match_lhs_with_rhs_single_element_pass() -> Result<()> {
     let path_value = PathAwareValue::try_from(serde_yaml::from_str::<serde_yaml::Value>(value)?)?;
     let guard_clause = GuardClause::try_from(clause)?;
     let mut eval = BasicQueryTesting {
-        root: &path_value,
+        root: Rc::new(path_value.clone()),
         recorder: None,
     };
     let status = eval_guard_clause(&guard_clause, &mut eval)?;
@@ -3812,7 +3819,7 @@ fn match_lhs_with_rhs_single_element_pass() -> Result<()> {
     let path_value = PathAwareValue::try_from(serde_yaml::from_str::<serde_yaml::Value>(value)?)?;
     let guard_clause = GuardClause::try_from(clause)?;
     let mut eval = BasicQueryTesting {
-        root: &path_value,
+        root: Rc::new(path_value.clone()),
         recorder: None,
     };
     let status = eval_guard_clause(&guard_clause, &mut eval)?;
@@ -3861,7 +3868,7 @@ fn parameterized_evaluations() -> Result<()> {
     let template =
         PathAwareValue::try_from(serde_yaml::from_str::<serde_yaml::Value>(template_value)?)?;
 
-    let mut eval = root_scope(&rules_files, &template)?;
+    let mut eval = root_scope(&rules_files, Rc::new(template.clone()))?;
     let status = eval_rules_file(&rules_files, &mut eval, None)?;
     let top = eval.reset_recorder().extract();
     let mut writer = Writer::new(Stdout(stdout()), Stderr(stderr()));
@@ -3882,7 +3889,7 @@ fn parameterized_evaluations() -> Result<()> {
     let config_value =
         PathAwareValue::try_from(serde_yaml::from_str::<serde_yaml::Value>(aws_config_value)?)?;
 
-    let mut eval = root_scope(&rules_files, &config_value)?;
+    let mut eval = root_scope(&rules_files, Rc::new(config_value.clone()))?;
     let status = eval_rules_file(&rules_files, &mut eval, None)?;
     let top = eval.reset_recorder().extract();
     crate::commands::validate::print_verbose_tree(&top, &mut writer);
@@ -3922,7 +3929,7 @@ fn using_resource_names_for_assessment() -> Result<()> {
     "###;
 
     let rules = RulesFile::try_from(rules_file)?;
-    let mut eval = root_scope(&rules, &value)?;
+    let mut eval = root_scope(&rules, Rc::new(value.clone()))?;
     let status = eval_rules_file(&rules, &mut eval, None)?;
     assert_eq!(status, Status::FAIL);
 
@@ -3958,7 +3965,7 @@ fn test_string_in_comparison() -> Result<()> {
     "###;
 
     let rules_files = RulesFile::try_from(rules)?;
-    let mut eval = root_scope(&rules_files, &value)?;
+    let mut eval = root_scope(&rules_files, Rc::new(value.clone()))?;
     let status = eval_rules_file(&rules_files, &mut eval, None)?;
     assert_eq!(status, Status::PASS);
 

--- a/guard/src/rules/evaluate.rs
+++ b/guard/src/rules/evaluate.rs
@@ -124,6 +124,7 @@ where
     Ok((lhs_cmp, results))
 }
 
+#[allow(clippy::never_loop)]
 fn compare_loop<F>(
     lhs: &Vec<&PathAwareValue>,
     rhs: &Vec<&PathAwareValue>,
@@ -145,10 +146,8 @@ where
                     if *each {
                         break 'outer true;
                     }
-                } else {
-                    if !*each {
-                        break 'outer false;
-                    }
+                } else if !*each {
+                    break 'outer false;
                 }
             }
             if atleast_one {
@@ -332,6 +331,7 @@ where
 }
 
 impl<'loc> Evaluate for GuardAccessClause<'loc> {
+    #[allow(clippy::never_loop)]
     fn evaluate<'s>(
         &self,
         context: &'s PathAwareValue,
@@ -727,6 +727,7 @@ impl<'loc> Evaluate for GuardNamedRuleClause<'loc> {
 }
 
 impl<'loc> Evaluate for GuardClause<'loc> {
+    #[allow(clippy::never_loop)]
     fn evaluate<'s>(
         &self,
         context: &'s PathAwareValue,
@@ -776,6 +777,7 @@ impl<'loc, T: Evaluate + 'loc> Evaluate for Block<'loc, T> {
 }
 
 impl<'loc, T: Evaluate + 'loc> Evaluate for Conjunctions<T> {
+    #[allow(clippy::never_loop)]
     fn evaluate<'s>(
         &self,
         context: &'s PathAwareValue,
@@ -833,6 +835,7 @@ impl<'loc, T: Evaluate + 'loc> Evaluate for Conjunctions<T> {
 }
 
 impl<'loc> Evaluate for BlockGuardClause<'loc> {
+    #[allow(clippy::never_loop)]
     fn evaluate<'s>(
         &self,
         context: &'s PathAwareValue,
@@ -918,6 +921,7 @@ impl<'loc> Evaluate for WhenGuardClause<'loc> {
 }
 
 impl<'loc> Evaluate for TypeBlock<'loc> {
+    #[allow(clippy::never_loop)]
     fn evaluate<'s>(
         &self,
         context: &'s PathAwareValue,
@@ -1102,6 +1106,8 @@ fn extract_variables<'s, 'loc>(
 }
 
 #[derive(Debug)]
+#[deprecated]
+#[allow(dead_code)]
 pub(crate) struct RootScope<'s, 'loc> {
     rules: &'s RulesFile<'loc>,
     input_context: &'s PathAwareValue,
@@ -1144,7 +1150,7 @@ impl<'s, 'loc> EvaluationContext for RootScope<'s, 'loc> {
         }
         return if let Some((key, query)) = self.pending_queries.get_key_value(variable) {
             let all = (*query).match_all;
-            let query: &[QueryPart<'_>] = &(*query).query;
+            let query = &query.query;
             let values = match query[0].variable() {
                 Some(var) => resolve_variable_query(all, var, query, self)?,
                 None => {
@@ -1200,6 +1206,7 @@ impl<'s, 'loc> EvaluationContext for RootScope<'s, 'loc> {
     fn start_evaluation(&self, _eval_type: EvaluationType, _context: &str) {}
 }
 
+#[allow(dead_code)]
 pub(crate) struct BlockScope<'s, T> {
     block_type: &'s Block<'s, T>,
     input_context: &'s PathAwareValue,
@@ -1240,7 +1247,7 @@ impl<'s, T> EvaluationContext for BlockScope<'s, T> {
         }
         return if let Some((key, query)) = self.pending_queries.get_key_value(variable) {
             let all = (*query).match_all;
-            let query: &[QueryPart<'_>] = &(*query).query;
+            let query = &query.query;
             let values = match query[0].variable() {
                 Some(var) => resolve_variable_query(all, var, query, self)?,
                 None => {

--- a/guard/src/rules/evaluate_tests.rs
+++ b/guard/src/rules/evaluate_tests.rs
@@ -30,7 +30,7 @@ fn read_data(file: File) -> Result<Value> {
     let context = read_file_content(file)?;
     match serde_json::from_str::<serde_json::Value>(&context) {
         Ok(value) => Value::try_from(value),
-        Err(e) => {
+        Err(_) => {
             let value = serde_yaml::from_str::<serde_yaml::Value>(&context)?;
             Value::try_from(value)
         }
@@ -2145,20 +2145,20 @@ fn test_multiple_valued_clause_reporting() -> Result<()> {
     "###;
 
     #[derive(Debug, Clone)]
-    struct Reporter {};
+    struct Reporter {}
     impl EvaluationContext for Reporter {
-        fn resolve_variable(&self, variable: &str) -> Result<Vec<&PathAwareValue>> {
+        fn resolve_variable(&self, _: &str) -> Result<Vec<&PathAwareValue>> {
             todo!()
         }
 
-        fn rule_status(&self, rule_name: &str) -> Result<Status> {
+        fn rule_status(&self, _: &str) -> Result<Status> {
             todo!()
         }
 
         fn end_evaluation(
             &self,
             eval_type: EvaluationType,
-            context: &str,
+            _: &str,
             msg: String,
             from: Option<PathAwareValue>,
             to: Option<PathAwareValue>,
@@ -2187,7 +2187,7 @@ fn test_multiple_valued_clause_reporting() -> Result<()> {
             }
         }
 
-        fn start_evaluation(&self, eval_type: EvaluationType, context: &str) {}
+        fn start_evaluation(&self, _: EvaluationType, _: &str) {}
     }
 
     let rules = Rule::try_from(rule)?;
@@ -2223,7 +2223,8 @@ fn test_multiple_valued_clause_reporting_var_access() -> Result<()> {
 
     struct Reporter<'a> {
         root: &'a dyn EvaluationContext,
-    };
+    }
+
     impl<'a> EvaluationContext for Reporter<'a> {
         fn resolve_variable(&self, variable: &str) -> Result<Vec<&PathAwareValue>> {
             self.root.resolve_variable(variable)

--- a/guard/src/rules/exprs.rs
+++ b/guard/src/rules/exprs.rs
@@ -5,6 +5,7 @@ use crate::rules::path_value::PathAwareValue;
 use serde::{Deserialize, Serialize};
 use std::fmt::Formatter;
 use std::hash::Hash;
+use std::rc::Rc;
 
 #[derive(Eq, PartialEq, Debug, Clone, Serialize, Deserialize, Hash)]
 pub(crate) struct FileLocation<'loc> {
@@ -380,7 +381,7 @@ impl<'loc> std::fmt::Display for LetValue<'loc> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
             LetValue::AccessClause(acc) => acc.fmt(f)?,
-            LetValue::Value(v) => write!(f, "{}", ValueOnlyDisplay(v))?,
+            LetValue::Value(v) => write!(f, "{}", ValueOnlyDisplay(Rc::new(v.clone())))?,
             LetValue::FunctionCall(call_expr) => write!(f, "{}", call_expr)?,
         }
         Ok(())

--- a/guard/src/rules/functions/collections.rs
+++ b/guard/src/rules/functions/collections.rs
@@ -1,6 +1,6 @@
 use crate::rules::QueryResult;
 
-pub(crate) fn count(args: &[QueryResult<'_>]) -> u32 {
+pub(crate) fn count(args: &[QueryResult]) -> u32 {
     args.iter().fold(0, |each, entry| match entry {
         QueryResult::Literal(_) | QueryResult::Resolved(_) => each + 1,
         _ => each,

--- a/guard/src/rules/functions/collections.rs
+++ b/guard/src/rules/functions/collections.rs
@@ -1,10 +1,18 @@
-use crate::rules::QueryResult;
+use crate::rules::{path_value::PathAwareValue, QueryResult};
 
 pub(crate) fn count(args: &[QueryResult]) -> u32 {
     args.iter().fold(0, |each, entry| match entry {
         QueryResult::Literal(_) | QueryResult::Resolved(_) => each + 1,
         _ => each,
     })
+}
+
+pub(crate) fn new_count(args: std::rc::Rc<PathAwareValue>) -> u32 {
+    match &*args {
+        PathAwareValue::List((_, l)) => l.len() as u32,
+        PathAwareValue::Map((_, m)) => m.keys.len() as u32,
+        _ => unreachable!(),
+    }
 }
 
 #[cfg(test)]

--- a/guard/src/rules/functions/collections.rs
+++ b/guard/src/rules/functions/collections.rs
@@ -1,18 +1,10 @@
-use crate::rules::{path_value::PathAwareValue, QueryResult};
+use crate::rules::QueryResult;
 
 pub(crate) fn count(args: &[QueryResult]) -> u32 {
     args.iter().fold(0, |each, entry| match entry {
         QueryResult::Literal(_) | QueryResult::Resolved(_) => each + 1,
         _ => each,
     })
-}
-
-pub(crate) fn new_count(args: std::rc::Rc<PathAwareValue>) -> u32 {
-    match &*args {
-        PathAwareValue::List((_, l)) => l.len() as u32,
-        PathAwareValue::Map((_, m)) => m.keys.len() as u32,
-        _ => unreachable!(),
-    }
 }
 
 #[cfg(test)]

--- a/guard/src/rules/functions/collections_tests.rs
+++ b/guard/src/rules/functions/collections_tests.rs
@@ -1,10 +1,10 @@
 use super::*;
 use crate::rules::eval_context::eval_context_tests::BasicQueryTesting;
-use crate::rules::eval_context::*;
 use crate::rules::exprs::AccessQuery;
 use crate::rules::path_value::*;
 use crate::rules::EvalContext;
 use std::convert::TryFrom;
+use std::rc::Rc;
 
 #[test]
 fn test_count_function() -> crate::rules::Result<()> {
@@ -12,7 +12,7 @@ fn test_count_function() -> crate::rules::Result<()> {
     let value = PathAwareValue::try_from(serde_yaml::from_str::<serde_yaml::Value>(value_str)?)?;
 
     let mut eval = BasicQueryTesting {
-        root: &value,
+        root: Rc::new(value.clone()),
         recorder: None,
     };
     let query = AccessQuery::try_from(r#"Resources"#)?;
@@ -24,7 +24,7 @@ fn test_count_function() -> crate::rules::Result<()> {
     let value = PathAwareValue::try_from(serde_yaml::from_str::<serde_yaml::Value>(value_str)?)?;
 
     let mut eval = BasicQueryTesting {
-        root: &value,
+        root: Rc::new(value.clone()),
         recorder: None,
     };
     let query = AccessQuery::try_from(r#"Resources"#)?;
@@ -41,7 +41,7 @@ fn test_count_function() -> crate::rules::Result<()> {
     "#;
     let value = PathAwareValue::try_from(serde_yaml::from_str::<serde_yaml::Value>(value_str)?)?;
     let mut eval = BasicQueryTesting {
-        root: &value,
+        root: Rc::new(value.clone()),
         recorder: None,
     };
     let query = AccessQuery::try_from(r#"Resources[ Type == 'AWS::S3::Bucket' ]"#)?;

--- a/guard/src/rules/functions/collections_tests.rs
+++ b/guard/src/rules/functions/collections_tests.rs
@@ -12,7 +12,7 @@ fn test_count_function() -> crate::rules::Result<()> {
     let value = PathAwareValue::try_from(serde_yaml::from_str::<serde_yaml::Value>(value_str)?)?;
 
     let mut eval = BasicQueryTesting {
-        root: Rc::new(value.clone()),
+        root: Rc::new(value),
         recorder: None,
     };
     let query = AccessQuery::try_from(r#"Resources"#)?;
@@ -24,7 +24,7 @@ fn test_count_function() -> crate::rules::Result<()> {
     let value = PathAwareValue::try_from(serde_yaml::from_str::<serde_yaml::Value>(value_str)?)?;
 
     let mut eval = BasicQueryTesting {
-        root: Rc::new(value.clone()),
+        root: Rc::new(value),
         recorder: None,
     };
     let query = AccessQuery::try_from(r#"Resources"#)?;
@@ -41,7 +41,7 @@ fn test_count_function() -> crate::rules::Result<()> {
     "#;
     let value = PathAwareValue::try_from(serde_yaml::from_str::<serde_yaml::Value>(value_str)?)?;
     let mut eval = BasicQueryTesting {
-        root: Rc::new(value.clone()),
+        root: Rc::new(value),
         recorder: None,
     };
     let query = AccessQuery::try_from(r#"Resources[ Type == 'AWS::S3::Bucket' ]"#)?;

--- a/guard/src/rules/functions/strings_tests.rs
+++ b/guard/src/rules/functions/strings_tests.rs
@@ -1,7 +1,8 @@
+use std::rc::Rc;
+
 use super::super::collections::count;
 use super::*;
 use crate::rules::eval_context::eval_context_tests::BasicQueryTesting;
-use crate::rules::eval_context::*;
 use crate::rules::exprs::AccessQuery;
 use crate::rules::path_value::*;
 use crate::rules::EvalContext;
@@ -24,7 +25,7 @@ fn test_json_parse() -> crate::rules::Result<()> {
     let value = PathAwareValue::try_from(serde_yaml::from_str::<serde_yaml::Value>(value_str)?)?;
 
     let mut eval = BasicQueryTesting {
-        root: &value,
+        root: Rc::new(value.clone()),
         recorder: None,
     };
     let query =
@@ -36,7 +37,7 @@ fn test_json_parse() -> crate::rules::Result<()> {
     assert_eq!(json.len(), 1);
     let path_value = json[0].as_ref().unwrap();
     assert_eq!(matches!(path_value, PathAwareValue::Map(_)), true);
-    if let PathAwareValue::Map((path, map)) = path_value {
+    if let PathAwareValue::Map((_, map)) = path_value {
         assert_eq!(map.values.len(), 2);
         assert_eq!(map.values.contains_key("Principal"), true);
         assert_eq!(map.values.contains_key("Actions"), true);
@@ -64,7 +65,7 @@ fn test_regex_replace() -> crate::rules::Result<()> {
     let value = PathAwareValue::try_from(serde_yaml::from_str::<serde_yaml::Value>(value_str)?)?;
 
     let mut eval = BasicQueryTesting {
-        root: &value,
+        root: Rc::new(value.clone()),
         recorder: None,
     };
     let query =
@@ -106,7 +107,7 @@ fn test_substring() -> crate::rules::Result<()> {
     let value = PathAwareValue::try_from(serde_yaml::from_str::<serde_yaml::Value>(value_str)?)?;
 
     let mut eval = BasicQueryTesting {
-        root: &value,
+        root: Rc::new(value.clone()),
         recorder: None,
     };
     let query =

--- a/guard/src/rules/functions/strings_tests.rs
+++ b/guard/src/rules/functions/strings_tests.rs
@@ -25,7 +25,7 @@ fn test_json_parse() -> crate::rules::Result<()> {
     let value = PathAwareValue::try_from(serde_yaml::from_str::<serde_yaml::Value>(value_str)?)?;
 
     let mut eval = BasicQueryTesting {
-        root: Rc::new(value.clone()),
+        root: Rc::new(value),
         recorder: None,
     };
     let query =
@@ -36,11 +36,11 @@ fn test_json_parse() -> crate::rules::Result<()> {
     let json = json_parse(&results)?;
     assert_eq!(json.len(), 1);
     let path_value = json[0].as_ref().unwrap();
-    assert_eq!(matches!(path_value, PathAwareValue::Map(_)), true);
+    assert!(matches!(path_value, PathAwareValue::Map(_)));
     if let PathAwareValue::Map((_, map)) = path_value {
         assert_eq!(map.values.len(), 2);
-        assert_eq!(map.values.contains_key("Principal"), true);
-        assert_eq!(map.values.contains_key("Actions"), true);
+        assert!(map.values.contains_key("Principal"));
+        assert!(map.values.contains_key("Actions"));
     }
 
     Ok(())
@@ -65,7 +65,7 @@ fn test_regex_replace() -> crate::rules::Result<()> {
     let value = PathAwareValue::try_from(serde_yaml::from_str::<serde_yaml::Value>(value_str)?)?;
 
     let mut eval = BasicQueryTesting {
-        root: Rc::new(value.clone()),
+        root: Rc::new(value),
         recorder: None,
     };
     let query =
@@ -107,7 +107,7 @@ fn test_substring() -> crate::rules::Result<()> {
     let value = PathAwareValue::try_from(serde_yaml::from_str::<serde_yaml::Value>(value_str)?)?;
 
     let mut eval = BasicQueryTesting {
-        root: Rc::new(value.clone()),
+        root: Rc::new(value),
         recorder: None,
     };
     let query =

--- a/guard/src/rules/mod.rs
+++ b/guard/src/rules/mod.rs
@@ -21,6 +21,7 @@ use nom::lib::std::convert::TryFrom;
 use serde::Serialize;
 use std::collections::{HashMap, HashSet};
 use std::fmt::Formatter;
+use std::rc::Rc;
 
 pub(crate) type Result<R> = std::result::Result<R, Error>;
 
@@ -154,66 +155,66 @@ impl std::fmt::Display for EvaluationType {
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize)]
-pub(crate) struct UnResolved<'value> {
-    pub(crate) traversed_to: &'value PathAwareValue,
+pub(crate) struct UnResolved {
+    pub(crate) traversed_to: Rc<PathAwareValue>,
     pub(crate) remaining_query: String,
     pub(crate) reason: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize)]
-pub(crate) enum QueryResult<'value> {
-    Literal(&'value PathAwareValue),
-    Resolved(&'value PathAwareValue),
-    UnResolved(UnResolved<'value>),
+pub(crate) enum QueryResult {
+    Literal(Rc<PathAwareValue>),
+    Resolved(Rc<PathAwareValue>),
+    UnResolved(UnResolved),
 }
 
-impl<'value> QueryResult<'value> {
-    pub(crate) fn resolved(&self) -> Option<&'value PathAwareValue> {
+impl QueryResult {
+    pub(crate) fn resolved(&self) -> Option<Rc<PathAwareValue>> {
         if let QueryResult::Resolved(res) = self {
-            return Some(*res);
+            return Some(Rc::clone(res));
         }
         None
     }
 
-    pub(crate) fn unresolved_traversed_to(&self) -> Option<&'value PathAwareValue> {
+    pub(crate) fn unresolved_traversed_to(&self) -> Option<Rc<PathAwareValue>> {
         if let QueryResult::UnResolved(res) = self {
-            return Some(res.traversed_to);
+            return Some(Rc::clone(&res.traversed_to));
         }
         None
     }
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize)]
-pub(crate) struct ComparisonClauseCheck<'value> {
+pub(crate) struct ComparisonClauseCheck {
     pub(crate) comparison: (CmpOperator, bool),
-    pub(crate) from: QueryResult<'value>,
-    pub(crate) to: Option<QueryResult<'value>>, // happens with from is unresolved
+    pub(crate) from: QueryResult,
+    pub(crate) to: Option<QueryResult>, // happens with from is unresolved
     pub(crate) message: Option<String>,
     pub(crate) custom_message: Option<String>,
     pub(crate) status: Status,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize)]
-pub(crate) struct InComparisonCheck<'value> {
+pub(crate) struct InComparisonCheck {
     pub(crate) comparison: (CmpOperator, bool),
-    pub(crate) from: QueryResult<'value>,
-    pub(crate) to: Vec<QueryResult<'value>>, // happens with from is unresolved
+    pub(crate) from: QueryResult,
+    pub(crate) to: Vec<QueryResult>, // happens with from is unresolved
     pub(crate) message: Option<String>,
     pub(crate) custom_message: Option<String>,
     pub(crate) status: Status,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize)]
-pub(crate) struct ValueCheck<'value> {
-    pub(crate) from: QueryResult<'value>,
+pub(crate) struct ValueCheck {
+    pub(crate) from: QueryResult,
     pub(crate) message: Option<String>,
     pub(crate) custom_message: Option<String>,
     pub(crate) status: Status,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize)]
-pub(crate) struct UnaryValueCheck<'value> {
-    pub(crate) value: ValueCheck<'value>,
+pub(crate) struct UnaryValueCheck {
+    pub(crate) value: ValueCheck,
     pub(crate) comparison: (CmpOperator, bool),
 }
 
@@ -228,12 +229,12 @@ pub(crate) struct MissingValueCheck<'value> {
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub(crate) enum ClauseCheck<'value> {
     Success,
-    Comparison(ComparisonClauseCheck<'value>),
-    InComparison(InComparisonCheck<'value>),
-    Unary(UnaryValueCheck<'value>),
+    Comparison(ComparisonClauseCheck),
+    InComparison(InComparisonCheck),
+    Unary(UnaryValueCheck),
     NoValueForEmptyCheck(Option<String>),
     DependentRule(MissingValueCheck<'value>),
-    MissingBlockValue(ValueCheck<'value>),
+    MissingBlockValue(ValueCheck),
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize)]
@@ -355,25 +356,21 @@ pub(crate) trait RecordTracer<'value> {
 }
 
 pub(crate) trait EvalContext<'value, 'loc: 'value>: RecordTracer<'value> {
-    fn query(&mut self, query: &'value [QueryPart<'loc>]) -> Result<Vec<QueryResult<'value>>>;
-    //fn resolve(&self, guard_clause: &GuardAccessClause<'_>) -> Result<Vec<QueryResult<'value>>>;
+    fn query(&mut self, query: &'value [QueryPart<'loc>]) -> Result<Vec<QueryResult>>;
+    //fn resolve(&self, guard_clause: &GuardAccessClause<'_>) -> Result<Vec<QueryResult>>;
     fn find_parameterized_rule(
         &mut self,
         rule_name: &str,
     ) -> Result<&'value ParameterizedRule<'loc>>;
-    fn root(&mut self) -> &'value PathAwareValue;
+    fn root(&mut self) -> Rc<PathAwareValue>;
     fn rule_status(&mut self, rule_name: &'value str) -> Result<Status>;
-    fn resolve_variable(&mut self, variable_name: &'value str) -> Result<Vec<QueryResult<'value>>>;
+    fn resolve_variable(&mut self, variable_name: &'value str) -> Result<Vec<QueryResult>>;
     fn add_variable_capture_key(
         &mut self,
         variable_name: &'value str,
-        key: &'value PathAwareValue,
+        key: Rc<PathAwareValue>,
     ) -> Result<()>;
-    fn add_variable_capture_index(
-        &mut self,
-        variable_name: &str,
-        index: &'value PathAwareValue,
-    ) -> Result<()> {
+    fn add_variable_capture_index(&mut self, _: &str, _: Rc<PathAwareValue>) -> Result<()> {
         Ok(())
     }
 }

--- a/guard/src/rules/parser.rs
+++ b/guard/src/rules/parser.rs
@@ -1393,17 +1393,28 @@ fn assignment(input: Span) -> IResult<Span, LetExpr> {
         Err(nom::Err::Error(_)) => {
             //
             // if we did not succeed in parsing a value object, then
-            // if must be an access pattern, else it is a failure
-            //
-            let (input, access) = cut(preceded(zero_or_more_ws_or_comment, access))(input)?;
+            // if must be an access pattern, or function call  else it is a failure
+            // TODO: do we still need to parse for a fn expr first?
+            match cut(preceded(zero_or_more_ws_or_comment, function_expr))(input) {
+                Ok((input, function)) => Ok((
+                    input,
+                    LetExpr {
+                        var: var_name,
+                        value: LetValue::FunctionCall(function),
+                    },
+                )),
+                Err(_) => {
+                    let (input, access) = cut(preceded(zero_or_more_ws_or_comment, access))(input)?;
 
-            Ok((
-                input,
-                LetExpr {
-                    var: var_name,
-                    value: LetValue::AccessClause(access),
-                },
-            ))
+                    Ok((
+                        input,
+                        LetExpr {
+                            var: var_name,
+                            value: LetValue::AccessClause(access),
+                        },
+                    ))
+                }
+            }
         }
 
         Err(e) => Err(e),

--- a/guard/src/rules/parser.rs
+++ b/guard/src/rules/parser.rs
@@ -1394,7 +1394,6 @@ fn assignment(input: Span) -> IResult<Span, LetExpr> {
             //
             // if we did not succeed in parsing a value object, then
             // if must be an access pattern, or function call  else it is a failure
-            // TODO: do we still need to parse for a fn expr first?
             match cut(preceded(zero_or_more_ws_or_comment, function_expr))(input) {
                 Ok((input, function)) => Ok((
                     input,

--- a/guard/src/rules/parser_tests.rs
+++ b/guard/src/rules/parser_tests.rs
@@ -1,5 +1,3 @@
-use std::convert::TryInto;
-
 use crate::rules::path_value::PathAwareValue;
 use crate::rules::values::WithinRange;
 use crate::rules::{EvaluationContext, EvaluationType, Status};
@@ -161,7 +159,7 @@ fn test_parse_regex() {
 
     let improperly_escaped_regular_expression =
         "/arn:[\\w+=/,.@-]+:[\\w+=/,.@-]+:[\\w+=/,.@-]*:[0-9]*:[\\w+=,.@-]+(/[\\w+=,.@-]+)*/";
-    let cmp = unsafe {
+    let _cmp = unsafe {
         Span::new_from_raw_offset(
             11,
             1,
@@ -4541,5 +4539,49 @@ fn test_parse_value_when_strings_are_randomly_generated() {
     for value in values {
         let cmp = unsafe { Span::new_from_raw_offset(value.len(), 5, value, "") };
         assert!(parse_value(cmp).is_err())
+    }
+}
+
+#[test]
+fn test_parse_assignment_with_function_call() {
+    let input = "let num = count(%s3_buckets_bucket_logging_enabled)";
+
+    let res = assignment(from_str2(input)).unwrap();
+
+    assert_eq!(res.1.var, "num");
+
+    let function = res.1.value;
+    assert!(matches!(function, LetValue::FunctionCall(_)));
+
+    if let LetValue::FunctionCall(function) = function {
+        assert_eq!(function.name, "count");
+        assert_eq!(function.parameters.len(), 1);
+        assert!(matches!(function.parameters[0], LetValue::AccessClause(_)));
+    }
+}
+
+#[test]
+fn test_parse_assignment_with_function_call2() {
+    let input = r#"let num = regex_replace(%s3_buckets_bucket_logging_enabled, "^arn:(\\w+):(\\w+):([\\w0-9-]+):(\\d+):(.+)$", "${1}/${4}/${3}/${2}-${5}")"#;
+    let res = assignment(from_str2(input)).unwrap();
+
+    assert_eq!(res.1.var, "num");
+
+    let function = res.1.value;
+    assert!(matches!(function, LetValue::FunctionCall(_)));
+
+    if let LetValue::FunctionCall(function) = function {
+        assert_eq!(function.name, "regex_replace");
+        assert_eq!(function.parameters.len(), 3);
+        assert!(matches!(
+            function.parameters[1],
+            LetValue::Value(PathAwareValue::String(_))
+        ));
+        assert!(matches!(
+            function.parameters[2],
+            LetValue::Value(PathAwareValue::String(_))
+        ));
+        assert_eq!(function.parameters.len(), 3);
+        assert!(matches!(function.parameters[0], LetValue::AccessClause(_)));
     }
 }

--- a/guard/tests/test_command.rs
+++ b/guard/tests/test_command.rs
@@ -288,9 +288,9 @@ mod test_command_tests {
                 "resources/test-command/functions/data/template.yaml",
             ))
             .rules(Some(
-                "resources/validate/rules-dir/s3_bucket_server_side_encryption_enabled.guard",
+                "resources/test-command/functions/rules/json_parse.guard",
             ))
-            .previous_engine()
+            .verbose()
             .run(&mut writer, &mut reader);
 
         assert_eq!(StatusCode::SUCCESS, status_code);

--- a/guard/tests/test_command.rs
+++ b/guard/tests/test_command.rs
@@ -278,4 +278,21 @@ mod test_command_tests {
             writer
         );
     }
+
+    #[test]
+    fn test_with_function_expr() {
+        let mut reader = Reader::new(Stdin(std::io::stdin()));
+        let mut writer = Writer::new(WBVec(vec![]), WBVec(vec![]));
+        let status_code = TestCommandTestRunner::default()
+            .test_data(Option::from(
+                "resources/test-command/functions/data/template.yaml",
+            ))
+            .rules(Some(
+                "resources/validate/rules-dir/s3_bucket_server_side_encryption_enabled.guard",
+            ))
+            .previous_engine()
+            .run(&mut writer, &mut reader);
+
+        assert_eq!(StatusCode::SUCCESS, status_code);
+    }
 }

--- a/guard/tests/validate.rs
+++ b/guard/tests/validate.rs
@@ -810,7 +810,7 @@ mod validate_tests {
     #[case("regex_replace.guard")]
     #[case("substring.guard")]
     #[case("json_parse.guard")]
-    #[case("string_manip.guard")]
+    #[case("string_manipulation.guard")]
     #[case("url_decode.guard")]
     #[case("join.guard")]
     #[case("count.guard")]

--- a/guard/tests/validate.rs
+++ b/guard/tests/validate.rs
@@ -805,4 +805,26 @@ mod validate_tests {
 
         assert_eq!(StatusCode::INTERNAL_FAILURE, status_code);
     }
+
+    #[rstest::rstest]
+    #[case("regex_replace.guard")]
+    #[case("substring.guard")]
+    #[case("json_parse.guard")]
+    #[case("string_manip.guard")]
+    #[case("url_decode.guard")]
+    #[case("join.guard")]
+    #[case("count.guard")]
+    fn test_validate_with_fn_expr_success(#[case] rule: &str) {
+        let mut reader = Reader::new(Stdin(std::io::stdin()));
+        let mut writer = Writer::new(WBVec(vec![]), WBVec(vec![]));
+
+        let status_code = ValidateTestRunner::default()
+            .rules(vec![&format!("/functions/rules/{rule}")])
+            .data(vec!["/functions/data/template.yaml"])
+            .verbose()
+            .show_summary(vec!["all"])
+            .run(&mut writer, &mut reader);
+
+        assert_eq!(StatusCode::SUCCESS, status_code);
+    }
 }


### PR DESCRIPTION
*Issue #, if available:*
#295 
#140 

*Description of changes:*
Refactor all occurrences of `&'value PathAwareValue` to `Rc<PathAwareValue>` while this has a performance impact, due to the way functions are computed we have no other choice, since `&'value` lifetime refers to when the specific value was parsed, and thus values that are computed can never meet that requirement. This also allowed us to remove the lifetime constraints on many structs and functions. This refactor also made us add a dependency on the `Rc` feature in the serde crate

Refactored the PathTree struct from `pub(super) type PathTree<'report, 'value> =
    BTreeMap<&'value str, Vec<std::rc::Rc<Node<'report, 'value>>>>;` to`pub(super) type PathTree<'report, 'value> =
    BTreeMap<String, Vec<std::rc::Rc<Node<'report, 'value>>>>;`  
    
this is a direct result of the change mentioned above


Add support for the following functions 

count - 
takes a single query result argument as a parameter and returns the number of occurrences. For examples please refer to 

json_parse - 
takes a single query result and attempts to convert a string into a json object. 

regex_replace - 
takes 3 arguments the first is a query result, the 2nd is the extracted regular expression, and the third is the replacement regular expression 

substring - 
takes 3 arguments the first is a query result, the 2nd is the starting index (inclusive), the 3rd is the last index (non inclusive)

to_lower - 
takes a single query result and returns a string that is all lowercase 

to_upper - 
same as above except the returned string is all uppercase

url_decode - 
takes a single queryy result and returns a url decoded version of the string 

ex:This%20string%20will%20be%20URL%20encoded =>  "This string will be URL encoded"

for examples of these functions see the accompanying guard files

---
*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
