### PR TITLE
[Enhancement] creating a new error code for rule failures

### DIFF
--- a/guard/resources/test-command/data-dir/failing_test.yaml
+++ b/guard/resources/test-command/data-dir/failing_test.yaml
@@ -1,0 +1,14 @@
+- name: S3 Bucket Encryption set to SSE AES 256, PASS
+  input:
+    Resources:
+      ExampleS3:
+        Type: AWS::S3::Bucket
+        Properties:
+          BucketName: my-bucket
+          BucketEncryption:
+            ServerSideEncryptionConfiguration:
+              - ServerSideEncryptionByDefault:
+                  SSEAlgorithm: AES256
+  expectations:
+    rules:
+      S3_BUCKET_SERVER_SIDE_ENCRYPTION_ENABLED: FAIL

--- a/guard/src/commands/validate.rs
+++ b/guard/src/commands/validate.rs
@@ -410,7 +410,7 @@ or rules files.
                         data: data_files,
                         output: output_type,
                         writer,
-                        exit_code: 0,
+                        exit_code,
                     };
                     evaluator.evaluate()?
                 }
@@ -439,8 +439,8 @@ or rules files.
                                     writer,
                                 )?;
 
-                                if status == 5 {
-                                    exit_code = 5
+                                if status == 5 || status == 20 {
+                                    exit_code = status
                                 }
                             }
                         }
@@ -484,7 +484,7 @@ or rules files.
                         data: data_collection,
                         output: output_type,
                         writer,
-                        exit_code: 0,
+                        exit_code,
                     };
                     evaluator.evaluate()?
                 }
@@ -502,8 +502,8 @@ or rules files.
                             writer,
                         )?;
 
-                        if status == 5 {
-                            exit_code = 5;
+                        if status == 5 || status == 20 {
+                            exit_code = status;
                         }
                     }
                     exit_code
@@ -555,7 +555,7 @@ fn evaluate_rule(
             )?;
 
             if status == Status::FAIL {
-                return Ok(5);
+                return Ok(20);
             }
         }
     }

--- a/guard/src/commands/validate.rs
+++ b/guard/src/commands/validate.rs
@@ -439,7 +439,7 @@ or rules files.
                                     writer,
                                 )?;
 
-                                if status != 00 {
+                                if status != 0 {
                                     exit_code = status
                                 }
                             }

--- a/guard/src/commands/validate.rs
+++ b/guard/src/commands/validate.rs
@@ -439,7 +439,7 @@ or rules files.
                                     writer,
                                 )?;
 
-                                if status == 5 || status == 20 {
+                                if status != 00 {
                                     exit_code = status
                                 }
                             }
@@ -502,7 +502,7 @@ or rules files.
                             writer,
                         )?;
 
-                        if status == 5 || status == 20 {
+                        if status != 0 {
                             exit_code = status;
                         }
                     }
@@ -555,7 +555,7 @@ fn evaluate_rule(
             )?;
 
             if status == Status::FAIL {
-                return Ok(20);
+                return Ok(19);
             }
         }
     }

--- a/guard/src/commands/validate/structured.rs
+++ b/guard/src/commands/validate/structured.rs
@@ -73,7 +73,7 @@ impl<'eval> StructuredEvaluator<'eval> {
                 let mut root_scope = root_scope(rule, Rc::new(each.path_value.clone()))?;
 
                 if let Status::FAIL = eval_rules_file(rule, &mut root_scope, Some(&each.name))? {
-                    self.exit_code = 20;
+                    self.exit_code = 19;
                 }
 
                 let root_record = root_scope.reset_recorder().extract();

--- a/guard/src/commands/validate/structured.rs
+++ b/guard/src/commands/validate/structured.rs
@@ -73,8 +73,9 @@ impl<'eval> StructuredEvaluator<'eval> {
                 let mut root_scope = root_scope(rule, Rc::new(each.path_value.clone()))?;
 
                 if let Status::FAIL = eval_rules_file(rule, &mut root_scope, Some(&each.name))? {
-                    self.exit_code = 5;
+                    self.exit_code = 20;
                 }
+
                 let root_record = root_scope.reset_recorder().extract();
                 let report = simplifed_json_from_root(&root_record)?;
                 file_report.combine(report);

--- a/guard/src/rules/eval.rs
+++ b/guard/src/rules/eval.rs
@@ -1907,13 +1907,11 @@ pub(crate) fn eval_rules_file<'value, 'loc: 'value>(
         &context,
         RecordType::FileCheck(NamedStatus {
             status: overall,
-            name: match data_file_name {
-                Some(file_name) => file_name,
-                None => "",
-            },
+            name: data_file_name.unwrap_or_default(),
             ..Default::default()
         }),
     )?;
+
     Ok(overall)
 }
 

