### PR TITLE
[Bugfix]: Fixed bug where cfn template fails validate rule check and when failing node isnt a child of resources

### DIFF
--- a/guard-ffi/src/errors.rs
+++ b/guard-ffi/src/errors.rs
@@ -29,6 +29,7 @@ fn get_code(e: &Error) -> ErrorCode {
         Error::MissingValue(_err) => 16,
         Error::FileNotFoundError(_) => 17,
         Error::IllegalArguments(_) => 18,
+        Error::InternalError(_) => unreachable!(),
     };
     ErrorCode::new(code)
 }

--- a/guard/resources/validate/failing_template_with_slash_in_key.yaml
+++ b/guard/resources/validate/failing_template_with_slash_in_key.yaml
@@ -1,0 +1,12 @@
+Resources:
+  A/Resource/Name/With/Slash:
+    Type: AWS::S3::Bucket
+    Properties:
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
+      BucketEncryption:
+      VersioningConfiguration:
+        Status: Enabled

--- a/guard/resources/validate/output-dir/failing_template_with_slash_in_key.out
+++ b/guard/resources/validate/output-dir/failing_template_with_slash_in_key.out
@@ -1,0 +1,46 @@
+failing_template_with_slash_in_key.yaml Status = FAIL
+FAILED rules
+s3_bucket_server_side_encryption_enabled.guard/S3_BUCKET_SERVER_SIDE_ENCRYPTION_ENABLED    FAIL
+---
+Evaluating data failing_template_with_slash_in_key.yaml against rules s3_bucket_server_side_encryption_enabled.guard
+Number of non-compliant resources 1
+Resource = A/Resource/Name/With/Slash {
+  Type      = AWS::S3::Bucket
+  Rule = S3_BUCKET_SERVER_SIDE_ENCRYPTION_ENABLED {
+    ALL {
+      Check =  %s3_buckets_server_side_encryption[*].Properties.BucketEncryption.ServerSideEncryptionConfiguration[*].ServerSideEncryptionByDefault.SSEAlgorithm IN  ["aws:kms","AES256"] {
+        Message {
+          Violation: S3 Bucket must enable server-side encryption.
+          Fix: Set the S3 Bucket property BucketEncryption.ServerSideEncryptionConfiguration.ServerSideEncryptionByDefault.SSEAlgorithm to either "aws:kms" or "AES256"
+        }
+        RequiredPropertyError {
+          PropertyPath = /Resources/A/Resource/Name/With/Slash/Properties/BucketEncryption[L:9,C:23]
+          MissingProperty = ServerSideEncryptionConfiguration[*].ServerSideEncryptionByDefault.SSEAlgorithm
+          Reason = Attempting to retrieve from key ServerSideEncryptionConfiguration but type is not an struct type at path /Resources/A/Resource/Name/With/Slash/Properties/BucketEncryption[L:9,C:23], Type = String, Value = String((Path("/Resources/A/Resource/Name/With/Slash/Properties/BucketEncryption", Location { line: 9, col: 23 }), ""))
+          Code:
+                7.        BlockPublicPolicy: true
+                8.        IgnorePublicAcls: true
+                9.        RestrictPublicBuckets: true
+               10.      BucketEncryption:
+               11.      VersioningConfiguration:
+               12.        Status: Enabled
+        }
+      }
+    }
+  }
+}
+`- File(failing_template_with_slash_in_key.yaml, Status=FAIL)[Context=File(rules=1)]
+   `- Rule(S3_BUCKET_SERVER_SIDE_ENCRYPTION_ENABLED, Status=FAIL)[Context=S3_BUCKET_SERVER_SIDE_ENCRYPTION_ENABLED]
+      |- Rule/When(Status=PASS)[Context=Rule#S3_BUCKET_SERVER_SIDE_ENCRYPTION_ENABLED/When]
+      |  `- GuardClauseBlock(Status = PASS)[Context=GuardAccessClause#block %s3_buckets_server_side_encryption not EMPTY  ]
+      |     |- Filter/ConjunctionsBlock(Status=PASS)[Context=Filter/Map#2]
+      |     |  |- GuardClauseBlock(Status = PASS)[Context=GuardAccessClause#block Type EQUALS  "AWS::S3::Bucket"]
+      |     |  |  `- GuardClauseValueCheck(Status=PASS)[Context= Type EQUALS  "AWS::S3::Bucket"]
+      |     |  `- Disjunction(Status = PASS)[Context=cfn_guard::rules::exprs::GuardClause#disjunction]
+      |     |     `- GuardClauseBlock(Status = PASS)[Context=GuardAccessClause#block Metadata.guard.SuppressedRules not EXISTS  ]
+      |     |        `- GuardClauseValueCheck(Status=PASS)[Context= Metadata.guard.SuppressedRules not EXISTS  ]
+      |     `- GuardClauseValueCheck(Status=PASS)[Context= %s3_buckets_server_side_encryption not EMPTY  ]
+      |- GuardClauseBlock(Status = PASS)[Context=GuardAccessClause#block %s3_buckets_server_side_encryption[*].Properties.BucketEncryption EXISTS  ]
+      |  `- GuardClauseValueCheck(Status=PASS)[Context= %s3_buckets_server_side_encryption[*].Properties.BucketEncryption EXISTS  ]
+      `- GuardClauseBlock(Status = FAIL)[Context=GuardAccessClause#block %s3_buckets_server_side_encryption[*].Properties.BucketEncryption.ServerSideEncryptionConfiguration[*].ServerSideEncryptionByDefault.SSEAlgorithm IN  ["aws:kms","AES256"]]
+         `- GuardClauseBinaryCheck(Status=FAIL, Comparison= IN, from=(unresolved, Path=/Resources/A/Resource/Name/With/Slash/Properties/BucketEncryption[L:9,C:23] Value=""), to=)[Context= %s3_buckets_server_side_encryption[*].Properties.BucketEncryption.ServerSideEncryptionConfiguration[*].ServerSideEncryptionByDefault.SSEAlgorithm IN  ["aws:kms","AES256"]]

--- a/guard/resources/validate/output-dir/failing_template_without_resources_at_root.out
+++ b/guard/resources/validate/output-dir/failing_template_without_resources_at_root.out
@@ -1,0 +1,37 @@
+template_where_resources_isnt_root.json Status = FAIL
+FAILED rules
+workshop.guard/assert_no_wildcard_actions    FAIL
+---
+Evaluation of rules workshop.guard against data template_where_resources_isnt_root.json
+--
+Property [/Roles/0] in data [template_where_resources_isnt_root.json] is not compliant with [assert_no_wildcard_actions] because needed value at [{"RoleName":"MyRole","RolePath":"/","TrustPolicy":{"Statement":[{"Effect":"Allow","Principal":{"AWS":["314595678785"]},"Action":["sts:AssumeRole"]}]},"Policies":[{"Name":"root","Policy":{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"*","Resource":"*"}]},"Path":"/","IsAWSManagedPolicy":false}]}] was not empty. Error Message []
+Property [/Roles/0/Policies/0] in data [template_where_resources_isnt_root.json] is not compliant with [assert_no_wildcard_actions] because needed value at [{"Name":"root","Policy":{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"*","Resource":"*"}]},"Path":"/","IsAWSManagedPolicy":false}] was not empty. Error Message []
+Property [/Roles/0/Policies/0/Policy/Statement/0/Action] in data [template_where_resources_isnt_root.json] is not compliant with [assert_no_wildcard_actions] because provided value ["*"] did match expected value ["*"]. Error Message []
+--
+`- File(template_where_resources_isnt_root.json, Status=FAIL)[Context=File(rules=1)]
+   `- Rule(assert_no_wildcard_actions, Status=FAIL)[Context=assert_no_wildcard_actions]
+      |- Disjunction(Status = FAIL)[Context=cfn_guard::rules::exprs::RuleClause#disjunction]
+      |  |- GuardClauseBlock(Status = FAIL)[Context=GuardAccessClause#block Roles[*] EMPTY  ]
+      |  |  `- GuardClauseUnaryCheck(Status=FAIL, Comparison= EMPTY, Value-At=(resolved, Path=/Roles/0[L:5,C:8] Value={"RoleName":"MyRole","RolePath":"/","TrustPolicy":{"Statement":[{"Effect":"Allow","Principal":{"AWS":["314595678785"]},"Action":["sts:AssumeRole"]}]},"Policies":[{"Name":"root","Policy":{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"*","Resource":"*"}]},"Path":"/","IsAWSManagedPolicy":false}]}))[Context= Roles[*] EMPTY  ]
+      |  `- GuardValueBlockCheck(Status = FAIL)[Context=BlockGuardClause#Location[file:workshop.guard, line:7, column:3]]
+      |     `- Disjunction(Status = FAIL)[Context=cfn_guard::rules::exprs::GuardClause#disjunction]
+      |        |- GuardClauseBlock(Status = FAIL)[Context=GuardAccessClause#block Policies[*] EMPTY  ]
+      |        |  `- GuardClauseUnaryCheck(Status=FAIL, Comparison= EMPTY, Value-At=(resolved, Path=/Roles/0/Policies/0[L:24,C:16] Value={"Name":"root","Policy":{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"*","Resource":"*"}]},"Path":"/","IsAWSManagedPolicy":false}))[Context= Policies[*] EMPTY  ]
+      |        `- GuardValueBlockCheck(Status = FAIL)[Context=BlockGuardClause#Location[file:workshop.guard, line:10, column:7]]
+      |           `- GuardClauseBlock(Status = FAIL)[Context=GuardAccessClause#block Action[*] not EQUALS  "*"]
+      |              `- GuardClauseBinaryCheck(Status=FAIL, Comparison=not EQUALS, from=(resolved, Path=/Roles/0/Policies/0/Policy/Statement/0/Action[L:31,C:42] Value="*"), to=(resolved, Path=[L:0,C:0] Value="*"))[Context= Action[*] not EQUALS  "*"]
+      |- Disjunction(Status = PASS)[Context=cfn_guard::rules::exprs::RuleClause#disjunction]
+      |  `- GuardClauseBlock(Status = PASS)[Context=GuardAccessClause#block Users[*] EMPTY  ]
+      |     `- GuardClauseValueCheck(Status=PASS)[Context= Users[*] EMPTY  ]
+      |- Disjunction(Status = PASS)[Context=cfn_guard::rules::exprs::RuleClause#disjunction]
+      |  `- GuardClauseBlock(Status = PASS)[Context=GuardAccessClause#block Groups[*] EMPTY  ]
+      |     `- GuardClauseValueCheck(Status=PASS)[Context= Groups[*] EMPTY  ]
+      |- Disjunction(Status = PASS)[Context=cfn_guard::rules::exprs::RuleClause#disjunction]
+      |  `- GuardClauseBlock(Status = PASS)[Context=GuardAccessClause#block Resources[*] EMPTY  ]
+      |     `- GuardClauseValueCheck(Status=PASS)[Context= Resources[*] EMPTY  ]
+      |- Disjunction(Status = PASS)[Context=cfn_guard::rules::exprs::RuleClause#disjunction]
+      |  `- GuardClauseBlock(Status = PASS)[Context=GuardAccessClause#block PermissionSets[*] EMPTY  ]
+      |     `- GuardClauseValueCheck(Status=PASS)[Context= PermissionSets[*] EMPTY  ]
+      `- Disjunction(Status = PASS)[Context=cfn_guard::rules::exprs::RuleClause#disjunction]
+         `- GuardClauseBlock(Status = PASS)[Context=GuardAccessClause#block OrphanedPolicies[*] EMPTY  ]
+            `- GuardClauseValueCheck(Status=PASS)[Context= OrphanedPolicies[*] EMPTY  ]

--- a/guard/resources/validate/template_where_resources_isnt_root.json
+++ b/guard/resources/validate/template_where_resources_isnt_root.json
@@ -1,0 +1,48 @@
+{
+    "Region": "us-east-1",
+    "Account": "314595678785",
+    "Partition": "aws",
+    "Roles": [
+        {
+            "RoleName": "MyRole",
+            "RolePath": "/",
+            "TrustPolicy": {
+                "Statement": [
+                    {
+                        "Effect": "Allow",
+                        "Principal": {
+                            "AWS": [
+                                "314595678785"
+                            ]
+                        },
+                        "Action": [
+                            "sts:AssumeRole"
+                        ]
+                    }
+                ]
+            },
+            "Policies": [
+                {
+                    "Name": "root",
+                    "Policy": {
+                        "Version": "2012-10-17",
+                        "Statement": [
+                            {
+                                "Effect": "Allow",
+                                "Action": "*",
+                                "Resource": "*"
+                            }
+                        ]
+                    },
+                    "Path": "/",
+                    "IsAWSManagedPolicy": false
+                }
+            ]
+        }
+    ],
+    "PermissionSets": [],
+    "Users": [],
+    "Groups": [],
+    "Resources": [],
+    "OrphanedPolicies": []
+}

--- a/guard/resources/validate/workshop.guard
+++ b/guard/resources/validate/workshop.guard
@@ -1,0 +1,62 @@
+# This rule will return 
+# 1) FAIL if any IAM policy has a wildcard action
+# 2) PASS if there are no IAM policies or IAM policies have no wildcard actions
+#
+rule assert_no_wildcard_actions {
+  Roles[*] empty or
+  Roles[*] {
+      # if there are no policies - PASS
+      Policies[*] empty or
+      Policies[*].Policy.Statement[*] {
+          Action[*] != '*'
+      }
+  }
+
+  # if there are no users - PASS
+  Users[*] empty or
+  Users[*] {
+      # if there are no policies - PASS
+      Policies[*] empty or
+      Policies[*].Policy.Statement[*] {
+          Action[*] != '*'
+      }
+  }
+
+  # if there are no groups - PASS
+  Groups[*] empty or
+  Groups[*] {
+      # if there are no policies - PASS
+      Policies[*] empty or
+      Policies[*].Policy.Statement[*] {
+          Action[*] != '*'
+      }
+  }
+
+  # if there are no resources - PASS
+  Resources[*] empty or
+  Resources[*] {
+      # resources only have a single policy
+      Policy.Policy.Statement[*] {
+          Action[*] != '*'
+      }
+  }
+
+  # if there are no permission sets - PASS
+  PermissionSets[*] empty or
+  PermissionSets[*] {
+      # if there are no policies - PASS
+      Policies[*] empty or
+      Policies[*].Policy.Statement[*] {
+          Action[*] != '*'
+      }
+  }
+
+  # if there are no orphaned policies - PASS
+  OrphanedPolicies[*] empty or
+  OrphanedPolicies[*] {
+      # orphaned policies have direct policy elements, no need to traverse to Policies[*]
+      Policy.Statement[*] {
+          Action[*] != '*'
+      }
+  }
+}

--- a/guard/src/commands/validate.rs
+++ b/guard/src/commands/validate.rs
@@ -29,7 +29,7 @@ use crate::rules::eval_context::{root_scope, EventRecord};
 use crate::rules::exprs::RulesFile;
 use crate::rules::path_value::traversal::Traversal;
 use crate::rules::path_value::PathAwareValue;
-use crate::rules::{EvaluationType, Result, Status};
+use crate::rules::{Result, Status};
 use crate::utils::reader::Reader;
 use crate::utils::writer::Writer;
 

--- a/guard/src/commands/validate/cfn_reporter.rs
+++ b/guard/src/commands/validate/cfn_reporter.rs
@@ -12,9 +12,9 @@ use crate::commands::validate::common::{
 use crate::commands::validate::{OutputFormatType, Reporter};
 use crate::rules::errors::Error;
 
-use super::EvaluationType;
 use crate::rules::eval_context::EventRecord;
 use crate::rules::path_value::traversal::Traversal;
+use crate::rules::EvaluationType;
 use crate::rules::Status;
 
 lazy_static! {

--- a/guard/src/rules/errors.rs
+++ b/guard/src/rules/errors.rs
@@ -45,6 +45,8 @@ pub enum Error {
     Errors(#[from] Errors),
     #[error("{0}")]
     IllegalArguments(String),
+    #[error("internal error {0}")]
+    InternalError(String),
 }
 
 #[derive(Debug, Error)]

--- a/guard/tests/validate.rs
+++ b/guard/tests/validate.rs
@@ -254,6 +254,18 @@ mod validate_tests {
         "resources/validate/output-dir/test_single_data_file_single_rules_file_verbose_non_compliant.out",
         StatusCode::PARSING_ERROR
     )]
+    #[case(
+        vec!["template_where_resources_isnt_root.json"],
+        vec!["workshop.guard"],
+        "resources/validate/output-dir/failing_template_without_resources_at_root.out",
+        StatusCode::PARSING_ERROR
+    )]
+    #[case(
+        vec!["failing_template_with_slash_in_key.yaml"],
+        vec!["rules-dir/s3_bucket_server_side_encryption_enabled.guard"],
+        "resources/validate/output-dir/failing_template_with_slash_in_key.out",
+        StatusCode::PARSING_ERROR
+    )]
     fn test_single_data_file_single_rules_file_verbose(
         #[case] data_arg: Vec<&str>,
         #[case] rules_arg: Vec<&str>,


### PR DESCRIPTION
*Issue #, if available:*


*Description of changes:*
Currently when using single-line-summary and guard detects a cloudformation template, if a rule fails and the node where the rule failed is not a child of Resources property this will cause a panic. To mitigate this we are now throwing a new error type called internal which as the name implies will not ever be returned to the user and is just used to match on and handle internal, recoverable errors. When the cfn reporter is outputting single-line-summary and the node isnt a child of resources, we return this internal error and try with our next reporter instead of panicking.


This pr also contains some test cases added for the fix done when I merged #275 



---
*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
