### PR TITLE
Conversion functions

### DIFF
--- a/guard/resources/validate/functions/data/template.yaml
+++ b/guard/resources/validate/functions/data/template.yaml
@@ -38,3 +38,12 @@ Resources:
     Type: AWS::S3::Bucket
   bucket4:
     Type: AWS::S3::Bucket
+  asg:
+    Type: AWS::AutoScaling::AutoScalingGroup
+    Properties:
+      MaxSize: "5.0"
+      MinSize: "1"
+      NewInstancesProtectedFromScaleIn: true
+      DefaultInstanceWarmup: 1.5
+      HealthCheckGracePeriod: 1
+      HealthCheckType: "true"

--- a/guard/resources/validate/functions/rules/converters.guard
+++ b/guard/resources/validate/functions/rules/converters.guard
@@ -6,9 +6,6 @@ rule test_parse_int when %asg !empty {
 
     %min == 1
 
-    let new_instances = parse_int(%asg.Properties.NewInstancesProtectedFromScaleIn)
-    %new_instances == 1
-
     let default = parse_int(%asg.Properties.DefaultInstanceWarmup)
     %default == 1
 }

--- a/guard/resources/validate/functions/rules/converters.guard
+++ b/guard/resources/validate/functions/rules/converters.guard
@@ -1,10 +1,14 @@
 let asg = Resources.*[ Type == 'AWS::AutoScaling::AutoScalingGroup' ]
 
 
