### PR TITLE
Adding support for arm64 architecture for both linux and macos

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,9 +46,13 @@ jobs:
             cp README.md ./cfn-guard-v3-x86_64-${{ matrix.os }}/
             tar czvf ./cfn-guard-v3-x86_64-${{ matrix.os }}.tar.gz ./cfn-guard-v3-x86_64-${{ matrix.os }}
 
+            export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=aarch64-linux-gnu-gcc
             rustup target add aarch64-unknown-linux-musl
             cargo build --release --target aarch64-unknown-linux-musl
             mkdir cfn-guard-v3-aarch64-${{ matrix.os }}
+            cp ./target/aarch64-unknown-linux-musl/release/cfn-guard ./cfn-guard-v3-aarch64-${{ matrix.os }}/
+            cp README.md ./cfn-guard-v3-aarch64-${{ matrix.os }}/
+            tar czvf ./cfn-guard-v3-aarch64-${{ matrix.os }}.tar.gz ./cfn-guard-v3-aarch64-${{ matrix.os }}
       - name: Upload x86 Release Asset
         id: upload-x86_64-release-asset
         uses: actions/upload-release-asset@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
             cp README.md ./cfn-guard-v3-aarch64-${{ matrix.os }}/
             tar czvf ./cfn-guard-v3-aarch64-${{ matrix.os }}.tar.gz ./cfn-guard-v3-aarch64-${{ matrix.os }}
       - name: Upload x86 Release Asset
-        id: upload-release-asset
+        id: upload-x86_64-release-asset
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -63,7 +63,7 @@ jobs:
           asset_name: cfn-guard-v3-x86_64-${{ matrix.os }}.tar.gz
           asset_content_type: application/octet-stream
       - name: Upload arm64 Release Asset
-        id: upload-release-asset
+        id: upload-aarch64-release-asset
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,9 +49,6 @@ jobs:
             rustup target add aarch64-unknown-linux-musl
             cargo build --release --target aarch64-unknown-linux-musl
             mkdir cfn-guard-v3-aarch64-${{ matrix.os }}
-            cp ./target/aarch64-unknown-linux-musl/release/cfn-guard ./cfn-guard-v3-aarch64-${{ matrix.os }}/
-            cp README.md ./cfn-guard-v3-aarch64-${{ matrix.os }}/
-            tar czvf ./cfn-guard-v3-aarch64-${{ matrix.os }}.tar.gz ./cfn-guard-v3-aarch64-${{ matrix.os }}
       - name: Upload x86 Release Asset
         id: upload-x86_64-release-asset
         uses: actions/upload-release-asset@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,7 @@ jobs:
             cp README.md ./cfn-guard-v3-x86_64-${{ matrix.os }}/
             tar czvf ./cfn-guard-v3-x86_64-${{ matrix.os }}.tar.gz ./cfn-guard-v3-x86_64-${{ matrix.os }}
 
+            sudo apt update
             sudo apt install gcc-aarch64-linux-gnu
             export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=aarch64-linux-gnu-gcc
             rustup target add aarch64-unknown-linux-musl

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,6 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        arch: [aarch64, x86_64]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
@@ -53,6 +52,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.get_release.outputs.upload_url }}
-          asset_path: ./cfn-guard-v3-${{ matrix.arch }}-${{ matrix.os }}.tar.gz
-          asset_name: cfn-guard-v3-${{ matrix.arch }}-${{ matrix.os }}.tar.gz
+          asset_path: ./cfn-guard-v3-${{ matrix.os }}.tar.gz
+          asset_name: cfn-guard-v3-${{ matrix.os }}.tar.gz
           asset_content_type: application/octet-stream

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,14 +46,6 @@ jobs:
             cp ./target/x86_64-unknown-linux-musl/release/cfn-guard ./cfn-guard-v3-x86_64-${{ matrix.os }}/
             cp README.md ./cfn-guard-v3-x86_64-${{ matrix.os }}/
             tar czvf ./cfn-guard-v3-x86_64-${{ matrix.os }}.tar.gz ./cfn-guard-v3-x86_64-${{ matrix.os }}
