### PR TITLE
[Fix]: Custom Message is now JSON/YAML parseable

### DIFF
--- a/guard/resources/validate/output-dir/structured.json
+++ b/guard/resources/validate/output-dir/structured.json
@@ -18,7 +18,7 @@
                 "Binary": {
                   "context": " NotAwsAccessKey not EQUALS  \"/(?<![A-Z0-9])[A-Z0-9]{20}(?![A-Z0-9])/\"",
                   "messages": {
-                    "custom_message": null,
+                    "custom_message": "",
                     "error_message": "Check was not compliant as property [NotAwsAccessKey] to compare from is missing. Value traversed to [Path=[L:4,C:0] Value={\"Resources\":{\"MyBucket\":{\"Type\":\"AWS::S3::Bucket\",\"Properties\":{\"BucketEncryption\":{\"ServerSideEncryptionConfiguration\":[{\"ServerSideEncryptionByDefault\":{\"SSEAlgorithm\":\"AES256\"}}]},\"VersioningConfiguration\":{\"Status\":\"Enabled\"}}}}}]."
                   },
                   "check": {
@@ -65,7 +65,7 @@
                 "Binary": {
                   "context": " NotSecretAccessKey not EQUALS  \"/(?<![A-Za-z0-9\\/+=])[A-Za-z0-9\\/+=]{40}(?![A-Za-z0-9\\/+=])/\"",
                   "messages": {
-                    "custom_message": null,
+                    "custom_message": "",
                     "error_message": "Check was not compliant as property [NotSecretAccessKey] to compare from is missing. Value traversed to [Path=[L:4,C:0] Value={\"Resources\":{\"MyBucket\":{\"Type\":\"AWS::S3::Bucket\",\"Properties\":{\"BucketEncryption\":{\"ServerSideEncryptionConfiguration\":[{\"ServerSideEncryptionByDefault\":{\"SSEAlgorithm\":\"AES256\"}}]},\"VersioningConfiguration\":{\"Status\":\"Enabled\"}}}}}]."
                   },
                   "check": {
@@ -176,7 +176,7 @@
                 "Unary": {
                   "context": " %s3_bucket_public_read_prohibited[*].Properties.PublicAccessBlockConfiguration EXISTS  ",
                   "messages": {
-                    "custom_message": null,
+                    "custom_message": "",
                     "error_message": "Check was not compliant as property [PublicAccessBlockConfiguration] is missing. Value traversed to [Path=/Resources/MyBucket/Properties[L:13,C:6] Value={\"BucketEncryption\":{\"ServerSideEncryptionConfiguration\":[{\"ServerSideEncryptionByDefault\":{\"SSEAlgorithm\":\"AES256\"}}]},\"VersioningConfiguration\":{\"Status\":\"Enabled\"}}]."
                   },
                   "check": {
@@ -216,7 +216,7 @@
                 "Binary": {
                   "context": " %s3_bucket_public_read_prohibited[*].Properties.PublicAccessBlockConfiguration.BlockPublicAcls EQUALS  true",
                   "messages": {
-                    "custom_message": null,
+                    "custom_message": "",
                     "error_message": "Check was not compliant as property [PublicAccessBlockConfiguration.BlockPublicAcls] to compare from is missing. Value traversed to [Path=/Resources/MyBucket/Properties[L:13,C:6] Value={\"BucketEncryption\":{\"ServerSideEncryptionConfiguration\":[{\"ServerSideEncryptionByDefault\":{\"SSEAlgorithm\":\"AES256\"}}]},\"VersioningConfiguration\":{\"Status\":\"Enabled\"}}]."
                   },
                   "check": {
@@ -256,7 +256,7 @@
                 "Binary": {
                   "context": " %s3_bucket_public_read_prohibited[*].Properties.PublicAccessBlockConfiguration.BlockPublicPolicy EQUALS  true",
                   "messages": {
-                    "custom_message": null,
+                    "custom_message": "",
                     "error_message": "Check was not compliant as property [PublicAccessBlockConfiguration.BlockPublicPolicy] to compare from is missing. Value traversed to [Path=/Resources/MyBucket/Properties[L:13,C:6] Value={\"BucketEncryption\":{\"ServerSideEncryptionConfiguration\":[{\"ServerSideEncryptionByDefault\":{\"SSEAlgorithm\":\"AES256\"}}]},\"VersioningConfiguration\":{\"Status\":\"Enabled\"}}]."
                   },
                   "check": {
@@ -296,7 +296,7 @@
                 "Binary": {
                   "context": " %s3_bucket_public_read_prohibited[*].Properties.PublicAccessBlockConfiguration.IgnorePublicAcls EQUALS  true",
                   "messages": {
-                    "custom_message": null,
+                    "custom_message": "",
                     "error_message": "Check was not compliant as property [PublicAccessBlockConfiguration.IgnorePublicAcls] to compare from is missing. Value traversed to [Path=/Resources/MyBucket/Properties[L:13,C:6] Value={\"BucketEncryption\":{\"ServerSideEncryptionConfiguration\":[{\"ServerSideEncryptionByDefault\":{\"SSEAlgorithm\":\"AES256\"}}]},\"VersioningConfiguration\":{\"Status\":\"Enabled\"}}]."
                   },
                   "check": {

--- a/guard/resources/validate/output-dir/structured.json
+++ b/guard/resources/validate/output-dir/structured.json
@@ -18,7 +18,7 @@
                 "Binary": {
                   "context": " NotAwsAccessKey not EQUALS  \"/(?<![A-Z0-9])[A-Z0-9]{20}(?![A-Z0-9])/\"",
                   "messages": {
-                    "custom_message": "",
+                    "custom_message": null,
                     "error_message": "Check was not compliant as property [NotAwsAccessKey] to compare from is missing. Value traversed to [Path=[L:4,C:0] Value={\"Resources\":{\"MyBucket\":{\"Type\":\"AWS::S3::Bucket\",\"Properties\":{\"BucketEncryption\":{\"ServerSideEncryptionConfiguration\":[{\"ServerSideEncryptionByDefault\":{\"SSEAlgorithm\":\"AES256\"}}]},\"VersioningConfiguration\":{\"Status\":\"Enabled\"}}}}}]."
                   },
                   "check": {
@@ -65,7 +65,7 @@
                 "Binary": {
                   "context": " NotSecretAccessKey not EQUALS  \"/(?<![A-Za-z0-9\\/+=])[A-Za-z0-9\\/+=]{40}(?![A-Za-z0-9\\/+=])/\"",
                   "messages": {
-                    "custom_message": "",
+                    "custom_message": null,
                     "error_message": "Check was not compliant as property [NotSecretAccessKey] to compare from is missing. Value traversed to [Path=[L:4,C:0] Value={\"Resources\":{\"MyBucket\":{\"Type\":\"AWS::S3::Bucket\",\"Properties\":{\"BucketEncryption\":{\"ServerSideEncryptionConfiguration\":[{\"ServerSideEncryptionByDefault\":{\"SSEAlgorithm\":\"AES256\"}}]},\"VersioningConfiguration\":{\"Status\":\"Enabled\"}}}}}]."
                   },
                   "check": {
@@ -124,7 +124,7 @@
                 "Unary": {
                   "context": " %s3_buckets_bucket_logging_enabled[*].Properties.LoggingConfiguration EXISTS  ",
                   "messages": {
-                    "custom_message": ";    Violation: S3 Bucket Logging needs to be configured to enable logging.;    Fix: Set the S3 Bucket property LoggingConfiguration to start logging into S3 bucket.;  ",
+                    "custom_message": "\n    Violation: S3 Bucket Logging needs to be configured to enable logging.\n    Fix: Set the S3 Bucket property LoggingConfiguration to start logging into S3 bucket.\n  ",
                     "error_message": "Check was not compliant as property [LoggingConfiguration] is missing. Value traversed to [Path=/Resources/MyBucket/Properties[L:13,C:6] Value={\"BucketEncryption\":{\"ServerSideEncryptionConfiguration\":[{\"ServerSideEncryptionByDefault\":{\"SSEAlgorithm\":\"AES256\"}}]},\"VersioningConfiguration\":{\"Status\":\"Enabled\"}}]."
                   },
                   "check": {
@@ -176,7 +176,7 @@
                 "Unary": {
                   "context": " %s3_bucket_public_read_prohibited[*].Properties.PublicAccessBlockConfiguration EXISTS  ",
                   "messages": {
-                    "custom_message": "",
+                    "custom_message": null,
                     "error_message": "Check was not compliant as property [PublicAccessBlockConfiguration] is missing. Value traversed to [Path=/Resources/MyBucket/Properties[L:13,C:6] Value={\"BucketEncryption\":{\"ServerSideEncryptionConfiguration\":[{\"ServerSideEncryptionByDefault\":{\"SSEAlgorithm\":\"AES256\"}}]},\"VersioningConfiguration\":{\"Status\":\"Enabled\"}}]."
                   },
                   "check": {
@@ -216,7 +216,7 @@
                 "Binary": {
                   "context": " %s3_bucket_public_read_prohibited[*].Properties.PublicAccessBlockConfiguration.BlockPublicAcls EQUALS  true",
                   "messages": {
-                    "custom_message": "",
+                    "custom_message": null,
                     "error_message": "Check was not compliant as property [PublicAccessBlockConfiguration.BlockPublicAcls] to compare from is missing. Value traversed to [Path=/Resources/MyBucket/Properties[L:13,C:6] Value={\"BucketEncryption\":{\"ServerSideEncryptionConfiguration\":[{\"ServerSideEncryptionByDefault\":{\"SSEAlgorithm\":\"AES256\"}}]},\"VersioningConfiguration\":{\"Status\":\"Enabled\"}}]."
                   },
                   "check": {
@@ -256,7 +256,7 @@
                 "Binary": {
                   "context": " %s3_bucket_public_read_prohibited[*].Properties.PublicAccessBlockConfiguration.BlockPublicPolicy EQUALS  true",
                   "messages": {
-                    "custom_message": "",
+                    "custom_message": null,
                     "error_message": "Check was not compliant as property [PublicAccessBlockConfiguration.BlockPublicPolicy] to compare from is missing. Value traversed to [Path=/Resources/MyBucket/Properties[L:13,C:6] Value={\"BucketEncryption\":{\"ServerSideEncryptionConfiguration\":[{\"ServerSideEncryptionByDefault\":{\"SSEAlgorithm\":\"AES256\"}}]},\"VersioningConfiguration\":{\"Status\":\"Enabled\"}}]."
                   },
                   "check": {
@@ -296,7 +296,7 @@
                 "Binary": {
                   "context": " %s3_bucket_public_read_prohibited[*].Properties.PublicAccessBlockConfiguration.IgnorePublicAcls EQUALS  true",
                   "messages": {
-                    "custom_message": "",
+                    "custom_message": null,
                     "error_message": "Check was not compliant as property [PublicAccessBlockConfiguration.IgnorePublicAcls] to compare from is missing. Value traversed to [Path=/Resources/MyBucket/Properties[L:13,C:6] Value={\"BucketEncryption\":{\"ServerSideEncryptionConfiguration\":[{\"ServerSideEncryptionByDefault\":{\"SSEAlgorithm\":\"AES256\"}}]},\"VersioningConfiguration\":{\"Status\":\"Enabled\"}}]."
                   },
                   "check": {
@@ -336,7 +336,7 @@
                 "Binary": {
                   "context": " %s3_bucket_public_read_prohibited[*].Properties.PublicAccessBlockConfiguration.RestrictPublicBuckets EQUALS  true",
                   "messages": {
-                    "custom_message": ";    Violation: S3 Bucket Public Write Access controls need to be restricted.;    Fix: Set S3 Bucket PublicAccessBlockConfiguration properties for BlockPublicAcls, BlockPublicPolicy, IgnorePublicAcls, RestrictPublicBuckets parameters to true.;  ",
+                    "custom_message": "\n    Violation: S3 Bucket Public Write Access controls need to be restricted.\n    Fix: Set S3 Bucket PublicAccessBlockConfiguration properties for BlockPublicAcls, BlockPublicPolicy, IgnorePublicAcls, RestrictPublicBuckets parameters to true.\n  ",
                     "error_message": "Check was not compliant as property [PublicAccessBlockConfiguration.RestrictPublicBuckets] to compare from is missing. Value traversed to [Path=/Resources/MyBucket/Properties[L:13,C:6] Value={\"BucketEncryption\":{\"ServerSideEncryptionConfiguration\":[{\"ServerSideEncryptionByDefault\":{\"SSEAlgorithm\":\"AES256\"}}]},\"VersioningConfiguration\":{\"Status\":\"Enabled\"}}]."
                   },
                   "check": {

--- a/guard/resources/validate/output-dir/structured.yaml
+++ b/guard/resources/validate/output-dir/structured.yaml
@@ -13,7 +13,7 @@
           Binary:
             context: ' NotAwsAccessKey not EQUALS  "/(?<![A-Z0-9])[A-Z0-9]{20}(?![A-Z0-9])/"'
             messages:
-              custom_message: null
+              custom_message: ''
               error_message: Check was not compliant as property [NotAwsAccessKey] to compare from is missing. Value traversed to [Path=[L:4,C:0] Value={"Resources":{"MyBucket":{"Type":"AWS::S3::Bucket","Properties":{"BucketEncryption":{"ServerSideEncryptionConfiguration":[{"ServerSideEncryptionByDefault":{"SSEAlgorithm":"AES256"}}]},"VersioningConfiguration":{"Status":"Enabled"}}}}}].
             check:
               UnResolved:
@@ -40,7 +40,7 @@
           Binary:
             context: ' NotSecretAccessKey not EQUALS  "/(?<![A-Za-z0-9\/+=])[A-Za-z0-9\/+=]{40}(?![A-Za-z0-9\/+=])/"'
             messages:
-              custom_message: null
+              custom_message: ''
               error_message: Check was not compliant as property [NotSecretAccessKey] to compare from is missing. Value traversed to [Path=[L:4,C:0] Value={"Resources":{"MyBucket":{"Type":"AWS::S3::Bucket","Properties":{"BucketEncryption":{"ServerSideEncryptionConfiguration":[{"ServerSideEncryptionByDefault":{"SSEAlgorithm":"AES256"}}]},"VersioningConfiguration":{"Status":"Enabled"}}}}}].
             check:
               UnResolved:
@@ -104,7 +104,7 @@
           Unary:
             context: ' %s3_bucket_public_read_prohibited[*].Properties.PublicAccessBlockConfiguration EXISTS  '
             messages:
-              custom_message: null
+              custom_message: ''
               error_message: Check was not compliant as property [PublicAccessBlockConfiguration] is missing. Value traversed to [Path=/Resources/MyBucket/Properties[L:13,C:6] Value={"BucketEncryption":{"ServerSideEncryptionConfiguration":[{"ServerSideEncryptionByDefault":{"SSEAlgorithm":"AES256"}}]},"VersioningConfiguration":{"Status":"Enabled"}}].
             check:
               UnResolved:
@@ -127,7 +127,7 @@
           Binary:
             context: ' %s3_bucket_public_read_prohibited[*].Properties.PublicAccessBlockConfiguration.BlockPublicAcls EQUALS  true'
             messages:
-              custom_message: null
+              custom_message: ''
               error_message: Check was not compliant as property [PublicAccessBlockConfiguration.BlockPublicAcls] to compare from is missing. Value traversed to [Path=/Resources/MyBucket/Properties[L:13,C:6] Value={"BucketEncryption":{"ServerSideEncryptionConfiguration":[{"ServerSideEncryptionByDefault":{"SSEAlgorithm":"AES256"}}]},"VersioningConfiguration":{"Status":"Enabled"}}].
             check:
               UnResolved:
@@ -150,7 +150,7 @@
           Binary:
             context: ' %s3_bucket_public_read_prohibited[*].Properties.PublicAccessBlockConfiguration.BlockPublicPolicy EQUALS  true'
             messages:
-              custom_message: null
+              custom_message: ''
               error_message: Check was not compliant as property [PublicAccessBlockConfiguration.BlockPublicPolicy] to compare from is missing. Value traversed to [Path=/Resources/MyBucket/Properties[L:13,C:6] Value={"BucketEncryption":{"ServerSideEncryptionConfiguration":[{"ServerSideEncryptionByDefault":{"SSEAlgorithm":"AES256"}}]},"VersioningConfiguration":{"Status":"Enabled"}}].
             check:
               UnResolved:
@@ -173,7 +173,7 @@
           Binary:
             context: ' %s3_bucket_public_read_prohibited[*].Properties.PublicAccessBlockConfiguration.IgnorePublicAcls EQUALS  true'
             messages:
-              custom_message: null
+              custom_message: ''
               error_message: Check was not compliant as property [PublicAccessBlockConfiguration.IgnorePublicAcls] to compare from is missing. Value traversed to [Path=/Resources/MyBucket/Properties[L:13,C:6] Value={"BucketEncryption":{"ServerSideEncryptionConfiguration":[{"ServerSideEncryptionByDefault":{"SSEAlgorithm":"AES256"}}]},"VersioningConfiguration":{"Status":"Enabled"}}].
             check:
               UnResolved:

--- a/guard/resources/validate/output-dir/structured.yaml
+++ b/guard/resources/validate/output-dir/structured.yaml
@@ -13,7 +13,7 @@
           Binary:
             context: ' NotAwsAccessKey not EQUALS  "/(?<![A-Z0-9])[A-Z0-9]{20}(?![A-Z0-9])/"'
             messages:
-              custom_message: ''
+              custom_message: null
               error_message: Check was not compliant as property [NotAwsAccessKey] to compare from is missing. Value traversed to [Path=[L:4,C:0] Value={"Resources":{"MyBucket":{"Type":"AWS::S3::Bucket","Properties":{"BucketEncryption":{"ServerSideEncryptionConfiguration":[{"ServerSideEncryptionByDefault":{"SSEAlgorithm":"AES256"}}]},"VersioningConfiguration":{"Status":"Enabled"}}}}}].
             check:
               UnResolved:
@@ -40,7 +40,7 @@
           Binary:
             context: ' NotSecretAccessKey not EQUALS  "/(?<![A-Za-z0-9\/+=])[A-Za-z0-9\/+=]{40}(?![A-Za-z0-9\/+=])/"'
             messages:
-              custom_message: ''
+              custom_message: null
               error_message: Check was not compliant as property [NotSecretAccessKey] to compare from is missing. Value traversed to [Path=[L:4,C:0] Value={"Resources":{"MyBucket":{"Type":"AWS::S3::Bucket","Properties":{"BucketEncryption":{"ServerSideEncryptionConfiguration":[{"ServerSideEncryptionByDefault":{"SSEAlgorithm":"AES256"}}]},"VersioningConfiguration":{"Status":"Enabled"}}}}}].
             check:
               UnResolved:
@@ -74,7 +74,7 @@
           Unary:
             context: ' %s3_buckets_bucket_logging_enabled[*].Properties.LoggingConfiguration EXISTS  '
             messages:
-              custom_message: ';    Violation: S3 Bucket Logging needs to be configured to enable logging.;    Fix: Set the S3 Bucket property LoggingConfiguration to start logging into S3 bucket.;  '
+              custom_message: "\n    Violation: S3 Bucket Logging needs to be configured to enable logging.\n    Fix: Set the S3 Bucket property LoggingConfiguration to start logging into S3 bucket.\n  "
               error_message: Check was not compliant as property [LoggingConfiguration] is missing. Value traversed to [Path=/Resources/MyBucket/Properties[L:13,C:6] Value={"BucketEncryption":{"ServerSideEncryptionConfiguration":[{"ServerSideEncryptionByDefault":{"SSEAlgorithm":"AES256"}}]},"VersioningConfiguration":{"Status":"Enabled"}}].
             check:
               UnResolved:
@@ -104,7 +104,7 @@
           Unary:
             context: ' %s3_bucket_public_read_prohibited[*].Properties.PublicAccessBlockConfiguration EXISTS  '
             messages:
-              custom_message: ''
+              custom_message: null
               error_message: Check was not compliant as property [PublicAccessBlockConfiguration] is missing. Value traversed to [Path=/Resources/MyBucket/Properties[L:13,C:6] Value={"BucketEncryption":{"ServerSideEncryptionConfiguration":[{"ServerSideEncryptionByDefault":{"SSEAlgorithm":"AES256"}}]},"VersioningConfiguration":{"Status":"Enabled"}}].
             check:
               UnResolved:
@@ -127,7 +127,7 @@
           Binary:
             context: ' %s3_bucket_public_read_prohibited[*].Properties.PublicAccessBlockConfiguration.BlockPublicAcls EQUALS  true'
             messages:
-              custom_message: ''
+              custom_message: null
               error_message: Check was not compliant as property [PublicAccessBlockConfiguration.BlockPublicAcls] to compare from is missing. Value traversed to [Path=/Resources/MyBucket/Properties[L:13,C:6] Value={"BucketEncryption":{"ServerSideEncryptionConfiguration":[{"ServerSideEncryptionByDefault":{"SSEAlgorithm":"AES256"}}]},"VersioningConfiguration":{"Status":"Enabled"}}].
             check:
               UnResolved:
@@ -150,7 +150,7 @@
           Binary:
             context: ' %s3_bucket_public_read_prohibited[*].Properties.PublicAccessBlockConfiguration.BlockPublicPolicy EQUALS  true'
             messages:
-              custom_message: ''
+              custom_message: null
               error_message: Check was not compliant as property [PublicAccessBlockConfiguration.BlockPublicPolicy] to compare from is missing. Value traversed to [Path=/Resources/MyBucket/Properties[L:13,C:6] Value={"BucketEncryption":{"ServerSideEncryptionConfiguration":[{"ServerSideEncryptionByDefault":{"SSEAlgorithm":"AES256"}}]},"VersioningConfiguration":{"Status":"Enabled"}}].
             check:
               UnResolved:
@@ -173,7 +173,7 @@
           Binary:
             context: ' %s3_bucket_public_read_prohibited[*].Properties.PublicAccessBlockConfiguration.IgnorePublicAcls EQUALS  true'
             messages:
-              custom_message: ''
+              custom_message: null
               error_message: Check was not compliant as property [PublicAccessBlockConfiguration.IgnorePublicAcls] to compare from is missing. Value traversed to [Path=/Resources/MyBucket/Properties[L:13,C:6] Value={"BucketEncryption":{"ServerSideEncryptionConfiguration":[{"ServerSideEncryptionByDefault":{"SSEAlgorithm":"AES256"}}]},"VersioningConfiguration":{"Status":"Enabled"}}].
             check:
               UnResolved:
@@ -196,7 +196,7 @@
           Binary:
             context: ' %s3_bucket_public_read_prohibited[*].Properties.PublicAccessBlockConfiguration.RestrictPublicBuckets EQUALS  true'
             messages:
-              custom_message: ';    Violation: S3 Bucket Public Write Access controls need to be restricted.;    Fix: Set S3 Bucket PublicAccessBlockConfiguration properties for BlockPublicAcls, BlockPublicPolicy, IgnorePublicAcls, RestrictPublicBuckets parameters to true.;  '
+              custom_message: "\n    Violation: S3 Bucket Public Write Access controls need to be restricted.\n    Fix: Set S3 Bucket PublicAccessBlockConfiguration properties for BlockPublicAcls, BlockPublicPolicy, IgnorePublicAcls, RestrictPublicBuckets parameters to true.\n  "
               error_message: Check was not compliant as property [PublicAccessBlockConfiguration.RestrictPublicBuckets] to compare from is missing. Value traversed to [Path=/Resources/MyBucket/Properties[L:13,C:6] Value={"BucketEncryption":{"ServerSideEncryptionConfiguration":[{"ServerSideEncryptionByDefault":{"SSEAlgorithm":"AES256"}}]},"VersioningConfiguration":{"Status":"Enabled"}}].
             check:
               UnResolved:

--- a/guard/src/rules/eval_context.rs
+++ b/guard/src/rules/eval_context.rs
@@ -1986,6 +1986,10 @@ fn report_all_failed_clauses_for_rules<'value>(
                         }
                     };
 
+                    let custom_message = custom_message
+                        .as_ref()
+                        .map_or(String::default(), |s| s.to_string());
+
                     let error_message = message
                         .as_ref()
                         .map_or("".to_string(), |s| format!("Error = [{}]", s));
@@ -2027,7 +2031,7 @@ fn report_all_failed_clauses_for_rules<'value>(
                     clauses.push(ClauseReport::Clause(GuardClauseReport::Unary(
                         UnaryReport {
                             messages: Messages {
-                                custom_message: custom_message.to_owned(),
+                                custom_message: Some(custom_message),
                                 error_message: Some(message),
                             },
                             context: current.context.clone(),
@@ -2044,6 +2048,10 @@ fn report_all_failed_clauses_for_rules<'value>(
                     status: Status::FAIL,
                     to,
                 }) => {
+                    let custom_message = custom_message
+                        .as_ref()
+                        .map_or(String::default(), |s| s.to_string());
+
                     let error_message = message
                         .as_ref()
                         .map_or("".to_string(), |s| format!(" Error = [{}]", s));
@@ -2061,7 +2069,7 @@ fn report_all_failed_clauses_for_rules<'value>(
                                 BinaryReport {
                                     context: current.context.to_string(),
                                     messages: Messages {
-                                        custom_message: custom_message.to_owned(),
+                                        custom_message: Some(custom_message),
                                         error_message: Some(message),
                                     },
                                     check: BinaryCheck::UnResolved(ValueUnResolved {
@@ -2102,7 +2110,7 @@ fn report_all_failed_clauses_for_rules<'value>(
                                                 context: current.context.to_string(),
                                                 messages: Messages {
                                                     error_message: Some(message),
-                                                    custom_message: custom_message.to_owned(),
+                                                    custom_message: Some(custom_message),
                                                 },
                                             }),
                                         ))
@@ -2119,7 +2127,7 @@ fn report_all_failed_clauses_for_rules<'value>(
                                             GuardClauseReport::Binary(BinaryReport {
                                                 context: current.context.to_string(),
                                                 messages: Messages {
-                                                    custom_message: custom_message.to_owned(),
+                                                    custom_message: Some(custom_message),
                                                     error_message: Some(message),
                                                 },
                                                 check: BinaryCheck::UnResolved(ValueUnResolved {

--- a/guard/src/rules/eval_context.rs
+++ b/guard/src/rules/eval_context.rs
@@ -1986,10 +1986,6 @@ fn report_all_failed_clauses_for_rules<'value>(
                         }
                     };
 
-                    let custom_message = custom_message
-                        .as_ref()
-                        .map_or("".to_string(), |s| s.replace('\n', ";"));
-
                     let error_message = message
                         .as_ref()
                         .map_or("".to_string(), |s| format!("Error = [{}]", s));
@@ -2031,7 +2027,7 @@ fn report_all_failed_clauses_for_rules<'value>(
                     clauses.push(ClauseReport::Clause(GuardClauseReport::Unary(
                         UnaryReport {
                             messages: Messages {
-                                custom_message: Some(custom_message),
+                                custom_message: custom_message.to_owned(),
                                 error_message: Some(message),
                             },
                             context: current.context.clone(),
@@ -2048,10 +2044,6 @@ fn report_all_failed_clauses_for_rules<'value>(
                     status: Status::FAIL,
                     to,
                 }) => {
-                    let custom_message = custom_message
-                        .as_ref()
-                        .map_or("".to_string(), |s| s.replace('\n', ";"));
-
                     let error_message = message
                         .as_ref()
                         .map_or("".to_string(), |s| format!(" Error = [{}]", s));
@@ -2069,7 +2061,7 @@ fn report_all_failed_clauses_for_rules<'value>(
                                 BinaryReport {
                                     context: current.context.to_string(),
                                     messages: Messages {
-                                        custom_message: Some(custom_message),
+                                        custom_message: custom_message.to_owned(),
                                         error_message: Some(message),
                                     },
                                     check: BinaryCheck::UnResolved(ValueUnResolved {
@@ -2110,7 +2102,7 @@ fn report_all_failed_clauses_for_rules<'value>(
                                                 context: current.context.to_string(),
                                                 messages: Messages {
                                                     error_message: Some(message),
-                                                    custom_message: Some(custom_message),
+                                                    custom_message: custom_message.to_owned(),
                                                 },
                                             }),
                                         ))
@@ -2127,7 +2119,7 @@ fn report_all_failed_clauses_for_rules<'value>(
                                             GuardClauseReport::Binary(BinaryReport {
                                                 context: current.context.to_string(),
                                                 messages: Messages {
-                                                    custom_message: Some(custom_message),
+                                                    custom_message: custom_message.to_owned(),
                                                     error_message: Some(message),
                                                 },
                                                 check: BinaryCheck::UnResolved(ValueUnResolved {


### PR DESCRIPTION
*Issue #, if available:*
#389 

*Description of changes:*
Somewhere between the release of guard 2.0.3 and 2.1.0 the custom message when validate commands failed were no longer json/yaml parseable. This PR fixes this, and they are now parseable. 

NOTE: Because this custom_message field contains json, inside of a json object, it is escaped so when parsing the user needs to use something like jq's `fromjson` command to continue parsing. 

---
*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