+let c = '1'
 rule test_parse_int when %asg !empty {
     let min = parse_int(%asg.Properties.MinSize)
 
     %min == 1
+
+    let char = parse_int(%c)
+    %char == 1
 
     let default = parse_int(%asg.Properties.DefaultInstanceWarmup)
     %default == 1
@@ -21,6 +25,9 @@ rule test_parse_float when %asg !empty {
 
     let health_check_period = parse_float(%asg.Properties.HealthCheckGracePeriod)
 
+    let char = parse_float(%c)
+    %char == 1.0
+
     %health_check_period == 1.0
 }
 
@@ -31,6 +38,9 @@ rule test_parse_str when %asg !empty {
 
     let health_check = parse_string(%asg.Properties.HealthCheckGracePeriod)
     %health_check == "1"
+
+    let char = parse_string(%c)
+    %char == "1"
 
     let new_instances = parse_string(%asg.Properties.NewInstancesProtectedFromScaleIn)
     %new_instances == "true"

--- a/guard/resources/validate/functions/rules/converters.guard
+++ b/guard/resources/validate/functions/rules/converters.guard
@@ -1,0 +1,40 @@
+let asg = Resources.*[ Type == 'AWS::AutoScaling::AutoScalingGroup' ]
+
+
+rule test_parse_int when %asg !empty {
+    let min = parse_int(%asg.Properties.MinSize)
+
+    %min == 1
+
+    let new_instances = parse_int(%asg.Properties.NewInstancesProtectedFromScaleIn)
+    %new_instances == 1
+
+    let default = parse_int(%asg.Properties.DefaultInstanceWarmup)
+    %default == 1
+}
+
+rule test_parse_bool when %asg !empty {
+    let health_check = parse_boolean(%asg.Properties.HealthCheckType)
+    %health_check == true
+}
+
+rule test_parse_float when %asg !empty {
+    let max = parse_float(%asg.Properties.MaxSize)
+    %max == 5.0
+
+    let health_check_period = parse_float(%asg.Properties.HealthCheckGracePeriod)
+
+    %health_check_period == 1.0
+}
+
+rule test_parse_str when %asg !empty {
+    let default = parse_string(%asg.Properties.DefaultInstanceWarmup)
+
+    %default == "1.5"
+
+    let health_check = parse_string(%asg.Properties.HealthCheckGracePeriod)
+    %health_check == "1"
+
+    let new_instances = parse_string(%asg.Properties.NewInstancesProtectedFromScaleIn)
+    %new_instances == "true"
+}

--- a/guard/src/rules/eval_context.rs
+++ b/guard/src/rules/eval_context.rs
@@ -4,9 +4,11 @@ use crate::rules::exprs::{
     ParameterizedRule, QueryPart, Rule, RulesFile, SliceDisplay,
 };
 use crate::rules::functions::collections::count;
+use crate::rules::functions::converters::{parse_bool, parse_float, parse_int, parse_str};
 use crate::rules::functions::strings::{
     join, json_parse, regex_replace, substring, to_lower, to_upper, url_decode,
 };
+use crate::rules::parser::parse_string;
 use crate::rules::path_value::{MapValue, PathAwareValue};
 use crate::rules::values::CmpOperator;
 use crate::rules::Result;
@@ -1198,7 +1200,8 @@ pub(crate) fn validate_number_of_params(name: &str, num_args: usize) -> Result<(
     let expected_num_args = match name {
         "join" => 2,
         "substring" | "regex_replace" => 3,
-        "count" | "json_parse" | "to_upper" | "to_lower" | "url_decode" => 1,
+        "count" | "json_parse" | "to_upper" | "to_lower" | "url_decode" | "parse_string"
+        | "parse_bool" | "parse_float" | "parse_int" => 1,
         _ => {
             return Err(Error::ParseError(format!(
                 "no such function named {name} exists"
@@ -1304,7 +1307,10 @@ pub(crate) fn try_handle_function_call(
             vec![Some(res)]
         }
         "url_decode" => url_decode(&args[0])?,
-
+        "parse_int" => parse_int(&args[0])?,
+        "parse_float" => parse_float(&args[0])?,
+        "parse_string" => parse_str(&args[0])?,
+        "parse_boolean" => parse_bool(&args[0])?,
         function => return Err(Error::ParseError(format!("No function named {function}"))),
     };
 

--- a/guard/src/rules/eval_context.rs
+++ b/guard/src/rules/eval_context.rs
@@ -4,7 +4,9 @@ use crate::rules::exprs::{
     ParameterizedRule, QueryPart, Rule, RulesFile, SliceDisplay,
 };
 use crate::rules::functions::collections::count;
-use crate::rules::functions::converters::{parse_bool, parse_float, parse_int, parse_str};
+use crate::rules::functions::converters::{
+    parse_bool, parse_char, parse_float, parse_int, parse_str,
+};
 use crate::rules::functions::strings::{
     join, json_parse, regex_replace, substring, to_lower, to_upper, url_decode,
 };
@@ -1200,7 +1202,7 @@ pub(crate) fn validate_number_of_params(name: &str, num_args: usize) -> Result<(
         "join" => 2,
         "substring" | "regex_replace" => 3,
         "count" | "json_parse" | "to_upper" | "to_lower" | "url_decode" | "parse_string"
-        | "parse_boolean" | "parse_float" | "parse_int" => 1,
+        | "parse_boolean" | "parse_float" | "parse_int" | "parse_char" => 1,
         _ => {
             return Err(Error::ParseError(format!(
                 "no such function named {name} exists"
@@ -1310,6 +1312,7 @@ pub(crate) fn try_handle_function_call(
         "parse_float" => parse_float(&args[0])?,
         "parse_string" => parse_str(&args[0])?,
         "parse_boolean" => parse_bool(&args[0])?,
+        "parse_char" => parse_char(&args[0])?,
         function => return Err(Error::ParseError(format!("No function named {function}"))),
     };
 

--- a/guard/src/rules/eval_context.rs
+++ b/guard/src/rules/eval_context.rs
@@ -8,7 +8,6 @@ use crate::rules::functions::converters::{parse_bool, parse_float, parse_int, pa
 use crate::rules::functions::strings::{
     join, json_parse, regex_replace, substring, to_lower, to_upper, url_decode,
 };
-use crate::rules::parser::parse_string;
 use crate::rules::path_value::{MapValue, PathAwareValue};
 use crate::rules::values::CmpOperator;
 use crate::rules::Result;
@@ -1201,7 +1200,7 @@ pub(crate) fn validate_number_of_params(name: &str, num_args: usize) -> Result<(
         "join" => 2,
         "substring" | "regex_replace" => 3,
         "count" | "json_parse" | "to_upper" | "to_lower" | "url_decode" | "parse_string"
-        | "parse_bool" | "parse_float" | "parse_int" => 1,
+        | "parse_boolean" | "parse_float" | "parse_int" => 1,
         _ => {
             return Err(Error::ParseError(format!(
                 "no such function named {name} exists"

--- a/guard/src/rules/functions.rs
+++ b/guard/src/rules/functions.rs
@@ -1,2 +1,3 @@
 pub(crate) mod collections;
+pub mod converters;
 pub(crate) mod strings;

--- a/guard/src/rules/functions/converters.rs
+++ b/guard/src/rules/functions/converters.rs
@@ -77,7 +77,7 @@ pub(crate) fn parse_int(args: &[QueryResult]) -> crate::rules::Result<Vec<Option
     Ok(aggr)
 }
 
-pub(crate) fn parse_boolean(
+pub(crate) fn parse_bool(
     args: &[QueryResult],
 ) -> crate::rules::Result<Vec<Option<PathAwareValue>>> {
     let mut aggr = vec![];
@@ -109,9 +109,7 @@ pub(crate) fn parse_boolean(
     Ok(aggr)
 }
 
-pub(crate) fn parse_string(
-    args: &[QueryResult],
-) -> crate::rules::Result<Vec<Option<PathAwareValue>>> {
+pub(crate) fn parse_str(args: &[QueryResult]) -> crate::rules::Result<Vec<Option<PathAwareValue>>> {
     let mut aggr = vec![];
     for entry in args.iter() {
         match entry {

--- a/guard/src/rules/functions/converters.rs
+++ b/guard/src/rules/functions/converters.rs
@@ -61,9 +61,6 @@ pub(crate) fn parse_int(args: &[QueryResult]) -> crate::rules::Result<Vec<Option
                 PathAwareValue::Float((path, val)) => {
                     aggr.push(Some(PathAwareValue::Int((path.clone(), *val as i64))))
                 }
-                PathAwareValue::Bool((path, val)) => {
-                    aggr.push(Some(PathAwareValue::Int((path.clone(), *val as i64))))
-                }
                 _ => {
                     aggr.push(None);
                 }

--- a/guard/src/rules/functions/converters.rs
+++ b/guard/src/rules/functions/converters.rs
@@ -1,7 +1,4 @@
-use crate::rules::{
-    path_value::{Path, PathAwareValue},
-    QueryResult,
-};
+use crate::rules::{path_value::PathAwareValue, QueryResult};
 
 pub(crate) fn parse_float(
     args: &[QueryResult],

--- a/guard/src/rules/functions/converters.rs
+++ b/guard/src/rules/functions/converters.rs
@@ -1,4 +1,7 @@
-use crate::rules::{path_value::PathAwareValue, QueryResult};
+use crate::rules::{
+    path_value::{Path, PathAwareValue},
+    QueryResult,
+};
 
 pub(crate) fn parse_float(
     args: &[QueryResult],
@@ -25,6 +28,10 @@ pub(crate) fn parse_float(
                 PathAwareValue::Float((path, val)) => {
                     aggr.push(Some(PathAwareValue::Float((path.clone(), *val))))
                 }
+                PathAwareValue::Char((path, val)) => aggr.push(Some(PathAwareValue::Float((
+                    path.clone(),
+                    convert_char_to_number(val, path)? as f64,
+                )))),
                 _ => {
                     aggr.push(None);
                 }
@@ -36,6 +43,12 @@ pub(crate) fn parse_float(
     }
 
     Ok(aggr)
+}
+
+fn convert_char_to_number(val: &char, path: &Path) -> crate::rules::Result<u32> {
+    val.to_digit(10).ok_or(crate::Error::ParseError(format!(
+        "attempting to convert a string: {val} into a number at {path}"
+    )))
 }
 
 pub(crate) fn parse_int(args: &[QueryResult]) -> crate::rules::Result<Vec<Option<PathAwareValue>>> {
@@ -58,6 +71,10 @@ pub(crate) fn parse_int(args: &[QueryResult]) -> crate::rules::Result<Vec<Option
                 PathAwareValue::Int((path, val)) => {
                     aggr.push(Some(PathAwareValue::Int((path.clone(), *val))))
                 }
+                PathAwareValue::Char((path, val)) => aggr.push(Some(PathAwareValue::Int((
+                    path.clone(),
+                    convert_char_to_number(val, path)? as i64,
+                )))),
                 PathAwareValue::Float((path, val)) => {
                     aggr.push(Some(PathAwareValue::Int((path.clone(), *val as i64))))
                 }
@@ -126,6 +143,10 @@ pub(crate) fn parse_str(args: &[QueryResult]) -> crate::rules::Result<Vec<Option
                 PathAwareValue::String((path, val)) => {
                     aggr.push(Some(PathAwareValue::String((path.clone(), val.clone()))))
                 }
+                PathAwareValue::Char((path, val)) => aggr.push(Some(PathAwareValue::String((
+                    path.clone(),
+                    val.to_string(),
+                )))),
                 _ => {
                     aggr.push(None);
                 }

--- a/guard/src/rules/functions/converters.rs
+++ b/guard/src/rules/functions/converters.rs
@@ -1,0 +1,149 @@
+use crate::rules::{path_value::PathAwareValue, QueryResult};
+
+pub(crate) fn parse_float(
+    args: &[QueryResult],
+) -> crate::rules::Result<Vec<Option<PathAwareValue>>> {
+    let mut aggr = vec![];
+    for entry in args.iter() {
+        match entry {
+            QueryResult::Literal(val) | QueryResult::Resolved(val) => match &**val {
+                PathAwareValue::String((path, val)) => {
+                    let number = match val.parse::<f64>() {
+                        Ok(f) => Some(PathAwareValue::Float((path.clone(), f))),
+                        Err(_) => {
+                            return Err(crate::Error::ParseError(format!(
+                                "attempting to convert a string: {val} into a number at {path}"
+                            )))
+                        }
+                    };
+
+                    aggr.push(number)
+                }
+                PathAwareValue::Int((path, val)) => {
+                    aggr.push(Some(PathAwareValue::Float((path.clone(), *val as f64))))
+                }
+                PathAwareValue::Float((path, val)) => {
+                    aggr.push(Some(PathAwareValue::Float((path.clone(), *val))))
+                }
+                _ => {
+                    aggr.push(None);
+                }
+            },
+            _ => {
+                aggr.push(None);
+            }
+        }
+    }
+
+    Ok(aggr)
+}
+
+pub(crate) fn parse_int(args: &[QueryResult]) -> crate::rules::Result<Vec<Option<PathAwareValue>>> {
+    let mut aggr = vec![];
+    for entry in args.iter() {
+        match entry {
+            QueryResult::Literal(val) | QueryResult::Resolved(val) => match &**val {
+                PathAwareValue::String((path, val)) => {
+                    let number = match val.parse::<i64>() {
+                        Ok(i) => Some(PathAwareValue::Int((path.clone(), i))),
+                        Err(_) => {
+                            return Err(crate::Error::ParseError(format!(
+                                "attempting to convert a string: {val} into a number at {path}"
+                            )))
+                        }
+                    };
+
+                    aggr.push(number)
+                }
+                PathAwareValue::Int((path, val)) => {
+                    aggr.push(Some(PathAwareValue::Int((path.clone(), *val))))
+                }
+                PathAwareValue::Float((path, val)) => {
+                    aggr.push(Some(PathAwareValue::Int((path.clone(), *val as i64))))
+                }
+                PathAwareValue::Bool((path, val)) => {
+                    aggr.push(Some(PathAwareValue::Int((path.clone(), *val as i64))))
+                }
+                _ => {
+                    aggr.push(None);
+                }
+            },
+            _ => {
+                aggr.push(None);
+            }
+        }
+    }
+
+    Ok(aggr)
+}
+
+pub(crate) fn parse_boolean(
+    args: &[QueryResult],
+) -> crate::rules::Result<Vec<Option<PathAwareValue>>> {
+    let mut aggr = vec![];
+    for entry in args.iter() {
+        match entry {
+            QueryResult::Literal(val) | QueryResult::Resolved(val) => match &**val {
+                PathAwareValue::Bool((path, val)) => {
+                    aggr.push(Some(PathAwareValue::Bool((path.clone(), *val))))
+                }
+                PathAwareValue::String((path, val)) => match val.to_lowercase().as_str() {
+                    "true" => aggr.push(Some(PathAwareValue::Bool((path.clone(), true)))),
+                    "false" => aggr.push(Some(PathAwareValue::Bool((path.clone(), false)))),
+                    _ => {
+                        return Err(crate::Error::ParseError(format!(
+                            "attempting to convert a string: {val} into a boolean at {path}"
+                        )))
+                    }
+                },
+                _ => {
+                    aggr.push(None);
+                }
+            },
+            _ => {
+                aggr.push(None);
+            }
+        }
+    }
+
+    Ok(aggr)
+}
+
+pub(crate) fn parse_string(
+    args: &[QueryResult],
+) -> crate::rules::Result<Vec<Option<PathAwareValue>>> {
+    let mut aggr = vec![];
+    for entry in args.iter() {
+        match entry {
+            QueryResult::Literal(val) | QueryResult::Resolved(val) => match &**val {
+                PathAwareValue::Int((path, val)) => aggr.push(Some(PathAwareValue::String((
+                    path.clone(),
+                    val.to_string(),
+                )))),
+                PathAwareValue::Float((path, val)) => aggr.push(Some(PathAwareValue::String((
+                    path.clone(),
+                    val.to_string(),
+                )))),
+                PathAwareValue::Bool((path, val)) => aggr.push(Some(PathAwareValue::String((
+                    path.clone(),
+                    val.to_string(),
+                )))),
+                PathAwareValue::String((path, val)) => {
+                    aggr.push(Some(PathAwareValue::String((path.clone(), val.clone()))))
+                }
+                _ => {
+                    aggr.push(None);
+                }
+            },
+            _ => {
+                aggr.push(None);
+            }
+        }
+    }
+
+    Ok(aggr)
+}
+
+#[cfg(test)]
+#[path = "converters_tests.rs"]
+mod converters_test;

--- a/guard/src/rules/functions/converters_tests.rs
+++ b/guard/src/rules/functions/converters_tests.rs
@@ -1,0 +1,349 @@
+use std::{convert::TryFrom, rc::Rc};
+
+use crate::rules::{
+    eval_context::eval_context_tests::BasicQueryTesting,
+    exprs::AccessQuery,
+    functions::converters::{parse_boolean, parse_float, parse_int, parse_string},
+    path_value::PathAwareValue,
+    EvalContext, QueryResult,
+};
+
+#[test]
+fn test_parse_int() -> crate::rules::Result<()> {
+    let value_str = r#"
+    Resources:
+      SecurityGroup:
+        Type: AWS::EC2::SecurityGroup
+        Properties:
+          SecurityGroupIngress:
+            String: "2456"
+            Bool: true
+            Char: '1'
+            Int: 1
+            Float: 1.0
+            BadValue: "123 not a real number"
+    "#;
+
+    let value = PathAwareValue::try_from(serde_yaml::from_str::<serde_yaml::Value>(value_str)?)?;
+
+    let mut eval = BasicQueryTesting {
+        root: Rc::new(value),
+        recorder: None,
+    };
+
+    let string_query = AccessQuery::try_from(
+        r#"Resources[ Type == 'AWS::EC2::SecurityGroup' ].Properties.SecurityGroupIngress.String"#,
+    )?;
+
+    let results = eval.query(&string_query.query)?;
+    match results[0].clone() {
+        QueryResult::Literal(val) | QueryResult::Resolved(val) => {
+            assert!(matches!(&*val, PathAwareValue::String(_)));
+        }
+        _ => unreachable!(),
+    }
+
+    let integer = parse_int(&results)?;
+    assert!(matches!(
+        integer[0].as_ref().unwrap(),
+        PathAwareValue::Int((_, 2456))
+    ));
+
+    let bool_query = AccessQuery::try_from(
+        r#"Resources[ Type == 'AWS::EC2::SecurityGroup' ].Properties.SecurityGroupIngress.Bool"#,
+    )?;
+    let results = eval.query(&bool_query.query)?;
+    match results[0].clone() {
+        QueryResult::Literal(val) | QueryResult::Resolved(val) => {
+            assert!(matches!(&*val, PathAwareValue::Bool(_)));
+        }
+        _ => unreachable!(),
+    }
+
+    let integer = parse_int(&results)?;
+    assert!(matches!(
+        integer[0].as_ref().unwrap(),
+        PathAwareValue::Int((_, 1))
+    ));
+
+    let char_query = AccessQuery::try_from(
+        r#"Resources[ Type == 'AWS::EC2::SecurityGroup' ].Properties.SecurityGroupIngress.Char"#,
+    )?;
+    let results = eval.query(&char_query.query)?;
+    match results[0].clone() {
+        QueryResult::Literal(val) | QueryResult::Resolved(val) => {
+            assert!(matches!(&*val, PathAwareValue::String(_)));
+        }
+        _ => unreachable!(),
+    }
+
+    let integer = parse_int(&results)?;
+    assert!(matches!(
+        integer[0].as_ref().unwrap(),
+        PathAwareValue::Int((_, 1))
+    ));
+
+    let int_query = AccessQuery::try_from(
+        r#"Resources[ Type == 'AWS::EC2::SecurityGroup' ].Properties.SecurityGroupIngress.Int"#,
+    )?;
+    let results = eval.query(&int_query.query)?;
+    match results[0].clone() {
+        QueryResult::Literal(val) | QueryResult::Resolved(val) => {
+            assert!(matches!(&*val, PathAwareValue::Int(_)));
+        }
+        _ => unreachable!(),
+    }
+
+    let integer = parse_int(&results)?;
+    assert!(matches!(
+        integer[0].as_ref().unwrap(),
+        PathAwareValue::Int((_, 1))
+    ));
+
+    let float_query = AccessQuery::try_from(
+        r#"Resources[ Type == 'AWS::EC2::SecurityGroup' ].Properties.SecurityGroupIngress.Float"#,
+    )?;
+    let results = eval.query(&float_query.query)?;
+    match results[0].clone() {
+        QueryResult::Literal(val) | QueryResult::Resolved(val) => {
+            assert!(matches!(&*val, PathAwareValue::Float(_)));
+        }
+        _ => unreachable!(),
+    }
+
+    let integer = parse_int(&results)?;
+    assert!(matches!(
+        integer[0].as_ref().unwrap(),
+        PathAwareValue::Int((_, 1))
+    ));
+
+    let bad_value_query = AccessQuery::try_from(
+        r#"Resources[ Type == 'AWS::EC2::SecurityGroup' ].Properties.SecurityGroupIngress.BadValue"#,
+    )?;
+
+    let results = eval.query(&bad_value_query.query)?;
+    match results[0].clone() {
+        QueryResult::Literal(val) | QueryResult::Resolved(val) => {
+            assert!(matches!(&*val, PathAwareValue::String(_)));
+        }
+        _ => unreachable!(),
+    }
+
+    let integer = parse_int(&results);
+    assert!(integer.is_err());
+
+    Ok(())
+}
+
+#[test]
+fn test_parse_float() -> crate::rules::Result<()> {
+    let value_str = r#"
+    Resources:
+      SecurityGroup:
+        Type: AWS::EC2::SecurityGroup
+        Properties:
+          SecurityGroupIngress:
+            String: "2.0"
+            Int: 1
+            Float: 1.0
+            BadValue: "123 not a real number"
+    "#;
+
+    let value = PathAwareValue::try_from(serde_yaml::from_str::<serde_yaml::Value>(value_str)?)?;
+
+    let mut eval = BasicQueryTesting {
+        root: Rc::new(value),
+        recorder: None,
+    };
+
+    let string_query = AccessQuery::try_from(
+        r#"Resources[ Type == 'AWS::EC2::SecurityGroup' ].Properties.SecurityGroupIngress.String"#,
+    )?;
+
+    let results = eval.query(&string_query.query)?;
+    match results[0].clone() {
+        QueryResult::Literal(val) | QueryResult::Resolved(val) => {
+            assert!(matches!(&*val, PathAwareValue::String(_)));
+        }
+        _ => unreachable!(),
+    }
+
+    let float = parse_float(&results)?;
+    assert!(matches!(
+        float[0].as_ref().unwrap(),
+        PathAwareValue::Float(_)
+    ));
+
+    let float = parse_float(&results)?;
+    assert!(matches!(
+        float[0].as_ref().unwrap(),
+        PathAwareValue::Float(_)
+    ));
+
+    let int_query = AccessQuery::try_from(
+        r#"Resources[ Type == 'AWS::EC2::SecurityGroup' ].Properties.SecurityGroupIngress.Int"#,
+    )?;
+    let results = eval.query(&int_query.query)?;
+    match results[0].clone() {
+        QueryResult::Literal(val) | QueryResult::Resolved(val) => {
+            assert!(matches!(&*val, PathAwareValue::Int(_)));
+        }
+        _ => unreachable!(),
+    }
+
+    let float = parse_float(&results)?;
+    assert!(matches!(
+        float[0].as_ref().unwrap(),
+        PathAwareValue::Float(_)
+    ));
+
+    let bad_value_query = AccessQuery::try_from(
+        r#"Resources[ Type == 'AWS::EC2::SecurityGroup' ].Properties.SecurityGroupIngress.BadValue"#,
+    )?;
+
+    let results = eval.query(&bad_value_query.query)?;
+    match results[0].clone() {
+        QueryResult::Literal(val) | QueryResult::Resolved(val) => {
+            assert!(matches!(&*val, PathAwareValue::String(_)));
+        }
+        _ => unreachable!(),
+    }
+
+    let float = parse_int(&results);
+    assert!(float.is_err());
+    Ok(())
+}
+
+#[test]
+fn test_parse_boolean() -> crate::rules::Result<()> {
+    let value_str = r#"
+    Resources:
+      SecurityGroup:
+        Type: AWS::EC2::SecurityGroup
+        Properties:
+          SecurityGroupIngress:
+            String: "true"
+            BadValue: "false fkdskljfl"
+            Int: 0
+    "#;
+
+    let value = PathAwareValue::try_from(serde_yaml::from_str::<serde_yaml::Value>(value_str)?)?;
+
+    let mut eval = BasicQueryTesting {
+        root: Rc::new(value),
+        recorder: None,
+    };
+
+    let string_query = AccessQuery::try_from(
+        r#"Resources[ Type == 'AWS::EC2::SecurityGroup' ].Properties.SecurityGroupIngress.String"#,
+    )?;
+
+    let results = eval.query(&string_query.query)?;
+    match results[0].clone() {
+        QueryResult::Literal(val) | QueryResult::Resolved(val) => {
+            assert!(matches!(&*val, PathAwareValue::String(_)));
+        }
+        _ => unreachable!(),
+    }
+
+    let bool = parse_boolean(&results)?;
+    assert!(matches!(
+        bool[0].as_ref().unwrap(),
+        PathAwareValue::Bool((_, true))
+    ));
+
+    let int_query = AccessQuery::try_from(
+        r#"Resources[ Type == 'AWS::EC2::SecurityGroup' ].Properties.SecurityGroupIngress.Int"#,
+    )?;
+    let results = eval.query(&int_query.query)?;
+    match results[0].clone() {
+        QueryResult::Literal(val) | QueryResult::Resolved(val) => {
+            assert!(matches!(&*val, PathAwareValue::Int(_)));
+        }
+        _ => unreachable!(),
+    }
+
+    let bool = parse_boolean(&results)?;
+    assert!(bool[0].as_ref().is_none());
+
+    let bad_value_query = AccessQuery::try_from(
+        r#"Resources[ Type == 'AWS::EC2::SecurityGroup' ].Properties.SecurityGroupIngress.BadValue"#,
+    )?;
+
+    let results = eval.query(&bad_value_query.query)?;
+    match results[0].clone() {
+        QueryResult::Literal(val) | QueryResult::Resolved(val) => {
+            assert!(matches!(&*val, PathAwareValue::String(_)));
+        }
+        _ => unreachable!(),
+    }
+
+    let float = parse_int(&results);
+    assert!(float.is_err());
+    Ok(())
+}
+
+#[test]
+fn test_parse_string() -> crate::rules::Result<()> {
+    let value_str = r#"
+    Resources:
+      SecurityGroup:
+        Type: AWS::EC2::SecurityGroup
+        Properties:
+          SecurityGroupIngress:
+            String: "true"
+            Int: 0
+            Float: 1.0
+            Bool: true
+    "#;
+
+    let value = PathAwareValue::try_from(serde_yaml::from_str::<serde_yaml::Value>(value_str)?)?;
+
+    let mut eval = BasicQueryTesting {
+        root: Rc::new(value),
+        recorder: None,
+    };
+
+    let string_query = AccessQuery::try_from(
+        r#"Resources[ Type == 'AWS::EC2::SecurityGroup' ].Properties.SecurityGroupIngress.String"#,
+    )?;
+
+    let results = eval.query(&string_query.query)?;
+    match results[0].clone() {
+        QueryResult::Literal(val) | QueryResult::Resolved(val) => {
+            assert!(matches!(&*val, PathAwareValue::String(_)));
+        }
+        _ => unreachable!(),
+    }
+
+    let string = parse_string(&results)?;
+    assert!(matches!(
+        string[0].as_ref().unwrap(),
+        PathAwareValue::String(_)
+    ));
+
+    let int_query = AccessQuery::try_from(
+        r#"Resources[ Type == 'AWS::EC2::SecurityGroup' ].Properties.SecurityGroupIngress.Int"#,
+    )?;
+    let results = eval.query(&int_query.query)?;
+    match results[0].clone() {
+        QueryResult::Literal(val) | QueryResult::Resolved(val) => {
+            assert!(matches!(&*val, PathAwareValue::Int(_)));
+        }
+        _ => unreachable!(),
+    }
+
+    let string = parse_string(&results)?;
+    assert!(matches!(
+        string[0].as_ref().unwrap(),
+        PathAwareValue::String(_)
+    ));
+
+    let string = parse_string(&results)?;
+    assert!(matches!(
+        string[0].as_ref().unwrap(),
+        PathAwareValue::String(_)
+    ));
+
+    Ok(())
+}

--- a/guard/src/rules/functions/converters_tests.rs
+++ b/guard/src/rules/functions/converters_tests.rs
@@ -3,7 +3,7 @@ use std::{convert::TryFrom, rc::Rc};
 use crate::rules::{
     eval_context::eval_context_tests::BasicQueryTesting,
     exprs::AccessQuery,
-    functions::converters::{parse_bool, parse_float, parse_int, parse_string},
+    functions::converters::{parse_bool, parse_float, parse_int, parse_str},
     path_value::PathAwareValue,
     EvalContext, QueryResult,
 };
@@ -316,7 +316,7 @@ fn test_parse_string() -> crate::rules::Result<()> {
         _ => unreachable!(),
     }
 
-    let string = parse_string(&results)?;
+    let string = parse_str(&results)?;
     assert!(matches!(
         string[0].as_ref().unwrap(),
         PathAwareValue::String(_)
@@ -333,13 +333,13 @@ fn test_parse_string() -> crate::rules::Result<()> {
         _ => unreachable!(),
     }
 
-    let string = parse_string(&results)?;
+    let string = parse_str(&results)?;
     assert!(matches!(
         string[0].as_ref().unwrap(),
         PathAwareValue::String(_)
     ));
 
-    let string = parse_string(&results)?;
+    let string = parse_str(&results)?;
     assert!(matches!(
         string[0].as_ref().unwrap(),
         PathAwareValue::String(_)

--- a/guard/src/rules/functions/converters_tests.rs
+++ b/guard/src/rules/functions/converters_tests.rs
@@ -49,23 +49,6 @@ fn test_parse_int() -> crate::rules::Result<()> {
         PathAwareValue::Int((_, 2456))
     ));
 
-    let bool_query = AccessQuery::try_from(
-        r#"Resources[ Type == 'AWS::EC2::SecurityGroup' ].Properties.SecurityGroupIngress.Bool"#,
-    )?;
-    let results = eval.query(&bool_query.query)?;
-    match results[0].clone() {
-        QueryResult::Literal(val) | QueryResult::Resolved(val) => {
-            assert!(matches!(&*val, PathAwareValue::Bool(_)));
-        }
-        _ => unreachable!(),
-    }
-
-    let integer = parse_int(&results)?;
-    assert!(matches!(
-        integer[0].as_ref().unwrap(),
-        PathAwareValue::Int((_, 1))
-    ));
-
     let char_query = AccessQuery::try_from(
         r#"Resources[ Type == 'AWS::EC2::SecurityGroup' ].Properties.SecurityGroupIngress.Char"#,
     )?;

--- a/guard/src/rules/functions/converters_tests.rs
+++ b/guard/src/rules/functions/converters_tests.rs
@@ -3,7 +3,7 @@ use std::{convert::TryFrom, rc::Rc};
 use crate::rules::{
     eval_context::eval_context_tests::BasicQueryTesting,
     exprs::AccessQuery,
-    functions::converters::{parse_boolean, parse_float, parse_int, parse_string},
+    functions::converters::{parse_bool, parse_float, parse_int, parse_string},
     path_value::PathAwareValue,
     EvalContext, QueryResult,
 };
@@ -246,7 +246,7 @@ fn test_parse_boolean() -> crate::rules::Result<()> {
         _ => unreachable!(),
     }
 
-    let bool = parse_boolean(&results)?;
+    let bool = parse_bool(&results)?;
     assert!(matches!(
         bool[0].as_ref().unwrap(),
         PathAwareValue::Bool((_, true))
@@ -263,7 +263,7 @@ fn test_parse_boolean() -> crate::rules::Result<()> {
         _ => unreachable!(),
     }
 
-    let bool = parse_boolean(&results)?;
+    let bool = parse_bool(&results)?;
     assert!(bool[0].as_ref().is_none());
 
     let bad_value_query = AccessQuery::try_from(

--- a/guard/tests/validate.rs
+++ b/guard/tests/validate.rs
@@ -637,6 +637,7 @@ mod validate_tests {
     #[case("url_decode.guard")]
     #[case("join.guard")]
     #[case("count.guard")]
+    #[case("converters.guard")]
     fn test_validate_with_fn_expr_success(#[case] rule: &str) {
         let mut reader = Reader::new(Stdin(std::io::stdin()));
         let mut writer = Writer::new(WBVec(vec![]), WBVec(vec![]));


### PR DESCRIPTION
*Issue #, if available:*
#312 

*Description of changes:*
This PR adds the ability to apply the following conversion functions 
1. strings/floats-> ints
2. strings/ints -> floats
3. strings -> bools 
4. bools/floats/ints -> strings 

This allows customers the ability to easily convert properties from schemas that may be better evaluated as a type other than the type defined in the schema (for example Min/MaxSize for AutoScalingGroups are string types, but it is helpful to evaluate them as numbers) 

---
*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