-
-            rustup target add aarch64-unknown-linux-musl
-            cargo build --release --target aarch64-unknown-linux-musl
-            mkdir cfn-guard-v3-aarch64-${{ matrix.os }}
-            cp ./target/aarch64-unknown-linux-musl/release/cfn-guard ./cfn-guard-v3-aarch64-${{ matrix.os }}/
-            cp README.md ./cfn-guard-v3-aarch64-${{ matrix.os }}/
-            tar czvf ./cfn-guard-v3-aarch64-${{ matrix.os }}.tar.gz ./cfn-guard-v3-aarch64-${{ matrix.os }}
-
       - name: Upload Release Asset
         id: upload-release-asset
         uses: actions/upload-release-asset@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,13 +45,30 @@ jobs:
             cp ./target/x86_64-unknown-linux-musl/release/cfn-guard ./cfn-guard-v3-x86_64-${{ matrix.os }}/
             cp README.md ./cfn-guard-v3-x86_64-${{ matrix.os }}/
             tar czvf ./cfn-guard-v3-x86_64-${{ matrix.os }}.tar.gz ./cfn-guard-v3-x86_64-${{ matrix.os }}
-      - name: Upload Release Asset
+
+            rustup target add aarch64-unknown-linux-musl
+            cargo build --release --target aarch64-unknown-linux-musl
+            mkdir cfn-guard-v3-aarch64-${{ matrix.os }}
+            cp ./target/aarch64-unknown-linux-musl/release/cfn-guard ./cfn-guard-v3-aarch64-${{ matrix.os }}/
+            cp README.md ./cfn-guard-v3-aarch64-${{ matrix.os }}/
+            tar czvf ./cfn-guard-v3-aarch64-${{ matrix.os }}.tar.gz ./cfn-guard-v3-aarch64-${{ matrix.os }}
+      - name: Upload x86 Release Asset
         id: upload-release-asset
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.get_release.outputs.upload_url }}
-          asset_path: ./cfn-guard-v3-${{ matrix.os }}.tar.gz
-          asset_name: cfn-guard-v3-${{ matrix.os }}.tar.gz
+          asset_path: ./cfn-guard-v3-x86_64-${{ matrix.os }}.tar.gz
+          asset_name: cfn-guard-v3-x86_64-${{ matrix.os }}.tar.gz
+          asset_content_type: application/octet-stream
+      - name: Upload arm64 Release Asset
+        id: upload-release-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.get_release.outputs.upload_url }}
+          asset_path: ./cfn-guard-v3-aarch64-${{ matrix.os }}.tar.gz
+          asset_name: cfn-guard-v3-aarch64-${{ matrix.os }}.tar.gz
           asset_content_type: application/octet-stream

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 name: Rust
 on:
   release:
-    types: [ published ]
+    types: [published]
 env:
   CARGO_TERM_COLOR: always
 
