### PR TITLE
updating docs, adding is_null and is_float operators

### DIFF
--- a/docs/CLAUSES.md
+++ b/docs/CLAUSES.md
@@ -93,7 +93,7 @@ The above two clauses will `PASS` for the example template.
 
 `empty` can be used to check if string value queries have an empty string (`""`) defined.
 
-`exists` - Checks if each occurrence of the query has a value and can be used in place of `!= null`.
+`exists` - Checks if each occurrence of the query exists.
 
 ```
 # Checks if BucketEncryption is defined
@@ -146,6 +146,13 @@ Resources.S3Bucket.Properties.Tags is_list
 ```
 # Checks if BucketEncryption is defined as a structured data
 Resources.S3Bucket.Properties.BucketEncryption is_struct
+```
+
+`is_null` - Checks if each occurrence of the query is of `float` type.
+
+```
+# Checks if Resources.S3Bucket.Properties is null
+Resources.S3Bucket is_null
 ```
 
 All the above example clauses will `PASS` for the example template. You can use the `not(!)` operator with the above operators to check the inverse state.

--- a/guard/resources/validate/functions/rules/converters.guard
+++ b/guard/resources/validate/functions/rules/converters.guard
@@ -3,6 +3,7 @@ let asg = Resources.*[ Type == 'AWS::AutoScaling::AutoScalingGroup' ]
 
 let c = '1'
 rule test_parse_int when %asg !empty {
+    %asg.Properties.MinSize is_string
     let min = parse_int(%asg.Properties.MinSize)
 
     %min == 1
@@ -10,11 +11,13 @@ rule test_parse_int when %asg !empty {
     let char = parse_int(%c)
     %char == 1
 
+    %asg.Properties.DefaultInstanceWarmup is_float
     let default = parse_int(%asg.Properties.DefaultInstanceWarmup)
     %default == 1
 }
 
 rule test_parse_bool when %asg !empty {
+    %asg.Properties.HealthCheckType is_string
     let health_check = parse_boolean(%asg.Properties.HealthCheckType)
     %health_check == true
 }
@@ -23,6 +26,7 @@ rule test_parse_float when %asg !empty {
     let max = parse_float(%asg.Properties.MaxSize)
     %max == 5.0
 
+    %asg.Properties.HealthCheckGracePeriod is_int
     let health_check_period = parse_float(%asg.Properties.HealthCheckGracePeriod)
 
     let char = parse_float(%c)
@@ -32,16 +36,19 @@ rule test_parse_float when %asg !empty {
 }
 
 rule test_parse_str when %asg !empty {
+    %asg.Properties.DefaultInstanceWarmup is_float
     let default = parse_string(%asg.Properties.DefaultInstanceWarmup)
 
     %default == "1.5"
 
+    %asg.Properties.HealthCheckGracePeriod is_int
     let health_check = parse_string(%asg.Properties.HealthCheckGracePeriod)
     %health_check == "1"
 
     let char = parse_string(%c)
     %char == "1"
 
+    %asg.Properties.NewInstancesProtectedFromScaleIn is_bool
     let new_instances = parse_string(%asg.Properties.NewInstancesProtectedFromScaleIn)
     %new_instances == "true"
 }

--- a/guard/src/commands/validate/common.rs
+++ b/guard/src/commands/validate/common.rs
@@ -608,15 +608,18 @@ where
                                     } else {
                                         "was int"
                                     },
-                                // NOTE: This enum actually doesnt exist and this is why we are
-                                // seeing a warning for  unreachable pattern underneath....Need to figure out what
-                                // happenned here...
-                                // IsFloat =>
-                                //     if !not {
-                                //         "was not a float"
-                                //     } else {
-                                //         "was float"
-                                // },
+                                IsNull =>
+                                    if !not {
+                                        "was not null"
+                                    } else {
+                                        "was null"
+                                    },
+                                IsFloat =>
+                                    if !not {
+                                        "was not a float"
+                                    } else {
+                                        "was float"
+                                    },
                                 Eq | In | Gt | Lt | Le | Ge => unreachable!(),
                             },
                             each

--- a/guard/src/rules/eval.rs
+++ b/guard/src/rules/eval.rs
@@ -58,7 +58,6 @@ is_type_fn!(is_string_operation, PathAwareValue::String(_));
 is_type_fn!(is_list_operation, PathAwareValue::List(_));
 is_type_fn!(is_struct_operation, PathAwareValue::Map(_));
 is_type_fn!(is_int_operation, PathAwareValue::Int(_));
-#[cfg(test)]
 is_type_fn!(is_float_operation, PathAwareValue::Float(_));
 is_type_fn!(is_bool_operation, PathAwareValue::Bool(_));
 #[cfg(test)]
@@ -67,6 +66,7 @@ is_type_fn!(is_char_range_operation, PathAwareValue::RangeChar(_));
 is_type_fn!(is_int_range_operation, PathAwareValue::RangeInt(_));
 #[cfg(test)]
 is_type_fn!(is_float_range_operation, PathAwareValue::RangeFloat(_));
+is_type_fn!(is_null_operation, PathAwareValue::Null(_));
 
 fn not_operation<O>(operation: O) -> impl Fn(&QueryResult) -> Result<bool>
 where
@@ -363,6 +363,24 @@ fn unary_operation<'r, 'l: 'r, 'loc: 'l>(
         (CmpOperator::IsInt, is_not_int) => box_create_func!(
             is_int_operation,
             is_not_int,
+            inverse,
+            cmp,
+            eval_context,
+            context,
+            custom_message
+        ),
+        (CmpOperator::IsNull, is_not_null) => box_create_func!(
+            is_null_operation,
+            is_not_null,
+            inverse,
+            cmp,
+            eval_context,
+            context,
+            custom_message
+        ),
+        (CmpOperator::IsFloat, is_not_float) => box_create_func!(
+            is_float_operation,
+            is_not_float,
             inverse,
             cmp,
             eval_context,

--- a/guard/src/rules/eval_context.rs
+++ b/guard/src/rules/eval_context.rs
@@ -1728,6 +1728,34 @@ pub(crate) fn cmp_str(cmp: (CmpOperator, bool)) -> &'static str {
                     "IS STRING"
                 }
             }
+            CmpOperator::IsFloat => {
+                if not {
+                    "NOT FLOAT"
+                } else {
+                    "IS FLOAT"
+                }
+            }
+            CmpOperator::IsNull => {
+                if not {
+                    "NOT NULL"
+                } else {
+                    "IS NULL"
+                }
+            }
+            CmpOperator::IsBool => {
+                if not {
+                    "NOT BOOL"
+                } else {
+                    "IS BOOl"
+                }
+            }
+            CmpOperator::IsInt => {
+                if not {
+                    "NOT INT"
+                } else {
+                    "IS INT"
+                }
+            }
             _ => unreachable!(),
         }
     } else {

--- a/guard/src/rules/eval_tests.rs
+++ b/guard/src/rules/eval_tests.rs
@@ -41,6 +41,7 @@ fn test_all_unary_functions() -> Result<()> {
     let char_range_value = PathAwareValue::try_from(r#"r[a, d)"#)?;
     let int_range_value = PathAwareValue::try_from(r#"r(10, 20)"#)?;
     let float_range_value = PathAwareValue::try_from(r#"r(10.0, 20.5]"#)?;
+    let null_value = PathAwareValue::Null(path_value::Path::root());
 
     type UnaryTest<'test> = Vec<(
         Box<dyn Fn(&QueryResult) -> Result<bool>>,
@@ -179,7 +180,7 @@ fn test_all_unary_functions() -> Result<()> {
         (
             Box::new(is_float_operation),
             // Success Case
-            vec![QueryResult::Resolved(Rc::new(float_value))],
+            vec![QueryResult::Resolved(Rc::new(float_value.clone()))],
             // Failure Cases
             vec![
                 QueryResult::Resolved(Rc::new(path_value.clone())),
@@ -237,7 +238,26 @@ fn test_all_unary_functions() -> Result<()> {
         (
             Box::new(is_float_range_operation),
             // Success Case
-            vec![QueryResult::Resolved(Rc::new(float_range_value))],
+            vec![QueryResult::Resolved(Rc::new(float_range_value.clone()))],
+            // Failure Cases
+            vec![
+                QueryResult::Resolved(Rc::new(path_value.clone())),
+                QueryResult::Resolved(Rc::new(list_value.clone())),
+                QueryResult::Resolved(Rc::new(string_value.clone())),
+                QueryResult::Resolved(Rc::new(int_value.clone())),
+                QueryResult::Resolved(Rc::new(non_empty_path_value.clone())),
+                QueryResult::Resolved(Rc::new(char_range_value.clone())),
+                QueryResult::UnResolved(UnResolved {
+                    traversed_to: Rc::new(path_value.clone()),
+                    reason: None,
+                    remaining_query: "".to_string(),
+                }),
+            ],
+        ),
+        (
+            Box::new(is_null_operation),
+            // Success Case
+            vec![QueryResult::Resolved(Rc::new(null_value.clone()))],
             // Failure Cases
             vec![
                 QueryResult::Resolved(Rc::new(path_value.clone())),
@@ -245,8 +265,9 @@ fn test_all_unary_functions() -> Result<()> {
                 QueryResult::Resolved(Rc::new(string_value)),
                 QueryResult::Resolved(Rc::new(int_value)),
                 QueryResult::Resolved(Rc::new(non_empty_path_value)),
-                QueryResult::Resolved(Rc::new(char_range_value.clone())),
                 QueryResult::Resolved(Rc::new(char_range_value)),
+                QueryResult::Resolved(Rc::new(float_value)),
+                QueryResult::Resolved(Rc::new(float_range_value)),
                 QueryResult::UnResolved(UnResolved {
                     traversed_to: Rc::new(path_value),
                     reason: None,

--- a/guard/src/rules/libyaml/loader.rs
+++ b/guard/src/rules/libyaml/loader.rs
@@ -89,7 +89,10 @@ impl Loader {
                     Ok(f) => MarkedValue::Float(f, location),
                     Err(_) => match val.parse::<bool>() {
                         Ok(b) => MarkedValue::Bool(b, location),
-                        Err(_) => MarkedValue::String(val, location),
+                        Err(_) => match val.to_lowercase().as_str() {
+                            "~" | "null" => MarkedValue::Null(location),
+                            _ => MarkedValue::String(val, location),
+                        },
                     },
                 },
             }

--- a/guard/src/rules/libyaml/loader_tests.rs
+++ b/guard/src/rules/libyaml/loader_tests.rs
@@ -260,3 +260,79 @@ b: *numbers
 
     Ok(())
 }
+
+#[test]
+fn test_handle_null() {
+    let docs = r###"
+    Resources: NULL
+    "###;
+
+    let mut loader = Loader::new();
+    let value = loader.load(String::from(docs)).unwrap();
+
+    let map = match &value {
+        MarkedValue::Map(m, _) => m,
+        _ => unreachable!(),
+    };
+
+    let val = map
+        .get(&("Resources".to_string(), Location::new(1, 4)))
+        .unwrap()
+        .to_owned();
+
+    assert!(matches!(val, MarkedValue::Null(_)));
+
+    let docs = r###"
+    Resources: ~
+    "###;
+
+    let value = loader.load(String::from(docs)).unwrap();
+
+    let map = match &value {
+        MarkedValue::Map(m, _) => m,
+        _ => unreachable!(),
+    };
+
+    let val = map
+        .get(&("Resources".to_string(), Location::new(1, 4)))
+        .unwrap()
+        .to_owned();
+
+    assert!(matches!(val, MarkedValue::Null(_)));
+
+    let docs = r###"
+    Resources: "~"
+    "###;
+
+    let value = loader.load(String::from(docs)).unwrap();
+
+    let map = match &value {
+        MarkedValue::Map(m, _) => m,
+        _ => unreachable!(),
+    };
+
+    let val = map
+        .get(&("Resources".to_string(), Location::new(1, 4)))
+        .unwrap()
+        .to_owned();
+
+    assert!(matches!(val, MarkedValue::String(..)));
+
+    let docs = r###"
+    Resources: "null"
+    "###;
+
+    let value = loader.load(String::from(docs)).unwrap();
+
+    let map = match &value {
+        MarkedValue::Map(m, _) => m,
+        _ => unreachable!(),
+    };
+
+    let val = map
+        .get(&("Resources".to_string(), Location::new(1, 4)))
+        .unwrap()
+        .to_owned();
+
+    assert!(matches!(val, MarkedValue::String(..)));
+}

--- a/guard/src/rules/parser.rs
+++ b/guard/src/rules/parser.rs
@@ -622,8 +622,21 @@ fn is_int(input: Span) -> IResult<Span, CmpOperator> {
     value(CmpOperator::IsInt, alt((tag("IS_INT"), tag("is_int"))))(input)
 }
 
+fn is_float(input: Span) -> IResult<Span, CmpOperator> {
+    value(
+        CmpOperator::IsFloat,
+        alt((tag("IS_FLOAT"), tag("is_float"))),
+    )(input)
+}
+
+fn is_null(input: Span) -> IResult<Span, CmpOperator> {
+    value(CmpOperator::IsNull, alt((tag("IS_NULL"), tag("is_null"))))(input)
+}
+
 fn is_type_operations(input: Span) -> IResult<Span, CmpOperator> {
-    alt((is_string, is_list, is_struct, is_bool, is_int))(input)
+    alt((
+        is_string, is_list, is_struct, is_bool, is_int, is_null, is_float,
+    ))(input)
 }
 
 pub(crate) fn value_cmp(input: Span) -> IResult<Span, (CmpOperator, bool)> {

--- a/guard/src/rules/parser_tests.rs
+++ b/guard/src/rules/parser_tests.rs
@@ -4076,6 +4076,10 @@ fn does_this_work() -> Result<(), Error> {
 #[case("IS_BOOL", CmpOperator::IsBool)]
 #[case("is_int", CmpOperator::IsInt)]
 #[case("IS_INT", CmpOperator::IsInt)]
+#[case("IS_FLOAT", CmpOperator::IsFloat)]
+#[case("is_float", CmpOperator::IsFloat)]
+#[case("is_null", CmpOperator::IsNull)]
+#[case("IS_NULL", CmpOperator::IsNull)]
 fn unary_parse(#[case] s: &str, #[case] expected: CmpOperator) -> Result<(), Error> {
     let parsed = value_cmp(LocatedSpan::new_extra(s, ""))?.1 .0;
     assert_eq!(expected, parsed);

--- a/guard/src/rules/values.rs
+++ b/guard/src/rules/values.rs
@@ -31,6 +31,8 @@ pub enum CmpOperator {
     IsMap,
     IsBool,
     IsInt,
+    IsFloat,
+    IsNull,
 }
 
 impl CmpOperator {
@@ -44,6 +46,8 @@ impl CmpOperator {
                 | CmpOperator::IsList
                 | CmpOperator::IsInt
                 | CmpOperator::IsMap
+                | CmpOperator::IsFloat
+                | CmpOperator::IsNull
         )
     }
 }
@@ -64,6 +68,8 @@ impl Display for CmpOperator {
             CmpOperator::IsInt => f.write_str("IS INT")?,
             CmpOperator::IsList => f.write_str("IS LIST")?,
             CmpOperator::IsMap => f.write_str("IS MAP")?,
+            CmpOperator::IsNull => f.write_str("IS NULL")?,
+            CmpOperator::IsFloat => f.write_str("IS FLOAT")?,
         }
         Ok(())
     }


### PR DESCRIPTION
*Issue #, if available:*
#377 

*Description of changes:*
Clarified the description for the `exists` unary function in guard. Previously said it could be used in place of where a dev would use `!= null` in other languages. The team believes this was slightly misleading. Exists is used to check if a query is resolved, its value doesn't matter (meaning it can be any valid value for guard, including null) and still pass. 

On that note we added a way to check if a value is null, using the `is_null` operator. Doing this we also noticed that even though our docs explicitly state we support an `is_float` operation, that wasn't previously true. For this reason we added support for an `is_float` operation as well. 

I also noticed a slight bug with the yaml loader, where we would resolve unquoted `null` and `~` keywords to strings of those values. Now we check the value of a string and match against those 2 before converting to a string value. I also added tests for this case. 

---
*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
