### PR TITLE
improve error message for templates that cause an error

### DIFF
--- a/guard/tests/validate.rs
+++ b/guard/tests/validate.rs
@@ -207,6 +207,7 @@ mod validate_tests {
     )]
     #[case(vec!["dne.yaml"], vec!["rules-dir/s3_bucket_public_read_prohibited.guard"], StatusCode::INTERNAL_FAILURE)]
     #[case(vec!["data-dir/s3-public-read-prohibited-template-non-compliant.yaml"], vec!["dne.guard"], StatusCode::INTERNAL_FAILURE)]
+    #[case(vec!["blank.yaml"], vec!["rules-dir/s3_bucket_public_read_prohibited.guard"], StatusCode::INTERNAL_FAILURE)]
     fn test_single_data_file_single_rules_file_status(
         #[case] data_arg: Vec<&str>,
         #[case] rules_arg: Vec<&str>,


### PR DESCRIPTION
*Issue #, if available:*
#225  #211 

*Description of changes:*
Improved the error messaging for validate commands when the template is empty. Also updated the error messaging when any error occurs when parsing text from a template file to include the name of the file.

---
*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