--- a/guard/tests/test_command.rs
+++ b/guard/tests/test_command.rs
@@ -282,6 +282,5 @@ mod test_command_tests {
             .run(&mut writer, &mut reader);
 
         assert_eq!(StatusCode::TEST_COMMAND_FAILURE, status_code);
-        // assert_output_from_file_eq!("resources/test-command/output-dir/functions.out", writer);
     }
 }

--- a/guard/tests/test_command.rs
+++ b/guard/tests/test_command.rs
@@ -267,4 +267,21 @@ mod test_command_tests {
         assert_eq!(StatusCode::SUCCESS, status_code);
         assert_output_from_file_eq!("resources/test-command/output-dir/functions.out", writer);
     }
+
+    #[test]
+    fn test_with_failure() {
+        let mut reader = Reader::new(Stdin(std::io::stdin()));
+        let mut writer = Writer::new(WBVec(vec![]), WBVec(vec![]));
+        let status_code = TestCommandTestRunner::default()
+            .test_data(Option::from(
+                "resources/test-command/data-dir/failing_test.yaml",
+            ))
+            .rules(Some(
+                "resources/validate/rules-dir/s3_bucket_server_side_encryption_enabled.guard",
+            ))
+            .run(&mut writer, &mut reader);
+
+        assert_eq!(StatusCode::TEST_COMMAND_FAILURE, status_code);
+        // assert_output_from_file_eq!("resources/test-command/output-dir/functions.out", writer);
+    }
 }

--- a/guard/tests/utils.rs
+++ b/guard/tests/utils.rs
@@ -25,7 +25,7 @@ impl StatusCode {
     pub const INCORRECT_STATUS_ERROR: i32 = 1;
     pub const TEST_COMMAND_FAILURE: i32 = 7;
     pub const PARSING_ERROR: i32 = 5;
-    pub const VALIDATION_ERROR: i32 = 20;
+    pub const VALIDATION_ERROR: i32 = 19;
 }
 
 pub fn read_from_resource_file(path: &str) -> String {

--- a/guard/tests/utils.rs
+++ b/guard/tests/utils.rs
@@ -25,6 +25,7 @@ impl StatusCode {
     pub const INCORRECT_STATUS_ERROR: i32 = 1;
     pub const TEST_COMMAND_FAILURE: i32 = 7;
     pub const PARSING_ERROR: i32 = 5;
+    pub const VALIDATION_ERROR: i32 = 20;
 }
 
 pub fn read_from_resource_file(path: &str) -> String {

--- a/guard/tests/validate.rs
+++ b/guard/tests/validate.rs
@@ -662,7 +662,7 @@ mod validate_tests {
             .show_summary(vec!["all"])
             .run(&mut writer, &mut reader);
 
-        assert_eq!(StatusCode::PARSING_ERROR, status_code);
+        assert_eq!(StatusCode::VALIDATION_ERROR, status_code);
         assert_output_from_file_eq!(
             "resources/validate/functions/output/failing_count_show_summary_all.out",
             writer

--- a/guard/tests/validate.rs
+++ b/guard/tests/validate.rs
@@ -183,7 +183,7 @@ mod validate_tests {
     #[case(
         vec!["data-dir/s3-public-read-prohibited-template-non-compliant.yaml"],
         vec!["rules-dir/s3_bucket_public_read_prohibited.guard"],
-        StatusCode::PARSING_ERROR
+        StatusCode::VALIDATION_ERROR
     )]
     #[case(vec!["s3-server-side-encryption-template-non-compliant-2.yaml"], vec!["malformed-rule.guard"], StatusCode::INTERNAL_FAILURE)]
     #[case(vec!["malformed-template.yaml"], vec!["s3_bucket_server_side_encryption_enabled_2.guard"], StatusCode::INTERNAL_FAILURE)]
@@ -252,7 +252,7 @@ mod validate_tests {
         vec!["data-dir/s3-public-read-prohibited-template-non-compliant.yaml"],
         vec!["rules-dir/s3_bucket_public_read_prohibited.guard"],
         "resources/validate/output-dir/test_single_data_file_single_rules_file_verbose_non_compliant.out",
-        StatusCode::PARSING_ERROR
+        StatusCode::VALIDATION_ERROR
     )]
     #[case(
         vec!["template_where_resources_isnt_root.json"],
@@ -290,13 +290,13 @@ mod validate_tests {
         vec!["data-dir/s3-public-read-prohibited-template-non-compliant.yaml"],
         vec!["rules-dir/s3_bucket_public_read_prohibited.guard"],
         "resources/validate/output-dir/test_single_data_file_single_rules_file_verbose.out",
-        StatusCode::PARSING_ERROR
+        StatusCode::VALIDATION_ERROR
     )]
     #[case(
         vec!["data-dir/advanced_regex_negative_lookbehind_non_compliant.yaml"],
         vec!["rules-dir/advanced_regex_negative_lookbehind_rule.guard"],
         "resources/validate/output-dir/advanced_regex_negative_lookbehind_non_compliant.out",
-        StatusCode::PARSING_ERROR
+        StatusCode::VALIDATION_ERROR
     )]
     #[case(
         vec!["data-dir/advanced_regex_negative_lookbehind_compliant.yaml"],
