### PR TITLE
[Enhancement]: Adding support for calling functions inline

### DIFF
--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -57,7 +57,7 @@ let api_gws = Resources.*[ Type == 'AWS::ApiGateway::RestApi' ]
    }
    ```
 
-   While the above code snippet might be tempting to use as it's more intuitive, we haven't made the changes required to support it in our grammar yet.
+   While the above code snippet might be tempting to use we haven't made the changes required to support it in our grammar yet.
 
    > **Workaround**:
    > When working with unary operators. assign the result of the function to a variable.

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -33,13 +33,13 @@ let api_gws = Resources.*[ Type == 'AWS::ApiGateway::RestApi' ]
 
 2. When performing `!=` comparison, if the values are incompatible like comparing a `string` to `int`, an error is thrown internally but currently suppressed and converted to `false` to satisfy the requirements of Rust’s [PartialEq](https://doc.rust-lang.org/std/cmp/trait.PartialEq.html). We are tracking to release a fix for this issue soon.
 3. `exists` and `empty` checks do not display the JSON pointer path inside the document in the error messages. Both these clauses often have retrieval errors which does not maintain this traversal information today. We are tracking to resolve this issue.
-4. <a name="function-limitation"></a> **No support for inline functions**
+4. <a name="function-limitation"></a> **No support for calling functions inline on the LHS of an operator**
 
-   We **do not** support inline usage of functions at the moment. The support for built-in functions is currently limited to assignment of the return value to a variable.
+   We **do not** support inline usage of functions on the LHS of operators at the moment. The support for built-in functions when being used on the LHS of an operator is currently limited to assignment of the return value to a variable.
 
    Consider an example wherein our template has a node named `Instances` which is a collection. We need to author a rule that checks to ensure this collection contains a certain number of minimum items, say 2.
 
-   This is currently **NOT SUPPORTED**:
+   These following examples are currently **NOT SUPPORTED**:
 
    ```
    # Not supported at the moment
@@ -48,11 +48,20 @@ let api_gws = Resources.*[ Type == 'AWS::ApiGateway::RestApi' ]
       count(Instances.*) < 2
       << Violation: We should have at least 2 instances >>
    }
+
+   # OR
+
+   rule VERIFY_COUNT_RETURNS_INT {
+      count(Instances.*) is_int
+      << Violation: We should have at least 2 instances >>
+   }
    ```
 
    While the above code snippet might be tempting to use as it's more intuitive, we haven't made the changes required to support it in our grammar yet.
 
-   > **Workaround**: Assign function value to a variable and then use this variable thereafter in all clauses that follow including the conditions.
+   > **Workaround**:
+   > When working with unary operators. assign the result of the function to a variable.
+   > When working with binary operators, you have the choice to have the function call on the RHS of the operator, or assign the result of the function call to a variable, and then you are free to have this variable on either side of the operator.
 
    So, our example rule now becomes:
 
@@ -62,9 +71,18 @@ let api_gws = Resources.*[ Type == 'AWS::ApiGateway::RestApi' ]
    rule INSTANCES_COUNT_CHECK {
       let no_of_instances = count(Instances.*)
 
+      # all of the following options are valid ways to write this clause
       %no_of_instances < 2
+      2 > %no_of_instances
+      2 > count(Instances.*)
       << Violation: We should have at least 2 instances >>
    }
+
+   rule VERIFY_COUNT_RETURNS_INT {
+      let no_of_instances = count(Instances.*)
+      %no_of_instances is_int
+   }
+
    ```
 
    5. Key names containing dashes

