### PR TITLE
bugfix: small change for single-line-summary error messages

### DIFF
--- a/guard/src/rules/eval_context.rs
+++ b/guard/src/rules/eval_context.rs
@@ -2005,6 +2005,13 @@ fn report_all_failed_clauses_for_rules<'value>(
                                 "was not bool"
                             }
                         }
+                        IsNull => {
+                            if *not {
+                                "was null"
+                            } else {
+                                "was not null"
+                            }
+                        }
                         _ => {
                             if *not {
                                 "was float"


### PR DESCRIPTION
*Issue #, if available:*


*Description of changes:*
In my previous PR I missed a path that gets triggered when single-line-summary is printed for a failing is_null check. This jut adds the appropriate output to that report 

---
*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