@@ -382,7 +382,7 @@ mod validate_tests {
             .rules(rules_arg)
             .run(&mut writer, &mut reader);
 
-        assert_eq!(StatusCode::PARSING_ERROR, status_code);
+        assert_eq!(StatusCode::VALIDATION_ERROR, status_code);
     }
 
     #[rstest::rstest]
@@ -390,7 +390,7 @@ mod validate_tests {
         vec!["db_resource.yaml"],
         vec!["db_param_port_rule.guard"],
         vec!["input-parameters-dir/db_params.yaml"],
-        StatusCode::PARSING_ERROR
+        StatusCode::VALIDATION_ERROR
     )]
     #[case(
         vec!["db_resource.yaml"],
@@ -485,7 +485,7 @@ mod validate_tests {
             "resources/validate/output-dir/payload_verbose_non_compliant.out",
             writer
         );
-        assert_eq!(StatusCode::PARSING_ERROR, status_code);
+        assert_eq!(StatusCode::VALIDATION_ERROR, status_code);
     }
 
     #[test]
@@ -546,7 +546,7 @@ mod validate_tests {
             "#
         };
 
-        assert_eq!(StatusCode::PARSING_ERROR, status_code);
+        assert_eq!(StatusCode::VALIDATION_ERROR, status_code);
         assert_eq!(expected, result);
     }
 
@@ -566,7 +566,7 @@ mod validate_tests {
             .run(&mut writer, &mut reader);
 
         assert_output_from_file_eq!("resources/validate/output-dir/structured.json", writer);
-        assert_eq!(StatusCode::PARSING_ERROR, status_code);
+        assert_eq!(StatusCode::VALIDATION_ERROR, status_code);
     }
 
     #[test]
@@ -585,7 +585,7 @@ mod validate_tests {
             .run(&mut writer, &mut reader);
 
         assert_output_from_file_eq!("resources/validate/output-dir/structured.yaml", writer);
-        assert_eq!(StatusCode::PARSING_ERROR, status_code);
+        assert_eq!(StatusCode::VALIDATION_ERROR, status_code);
     }
 
     #[test]

--- a/guard/tests/validate.rs
+++ b/guard/tests/validate.rs
@@ -258,13 +258,13 @@ mod validate_tests {
         vec!["template_where_resources_isnt_root.json"],
         vec!["workshop.guard"],
         "resources/validate/output-dir/failing_template_without_resources_at_root.out",
-        StatusCode::PARSING_ERROR
+        StatusCode::VALIDATION_ERROR
     )]
     #[case(
         vec!["failing_template_with_slash_in_key.yaml"],
         vec!["rules-dir/s3_bucket_server_side_encryption_enabled.guard"],
         "resources/validate/output-dir/failing_template_with_slash_in_key.out",
-        StatusCode::PARSING_ERROR
+        StatusCode::VALIDATION_ERROR
     )]
     fn test_single_data_file_single_rules_file_verbose(
         #[case] data_arg: Vec<&str>,


### PR DESCRIPTION
*Issue #, if available:*
#344 

*Description of changes:*
Previously exit codes for the validation command were the same regardless of a parsing error or just a rule failure. This change introduces a new error code (19) for when a rule fails. This allows customers to more easily distinguish the root of the issue. 

I updated all old tests for validate that would now result in a status code of 19 instead of 5. I also added a test that checks the error code for a test command that fails (7). 

---
*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