@@ -10,41 +10,57 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
+        arch: [aarch64, x86_64]
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v2
-    - name: Build
-      run: cargo build --verbose --release
-    - name: Get release
-      id: get_release
-      uses: bruceadams/get-release@v1.3.2
-      env:
-        GITHUB_TOKEN: ${{ github.token }}
-    - name: Package release
-      id: package
-      uses: knicknic/os-specific-run@v1.0.3
-      with:
-        macos: |
-          rustup target add x86_64-apple-darwin
-          cargo build --release --target x86_64-apple-darwin
-          mkdir cfn-guard-v3-${{ matrix.os }}
-          cp ./target/x86_64-apple-darwin/release/cfn-guard ./cfn-guard-v3-${{ matrix.os }}/
-          cp README.md ./cfn-guard-v3-${{ matrix.os }}/
-          tar czvf ./cfn-guard-v3-${{ matrix.os }}.tar.gz ./cfn-guard-v3-${{ matrix.os }}
-        linux: |
-          rustup target add x86_64-unknown-linux-musl
-          cargo build --release --target x86_64-unknown-linux-musl
-          mkdir cfn-guard-v3-${{ matrix.os }}
-          cp ./target/x86_64-unknown-linux-musl/release/cfn-guard ./cfn-guard-v3-${{ matrix.os }}/
-          cp README.md ./cfn-guard-v3-${{ matrix.os }}/
-          tar czvf ./cfn-guard-v3-${{ matrix.os }}.tar.gz ./cfn-guard-v3-${{ matrix.os }}
-    - name: Upload Release Asset
-      id: upload-release-asset 
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.get_release.outputs.upload_url }}
-        asset_path: ./cfn-guard-v3-${{ matrix.os }}.tar.gz
-        asset_name: cfn-guard-v3-${{ matrix.os }}.tar.gz
-        asset_content_type: application/octet-stream
+      - uses: actions/checkout@v2
+      - name: Build
+        run: cargo build --verbose --release
+      - name: Get release
+        id: get_release
+        uses: bruceadams/get-release@v1.3.2
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+      - name: Package release
+        id: package
+        uses: knicknic/os-specific-run@v1.0.3
+        with:
+          macos: |
+            rustup target add x86_64-apple-darwin
+            cargo build --release --target x86_64-apple-darwin
+            mkdir cfn-guard-v3-x86_64-${{ matrix.os }}
+            cp ./target/x86_64-apple-darwin/release/cfn-guard ./cfn-guard-v3-x86_64-${{ matrix.os }}/
+            cp README.md ./cfn-guard-v3-x86_64-${{ matrix.os }}/
+            tar czvf ./cfn-guard-v3-x86_64-${{ matrix.os }}.tar.gz ./cfn-guard-v3-x86_64-${{ matrix.os }}
+
+            rustup target add aarch64-apple-darwin
+            cargo build --release --target aarch64-apple-darwin
+            mkdir cfn-guard-v3-aarch64-${{ matrix.os }}
+            cp ./target/aarch64-apple-darwin/release/cfn-guard ./cfn-guard-v3-aarch64-${{ matrix.os }}/
+            cp README.md ./cfn-guard-v3-aarch64-${{ matrix.os }}/
+            tar czvf ./cfn-guard-v3-aarch64-${{ matrix.os }}.tar.gz ./cfn-guard-v3-aarch64-${{ matrix.os }}
+          linux: |
+            rustup target add x86_64-unknown-linux-musl
+            cargo build --release --target x86_64-unknown-linux-musl
+            mkdir cfn-guard-v3-x86_64-${{ matrix.os }}
+            cp ./target/x86_64-unknown-linux-musl/release/cfn-guard ./cfn-guard-v3-x86_64-${{ matrix.os }}/
+            cp README.md ./cfn-guard-v3-x86_64-${{ matrix.os }}/
+            tar czvf ./cfn-guard-v3-x86_64-${{ matrix.os }}.tar.gz ./cfn-guard-v3-x86_64-${{ matrix.os }}
+
+            rustup target add aarch64-unknown-linux-musl
+            cargo build --release --target aarch64-unknown-linux-musl
+            mkdir cfn-guard-v3-aarch64-${{ matrix.os }}
+            cp ./target/aarch64-unknown-linux-musl/release/cfn-guard ./cfn-guard-v3-aarch64-${{ matrix.os }}/
+            cp README.md ./cfn-guard-v3-aarch64-${{ matrix.os }}/
+            tar czvf ./cfn-guard-v3-aarch64-${{ matrix.os }}.tar.gz ./cfn-guard-v3-aarch64-${{ matrix.os }}
+
+      - name: Upload Release Asset
+        id: upload-release-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.get_release.outputs.upload_url }}
+          asset_path: ./cfn-guard-v3-${{ matrix.arch }}-${{ matrix.os }}.tar.gz
+          asset_name: cfn-guard-v3-${{ matrix.arch }}-${{ matrix.os }}.tar.gz
+          asset_content_type: application/octet-stream

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,7 @@ jobs:
             cp README.md ./cfn-guard-v3-x86_64-${{ matrix.os }}/
             tar czvf ./cfn-guard-v3-x86_64-${{ matrix.os }}.tar.gz ./cfn-guard-v3-x86_64-${{ matrix.os }}
 
+            sudo apt install gcc-aarch64-linux-gnu
             export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=aarch64-linux-gnu-gcc
             rustup target add aarch64-unknown-linux-musl
             cargo build --release --target aarch64-unknown-linux-musl