--- a/guard/resources/validate/functions/output/failing_complex_rule.out
+++ b/guard/resources/validate/functions/output/failing_complex_rule.out
@@ -1,0 +1,34 @@
+template.yaml Status = FAIL
+FAILED rules
+failing_complex_rule.guard/PARAMETERIZED_RULE_WITH_FUNCTION_CALL_IN_PARAMS    FAIL
+---
+Evaluating data template.yaml against rules failing_complex_rule.guard
+Number of non-compliant resources 1
+Resource = newServer {
+  Type      = AWS::New::Service
+  Rule = PARAMETERIZED_RULE_WITH_FUNCTION_CALL_IN_PARAMS {
+    ALL {
+      Rule = compare_result_of_regex_replace {
+        ALL {
+          Check =  %expected EQUALS  %replaced {
+            ComparisonError {
+              Error            = Check was not compliant as property [/Resources/newServer/Properties/Arn[L:9,C:11]] was not present in [(resolved, Path=/Resources/newServer/Properties/Arn[L:9,C:11] Value="aws/123456789012/us-west-2/newservice-Table/extracted")]
+            }
+              PropertyPath    = /Resources/newServer/Properties/Arn[L:9,C:11]
+              Operator        = EQUAL
+              Value           = "aws/123456789012/us-west-2/newservice-Table/extracted"
+              ComparedWith    = ["aws/123456789012/us-west-2/newservice-Table/extracted"]
+              Code:
+                    7.           "Principal": "*",
+                    8.           "Actions": ["s3*", "ec2*"]
+                    9.        }
+                   10.      Arn: arn:aws:newservice:us-west-2:123456789012:Table/extracted
+                   11.      Encoded: This%20string%20will%20be%20URL%20encoded
+                   12.    Collection:
+
+          }
+        }
+      }
+    }
+  }
+}

--- a/guard/resources/validate/functions/output/failing_join_show_summary_all.out
+++ b/guard/resources/validate/functions/output/failing_join_show_summary_all.out
@@ -10,7 +10,6 @@ Resource = newServer {
     ALL {
       Check =  %res EQUALS  "a,b" {
         ComparisonError {
-          Message          = Violation: The joined value does not match the expected result
           Error            = Check was not compliant as property value [Path=/Resources/newServer/Collection/0[L:12,C:8] Value="a,b,c"] not equal to value [Path=[L:0,C:0] Value="a,b"].
           PropertyPath    = /Resources/newServer/Collection/0[L:12,C:8]
           Operator        = EQUAL
@@ -25,6 +24,24 @@ Resource = newServer {
                15.      - c
 
         }
+      }
+      Check =  a,b EQUALS  join(%collection, ",") {
+        ComparisonError {
+          Message          = Violation: The joined value does not match the expected result
+          Error            = Check was not compliant as property [/Resources/newServer/Collection/0[L:12,C:8]] was not present in [(resolved, Path=/Resources/newServer/Collection/0[L:12,C:8] Value="a,b,c")]
+        }
+          PropertyPath    = /Resources/newServer/Collection/0[L:12,C:8]
+          Operator        = EQUAL
+          Value           = "a,b,c"
+          ComparedWith    = ["a,b,c"]
+          Code:
+               10.      Arn: arn:aws:newservice:us-west-2:123456789012:Table/extracted
+               11.      Encoded: This%20string%20will%20be%20URL%20encoded
+               12.    Collection:
+               13.      - a
+               14.      - b
+               15.      - c
+
       }
     }
   }

--- a/guard/resources/validate/functions/rules/complex_rules.guard
+++ b/guard/resources/validate/functions/rules/complex_rules.guard
@@ -1,0 +1,22 @@
+rule compare_number_of_buckets(expected) {
+    %expected == 5
+}
+
+let buckets = Resources.*[ Type == 'AWS::S3::Bucket' ]
+
+rule COMBINED_FUNCTION_AND_PARAMETERIZED_RULES when %buckets !empty {
+    let number_of_buckets = count(%buckets)
+    compare_number_of_buckets(%number_of_buckets)
+}
+
+rule compare_result_of_regex_replace(replaced, expected) {
+    %replaced == %expected
+}
+
+let template = Resources.*[ Type == 'AWS::New::Service'] 
+
+rule PARAMETERIZED_RULE_WITH_FUNCTION_CALL_IN_PARAMS when %template exists {
+    let arn = %template.Properties.Arn 
+    let expected = "aws/123456789012/us-west-2/newservice-Table/extracted"
+    compare_result_of_regex_replace(regex_replace(%arn, "^arn:(\w+):(\w+):([\w0-9-]+):(\d+):(.+)$", "${1}/${4}/${3}/${2}-${5}"), %expected)
+}

--- a/guard/resources/validate/functions/rules/complex_rules.guard
+++ b/guard/resources/validate/functions/rules/complex_rules.guard
@@ -5,8 +5,7 @@ rule compare_number_of_buckets(expected) {
 let buckets = Resources.*[ Type == 'AWS::S3::Bucket' ]
 
 rule COMBINED_FUNCTION_AND_PARAMETERIZED_RULES when %buckets !empty {
-    let number_of_buckets = count(%buckets)
-    compare_number_of_buckets(%number_of_buckets)
+    compare_number_of_buckets(count(%buckets))
 }
 
 rule compare_result_of_regex_replace(replaced, expected) {

--- a/guard/resources/validate/functions/rules/failing_complex_rule.guard
+++ b/guard/resources/validate/functions/rules/failing_complex_rule.guard
@@ -1,0 +1,10 @@
+rule compare_result_of_regex_replace(replaced, expected) {
+    %expected == %replaced
+}
+
+let template = Resources.*[ Type == 'AWS::New::Service'] 
+
+rule PARAMETERIZED_RULE_WITH_FUNCTION_CALL_IN_PARAMS when %template exists {
+    let arn = %template.Properties.Arn 
+    compare_result_of_regex_replace(regex_replace(%arn, "^arn:(\w+):(\w+):([\w0-9-]+):(\d+):(.+)$", "${1}/${4}/${3}/${2}-${5}"), "random_str")
+}

--- a/guard/resources/validate/functions/rules/join_with_message.guard
+++ b/guard/resources/validate/functions/rules/join_with_message.guard
@@ -5,5 +5,8 @@ rule TEST_COLLECTION when %template !empty {
 
     let res = join(%collection, ",")
     %res == "a,b"
+
+    "a,b" == join(%collection, ",")
     << Violation: The joined value does not match the expected result >>
 }
+

--- a/guard/resources/validate/functions/rules/json_parse.guard
+++ b/guard/resources/validate/functions/rules/json_parse.guard
@@ -10,6 +10,8 @@ rule SOME_RULE when %template !empty {
 
     let res = json_parse(%policy)
 
+    %expected == json_parse(%policy)
+
     %res !empty
     %res == %expected
 
@@ -22,4 +24,5 @@ rule SOME_RULE when %template !empty {
             Resource == "arn:aws:s3:::s3-test-123/*"
     }
 }
+
 

--- a/guard/src/commands/validate/tf.rs
+++ b/guard/src/commands/validate/tf.rs
@@ -51,12 +51,7 @@ impl<'reporter> Reporter for TfAware<'reporter> {
         output_type: OutputFormatType,
     ) -> crate::rules::Result<()> {
         let root = data.root().unwrap();
-        let is_tf_plan = match data.at("/resource_changes", root) {
-            Ok(_resource_changes) => matches!(data.at("/terraform_version", root), Ok(_)),
-            _ => false,
-        };
-
-        if is_tf_plan {
+        if data.at("/resource_changes", root).is_ok() {
             let failure_report = simplifed_json_from_root(root_record)?;
             match output_type {
                 OutputFormatType::YAML => serde_yaml::to_writer(write, &failure_report)?,

--- a/guard/src/rules/parser.rs
+++ b/guard/src/rules/parser.rs
@@ -986,12 +986,19 @@ where
                             move |(rhs, msg)| {
                                 (Some(LetValue::Value(PathAwareValue::try_from(rhs).unwrap())), msg.map(String::from).or(None))
                             }),
+                       map(tuple((
+                            preceded(zero_or_more_ws_or_comment, function_expr), 
+                            preceded(zero_or_more_ws_or_comment, opt(custom_message)))),
+                            |(rhs, msg)| {
+                                (Some(LetValue::FunctionCall(rhs)), msg.map(String::from).or(None))
+                            }),
                         map(tuple((
                             preceded(zero_or_more_ws_or_comment, access),
                             preceded(zero_or_more_ws_or_comment, opt(custom_message)))),
                             |(rhs, msg)| {
                                 (Some(LetValue::AccessClause(rhs)), msg.map(String::from).or(None))
                             }),
+
                     ))))(rest)?;
         Ok((
             rest,
@@ -1067,8 +1074,8 @@ pub(crate) fn let_value(input: Span) -> IResult<Span, LetValue> {
             map(parse_value, |val| {
                 LetValue::Value(PathAwareValue::try_from(val).unwrap())
             }),
-            map(access, LetValue::AccessClause),
             map(function_expr, LetValue::FunctionCall),
+            map(access, LetValue::AccessClause),
         )),
     )(input)
 }

--- a/guard/src/rules/parser.rs
+++ b/guard/src/rules/parser.rs
@@ -987,7 +987,7 @@ where
                                 (Some(LetValue::Value(PathAwareValue::try_from(rhs).unwrap())), msg.map(String::from).or(None))
                             }),
                        map(tuple((
-                            preceded(zero_or_more_ws_or_comment, function_expr), 
+                            preceded(zero_or_more_ws_or_comment, function_expr),
                             preceded(zero_or_more_ws_or_comment, opt(custom_message)))),
                             |(rhs, msg)| {
                                 (Some(LetValue::FunctionCall(rhs)), msg.map(String::from).or(None))

--- a/guard/tests/validate.rs
+++ b/guard/tests/validate.rs
@@ -638,6 +638,7 @@ mod validate_tests {
     #[case("join.guard")]
     #[case("count.guard")]
     #[case("converters.guard")]
+    #[case("complex_rules.guard")]
     fn test_validate_with_fn_expr_success(#[case] rule: &str) {
         let mut reader = Reader::new(Stdin(std::io::stdin()));
         let mut writer = Writer::new(WBVec(vec![]), WBVec(vec![]));
@@ -666,6 +667,23 @@ mod validate_tests {
         assert_eq!(StatusCode::VALIDATION_ERROR, status_code);
         assert_output_from_file_eq!(
             "resources/validate/functions/output/failing_count_show_summary_all.out",
+            writer
+        );
+    }
+
+    #[test]
+    fn test_validate_with_failing_complex_rule() {
+        let mut reader = Reader::new(Stdin(std::io::stdin()));
+        let mut writer = Writer::new(WBVec(vec![]), WBVec(vec![]));
+
+        let status_code = ValidateTestRunner::default()
+            .rules(vec!["/functions/rules/failing_complex_rule.guard"])
+            .data(vec!["/functions/data/template.yaml"])
+            .run(&mut writer, &mut reader);
+
+        assert_eq!(StatusCode::VALIDATION_ERROR, status_code);
+        assert_output_from_file_eq!(
+            "resources/validate/functions/output/failing_complex_rule.out",
             writer
         );
     }


### PR DESCRIPTION
*Issue #, if available:*
#374 

*Description of changes:*
This pr adds functionality to both the parser and the guard evaluation engine to allow users to write functions inline. Previously users would have to assign the result from a function to a variable, and then use an access query to evaluate the result. Now users are able to call functions directly, and compare them. 

Please note: although this PR addresses most cases where functions can be called inline, there's still a limitation on calling them on the LHS of an operator. We are still researching if this is possible achieve in 3.x

---
*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