--- a/install-guard.sh
+++ b/install-guard.sh
@@ -98,16 +98,13 @@ check_cmd() {
 
 download() {
 	if check_cmd curl; then
-		$curl -fsSL "$1"
+		curl -fsSL "$1"
 	else
 		wget -qO- "$1"
 	fi
 
 	if [ $? -ne 0 ]; then
-		echo $output
 		err "error attempting to download from the github repository"
-	else
-		echo "good stuff"
 	fi
 }
 

--- a/install-guard.sh
+++ b/install-guard.sh
@@ -25,7 +25,7 @@ main() {
 			mkdir -p ~/.guard/"$MAJOR_VER" ~/.guard/bin ||
 				err "unable to make directories ~/.guard/$MAJOR_VER, ~/.guard/bin"
 			get_os_type
-			download https://github.com/joshfried-aws/cloudformation-guard/releases/download/"$VERSION"/cfn-guard-v"$MAJOR_VER"-"$ARCH_TYPE"-"$OS_TYPE"-latest.tar.gz >/tmp/guard.tar.gz ||
+			download https://github.com/aws-cloudformation/cloudformation-guard/releases/download/"$VERSION"/cfn-guard-v"$MAJOR_VER"-"$ARCH_TYPE"-"$OS_TYPE"-latest.tar.gz >/tmp/guard.tar.gz ||
 				err "unable to download https://github.com/aws-cloudformation/cloudformation-guard/releases/download/$VERSION/cfn-guard-v$MAJOR_VER-"$ARCH_TYPE"-$OS_TYPE-latest.tar.gz"
 			tar -C ~/.guard/"$MAJOR_VER" -xzf /tmp/guard.tar.gz ||
 				err "unable to untar /tmp/guard.tar.gz"
@@ -76,7 +76,7 @@ get_arch_type() {
 }
 
 get_latest_release() {
-	download https://api.github.com/repos/joshfried-aws/cloudformation-guard/releases/latest |
+	download https://api.github.com/repos/aws-cloudformation/cloudformation-guard/releases/latest |
 		awk -F '"' '/tag_name/ { print $4 }' |
 		awk -F '.' '{ print $1 "\n" $0 }'
 }

--- a/install-guard.sh
+++ b/install-guard.sh
@@ -98,11 +98,11 @@ check_cmd() {
 
 download() {
 	if check_cmd curl; then
-		if !(curl -fsSL "$1"); then
+		if ! (curl -fsSL "$1"); then
 			err "error attempting to download from the github repository"
 		fi
 	else
-		if !(wget -qO- "$1"); then
+		if ! (wget -qO- "$1"); then
 			err "error attempting to download from the github repository"
 		fi
 	fi

--- a/install-guard.sh
+++ b/install-guard.sh
@@ -29,7 +29,6 @@ main() {
 				err "unable to download https://github.com/aws-cloudformation/cloudformation-guard/releases/download/$VERSION/cfn-guard-v$MAJOR_VER-"$ARCH_TYPE"-$OS_TYPE-latest.tar.gz"
 			tar -C ~/.guard/"$MAJOR_VER" -xzf /tmp/guard.tar.gz ||
 				err "unable to untar /tmp/guard.tar.gz"
-			echo ~/.guard/"$MAJOR_VER"/cfn-guard-v"$MAJOR_VER"-"$ARCH_TYPE"-"$OS_TYPE"-latest/cfn-guard
 			ln -sf ~/.guard/"$MAJOR_VER"/cfn-guard-v"$MAJOR_VER"-"$ARCH_TYPE"-"$OS_TYPE"-latest/cfn-guard ~/.guard/bin ||
 				err "unable to symlink to ~/.guard/bin directory"
 			~/.guard/bin/cfn-guard help ||

--- a/install-guard.sh
+++ b/install-guard.sh
@@ -25,7 +25,7 @@ main() {
 			mkdir -p ~/.guard/"$MAJOR_VER" ~/.guard/bin ||
 				err "unable to make directories ~/.guard/$MAJOR_VER, ~/.guard/bin"
 			get_os_type
-			download https://github.com/aws-cloudformation/cloudformation-guard/releases/download/"$VERSION"/cfn-guard-v"$MAJOR_VER"-"$ARCH_TYPE"-"$OS_TYPE"-latest.tar.gz >/tmp/guard.tar.gz ||
+			download https://github.com/joshfried-aws/cloudformation-guard/releases/download/"$VERSION"/cfn-guard-v"$MAJOR_VER"-"$ARCH_TYPE"-"$OS_TYPE"-latest.tar.gz >/tmp/guard.tar.gz ||
 				err "unable to download https://github.com/aws-cloudformation/cloudformation-guard/releases/download/$VERSION/cfn-guard-v$MAJOR_VER-"$ARCH_TYPE"-$OS_TYPE-latest.tar.gz"
 			tar -C ~/.guard/"$MAJOR_VER" -xzf /tmp/guard.tar.gz ||
 				err "unable to untar /tmp/guard.tar.gz"
@@ -62,7 +62,9 @@ get_arch_type() {
 	arm64)
 		ARCH_TYPE="aarch64"
 		;;
-
+	aarch64)
+		ARCH_TYPE="aarch64"
+		;;
 	x86_64)
 		ARCH_TYPE="x86_64"
 		;;
@@ -74,7 +76,7 @@ get_arch_type() {
 }
 
 get_latest_release() {
-	download https://api.github.com/repos/aws-cloudformation/cloudformation-guard/releases/latest |
+	download https://api.github.com/repos/joshfried-aws/cloudformation-guard/releases/latest |
 		awk -F '"' '/tag_name/ { print $4 }' |
 		awk -F '.' '{ print $1 "\n" $0 }'
 }
@@ -96,7 +98,7 @@ check_cmd() {
 
 download() {
 	if check_cmd curl; then
-		curl -fsSL "$1"
+		$curl -fsSL "$1"
 	else
 		wget -qO- "$1"
 	fi

--- a/install-guard.sh
+++ b/install-guard.sh
@@ -25,8 +25,8 @@ main() {
 			mkdir -p ~/.guard/"$MAJOR_VER" ~/.guard/bin ||
 				err "unable to make directories ~/.guard/$MAJOR_VER, ~/.guard/bin"
 			get_os_type
-			download https://github.com/aws-cloudformation/cloudformation-guard/releases/download/"$VERSION"/cfn-guard-v"$MAJOR_VER"-"$ARCH_TYPE"-"$OS_TYPE"-latest.tar.gz >/tmp/guard.tar.gz ||
-				err "unable to download https://github.com/aws-cloudformation/cloudformation-guard/releases/download/$VERSION/cfn-guard-v$MAJOR_VER-"$ARCH_TYPE"-$OS_TYPE-latest.tar.gz"
+			download https://github.com/cloudformation-guard/releases/download/"$VERSION"/cfn-guard-v"$MAJOR_VER"-"$ARCH_TYPE"-"$OS_TYPE"-latest.tar.gz >/tmp/guard.tar.gz ||
+				err "unable to download https://github.com/aws-cloudformation/cloudformation-guard/releases/download/$VERSION/cfn-guard-v$MAJOR_VER-$ARCH_TYPE-$OS_TYPE-latest.tar.gz"
 			tar -C ~/.guard/"$MAJOR_VER" -xzf /tmp/guard.tar.gz ||
 				err "unable to untar /tmp/guard.tar.gz"
 			ln -sf ~/.guard/"$MAJOR_VER"/cfn-guard-v"$MAJOR_VER"-"$ARCH_TYPE"-"$OS_TYPE"-latest/cfn-guard ~/.guard/bin ||
@@ -98,13 +98,13 @@ check_cmd() {
 
 download() {
 	if check_cmd curl; then
-		curl -fsSL "$1"
+		if !(curl -fsSL "$1"); then
+			err "error attempting to download from the github repository"
+		fi
 	else
-		wget -qO- "$1"
-	fi
-
-	if [ $? -ne 0 ]; then
-		err "error attempting to download from the github repository"
+		if !(wget -qO- "$1"); then
+			err "error attempting to download from the github repository"
+		fi
 	fi
 }
 

--- a/install-guard.sh
+++ b/install-guard.sh
@@ -29,6 +29,7 @@ main() {
 				err "unable to download https://github.com/aws-cloudformation/cloudformation-guard/releases/download/$VERSION/cfn-guard-v$MAJOR_VER-"$ARCH_TYPE"-$OS_TYPE-latest.tar.gz"
 			tar -C ~/.guard/"$MAJOR_VER" -xzf /tmp/guard.tar.gz ||
 				err "unable to untar /tmp/guard.tar.gz"
+			echo ~/.guard/"$MAJOR_VER"/cfn-guard-v"$MAJOR_VER"-"$ARCH_TYPE"-"$OS_TYPE"-latest/cfn-guard
 			ln -sf ~/.guard/"$MAJOR_VER"/cfn-guard-v"$MAJOR_VER"-"$ARCH_TYPE"-"$OS_TYPE"-latest/cfn-guard ~/.guard/bin ||
 				err "unable to symlink to ~/.guard/bin directory"
 			~/.guard/bin/cfn-guard help ||

--- a/install-guard.sh
+++ b/install-guard.sh
@@ -29,7 +29,7 @@ main() {
 				err "unable to download https://github.com/aws-cloudformation/cloudformation-guard/releases/download/$VERSION/cfn-guard-v$MAJOR_VER-"$ARCH_TYPE"-$OS_TYPE-latest.tar.gz"
 			tar -C ~/.guard/"$MAJOR_VER" -xzf /tmp/guard.tar.gz ||
 				err "unable to untar /tmp/guard.tar.gz"
-			ln -sf ~/.guard/"$MAJOR_VER"/cfn-guard-v"$MAJOR_VER"-"$OS_TYPE"-latest/cfn-guard ~/.guard/bin ||
+			ln -sf ~/.guard/"$MAJOR_VER"/cfn-guard-v"$MAJOR_VER"-"$ARCH_TYPE"-"$OS_TYPE"-latest/cfn-guard ~/.guard/bin ||
 				err "unable to symlink to ~/.guard/bin directory"
 			~/.guard/bin/cfn-guard help ||
 				err "cfn-guard was not installed properly"

--- a/install-guard.sh
+++ b/install-guard.sh
@@ -5,83 +5,108 @@
 # to the latest one
 
 main() {
-    if ! ( check_cmd curl || check_cmd wget ); then
-        err "need 'curl' or 'wget' (command not found)"
-    fi
-    need_cmd awk
-    need_cmd mkdir
-    need_cmd rm
-    need_cmd uname
-    need_cmd tar
-    need_cmd ln
+	if ! (check_cmd curl || check_cmd wget); then
+		err "need 'curl' or 'wget' (command not found)"
+	fi
+	need_cmd awk
+	need_cmd mkdir
+	need_cmd rm
+	need_cmd uname
+	need_cmd tar
+	need_cmd ln
 
-    get_os_type
-    get_latest_release |
-        while read -r MAJOR_VER; read -r VERSION; do
-            mkdir -p ~/.guard/"$MAJOR_VER" ~/.guard/bin ||
-                err "unable to make directories ~/.guard/$MAJOR_VER, ~/.guard/bin"
-            get_os_type
-            download https://github.com/aws-cloudformation/cloudformation-guard/releases/download/"$VERSION"/cfn-guard-v"$MAJOR_VER"-"$OS_TYPE"-latest.tar.gz > /tmp/guard.tar.gz ||
-                err "unable to download https://github.com/aws-cloudformation/cloudformation-guard/releases/download/$VERSION/cfn-guard-v$MAJOR_VER-$OS_TYPE-latest.tar.gz"
-            tar -C ~/.guard/"$MAJOR_VER" -xzf /tmp/guard.tar.gz ||
-                err "unable to untar /tmp/guard.tar.gz"
-            ln -sf ~/.guard/"$MAJOR_VER"/cfn-guard-v"$MAJOR_VER"-"$OS_TYPE"-latest/cfn-guard ~/.guard/bin ||
-                err "unable to symlink to ~/.guard/bin directory"
-            ~/.guard/bin/cfn-guard help ||
-                err "cfn-guard was not installed properly"
-            echo "Remember to SET PATH include PATH=\${PATH}:~/.guard/bin"
-        done
+	get_os_type
+	get_arch_type
+	get_latest_release |
+		while
+			read -r MAJOR_VER
+			read -r VERSION
+		do
+			mkdir -p ~/.guard/"$MAJOR_VER" ~/.guard/bin ||
+				err "unable to make directories ~/.guard/$MAJOR_VER, ~/.guard/bin"
+			get_os_type
+			download https://github.com/aws-cloudformation/cloudformation-guard/releases/download/"$VERSION"/cfn-guard-v"$MAJOR_VER"-"$ARCH_TYPE"-"$OS_TYPE"-latest.tar.gz >/tmp/guard.tar.gz ||
+				err "unable to download https://github.com/aws-cloudformation/cloudformation-guard/releases/download/$VERSION/cfn-guard-v$MAJOR_VER-"$ARCH_TYPE"-$OS_TYPE-latest.tar.gz"
+			tar -C ~/.guard/"$MAJOR_VER" -xzf /tmp/guard.tar.gz ||
+				err "unable to untar /tmp/guard.tar.gz"
+			ln -sf ~/.guard/"$MAJOR_VER"/cfn-guard-v"$MAJOR_VER"-"$OS_TYPE"-latest/cfn-guard ~/.guard/bin ||
+				err "unable to symlink to ~/.guard/bin directory"
+			~/.guard/bin/cfn-guard help ||
+				err "cfn-guard was not installed properly"
+			echo "Remember to SET PATH include PATH=\${PATH}:~/.guard/bin"
+		done
 }
 
 get_os_type() {
-    _ostype="$(uname -s)"
-    case "$_ostype" in
-        Darwin)
-            OS_TYPE="macos"
-            ;;
+	_ostype="$(uname -s)"
+	case "$_ostype" in
+	Darwin)
+		OS_TYPE="macos"
+		;;
 
-        Linux)
-            # IS this RIGHT, we need to build for different ARCH as well.
-            # Need more ARCH level detections
-            OS_TYPE="ubuntu"
-            ;;
+	Linux)
+		# IS this RIGHT, we need to build for different ARCH as well.
+		# Need more ARCH level detections
+		OS_TYPE="ubuntu"
+		;;
 
-        *)
-            err "unsupported OS type $_ostype"
-            ;;
-    esac
+	*)
+		err "unsupported OS type $_ostype"
+		;;
+	esac
 }
 
+get_arch_type() {
+	_archtype="$(uname -m)"
+	case "$_archtype" in
+	arm64)
+		ARCH_TYPE="aarch64"
+		;;
+
+	x86_64)
+		ARCH_TYPE="x86_64"
+		;;
+
+	*)
+		err "unsupported architecture type $_archtype"
+		;;
+	esac
+}
 
 get_latest_release() {
-    download https://api.github.com/repos/aws-cloudformation/cloudformation-guard/releases/latest |
-    awk -F '"' '/tag_name/ { print $4 }' |
-    awk -F '.' '{ print $1 "\n" $0 }'
+	download https://api.github.com/repos/aws-cloudformation/cloudformation-guard/releases/latest |
+		awk -F '"' '/tag_name/ { print $4 }' |
+		awk -F '.' '{ print $1 "\n" $0 }'
 }
 
 err() {
-    echo "$1" >&2
-    exit 1
+	echo "$1" >&2
+	exit 1
 }
 
 need_cmd() {
-    if ! check_cmd "$1"; then
-        err "need '$1' (command not found)"
-    fi
+	if ! check_cmd "$1"; then
+		err "need '$1' (command not found)"
+	fi
 }
 
 check_cmd() {
-    command -v "$1" > /dev/null 2>&1
+	command -v "$1" >/dev/null 2>&1
 }
 
-download()
-{
-    if check_cmd curl; then
-        curl -fsSL "$1"
-    else
-        wget -qO- "$1"
-    fi
-}
+download() {
+	if check_cmd curl; then
+		curl -fsSL "$1"
+	else
+		wget -qO- "$1"
+	fi
 
+	if [ $? -ne 0 ]; then
+		echo $output
+		err "error attempting to download from the github repository"
+	else
+		echo "good stuff"
+	fi
+}
 
 main


### PR DESCRIPTION
*Issue #, if available:*
#314 #385 

*Description of changes:*
This PR adds support to add guard binaries for both x86 and arm64 architectures for guard binaries on release. In this PR we also added a check for the status code after the curl/wget command to download from github happens. If it is anything other than 0, we indicate a failure. 

---
*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
