### PR TITLE
[Code Quality]: Addressing new clippy lints (warns)

### DIFF
--- a/guard/src/rules/eval_context_tests.rs
+++ b/guard/src/rules/eval_context_tests.rs
@@ -5,7 +5,7 @@ use std::convert::TryFrom;
 
 #[test]
 fn extraction_test() -> Result<()> {
-    let rules_files = r###"
+    let rules_files = r#"
     let aws_route53_recordset_resources = Resources.*[ Type == 'AWS::Route53::RecordSet' ]
     rule aws_route53_recordset when %aws_route53_recordset_resources !empty {
       %aws_route53_recordset_resources.Properties.Comment == "DNS name for my instance."
@@ -16,7 +16,7 @@ fn extraction_test() -> Result<()> {
       %aws_route53_recordset_resources.Properties.TTL == "900"
       %aws_route53_recordset_resources.Properties.HostedZoneName == "HostedZoneName"
     }
-    "###;
+    "#;
 
     let rules = RulesFile::try_from(rules_files)?;
     let path_value = PathAwareValue::try_from("{}")?;

--- a/guard/src/rules/eval_tests.rs
+++ b/guard/src/rules/eval_tests.rs
@@ -891,12 +891,12 @@ fn binary_comparisons_lt_le() -> Result<()> {
 
 #[test]
 fn test_compare_rulegen() -> Result<()> {
-    let rulegen_created = r###"
+    let rulegen_created = r#"
 let aws_ec2_securitygroup_resources = Resources.*[ Type == 'AWS::EC2::SecurityGroup' ]
 rule aws_ec2_securitygroup when %aws_ec2_securitygroup_resources !empty {
   %aws_ec2_securitygroup_resources.Properties.SecurityGroupEgress == [{"CidrIp":"0.0.0.0/0","IpProtocol":-1},{"CidrIpv6":"::/0","IpProtocol":-1}]
-}"###;
-    let template = r###"
+}"#;
+    let template = r#"
 Resources:
 
   # SecurityGroups
@@ -913,7 +913,7 @@ Resources:
         - CidrIpv6: "::/0"
           IpProtocol: -1
       VpcId: vpc-123abc
-    "###;
+    "#;
     let rules = RulesFile::try_from(rulegen_created)?;
     let value = PathAwareValue::try_from(serde_yaml::from_str::<serde_yaml::Value>(template)?)?;
     let mut root = root_scope(&rules, Rc::new(value))?;
@@ -1916,7 +1916,7 @@ fn test_in_comparison_operator_for_list_of_lists(
         resource_records_arg,
     };
 
-    let rules = r###"
+    let rules = r#"
     let aws_route53_recordset_resources = Resources.*[ Type == 'AWS::Route53::RecordSet' ]
     rule aws_route53_recordset when %aws_route53_recordset_resources !empty {
       let targets = [{"Fn::Join": ["",[{"Ref": "SubdomainMaster"},".", {"Ref": "HostedZoneName"}]]}, {"Fn::Join": ["",[{"Ref": "SubdomainWild"},".", {"Ref": "HostedZoneName"}]]}, {"Fn::Join": ["",[{"Ref": 'SubdomainInternal'},".", {"Ref": "HostedZoneName"}]]}, {"Fn::Join": ["",[{"Ref": "SubdomainDefault"},".", {"Ref": "HostedZoneName"}]]}]
@@ -1927,7 +1927,7 @@ fn test_in_comparison_operator_for_list_of_lists(
       %aws_route53_recordset_resources.Properties.TTL == "900"
       %aws_route53_recordset_resources.Properties.HostedZoneName == {"Ref": "HostedZoneName"}
     }
-    "###;
+    "#;
 
     let value = PathAwareValue::try_from(serde_yaml::from_str::<serde_yaml::Value>(&template)?)?;
     let rule_eval = RulesFile::try_from(rules)?;
@@ -1956,12 +1956,12 @@ fn test_type_conversions(#[case] ttl_arg: &str, #[case] status_arg: Status) -> R
         ttl_arg,
     };
 
-    let rules = r###"
+    let rules = r#"
     let aws_route53_recordset_resources = Resources.*[ Type == 'AWS::Route53::RecordSet' ]
     rule aws_route53_recordset when %aws_route53_recordset_resources !empty {
       %aws_route53_recordset_resources.Properties.TTL == "900"
     }
-    "###;
+    "#;
 
     let value = PathAwareValue::try_from(serde_yaml::from_str::<serde_yaml::Value>(&template)?)?;
     let rule_eval = RulesFile::try_from(rules)?;
@@ -1993,11 +1993,11 @@ fn is_bool() -> Result<()> {
     let status = eval_rules_file(&rules_file, &mut eval, None)?;
     assert_eq!(status, Status::PASS);
 
-    let resources_str = r###"
+    let resources_str = r#"
     {
         foo: "false"
     }
-    "###;
+    "#;
     let value = PathAwareValue::try_from(resources_str)?;
     let mut eval = root_scope(&rules_file, Rc::new(value))?;
     let status = eval_rules_file(&rules_file, &mut eval, None)?;
@@ -2027,11 +2027,11 @@ fn is_int() -> Result<()> {
     let status = eval_rules_file(&rules_file, &mut eval, None)?;
     assert_eq!(status, Status::PASS);
 
-    let resources_str = r###"
+    let resources_str = r#"
     {
         foo: "1"
     }
-    "###;
+    "#;
     let value = PathAwareValue::try_from(resources_str)?;
     let mut eval = root_scope(&rules_file, Rc::new(value))?;
     let status = eval_rules_file(&rules_file, &mut eval, None)?;
@@ -2065,7 +2065,7 @@ fn double_projection_tests() -> Result<()> {
     }
     "###;
 
-    let resources_str = r###"
+    let resources_str = r#"
     {
         Resources: {
             ecs: {
@@ -2091,7 +2091,7 @@ fn double_projection_tests() -> Result<()> {
             }
         }
     }
-    "###;
+    "#;
 
     let value = PathAwareValue::try_from(resources_str)?;
     let rules_file = RulesFile::try_from(rule_str)?;
@@ -2099,7 +2099,7 @@ fn double_projection_tests() -> Result<()> {
     let status = eval_rules_file(&rules_file, &mut eval, None)?;
     assert_eq!(status, Status::PASS);
 
-    let resources_str = r###"
+    let resources_str = r#"
     {
         Resources: {
             ecs2: {
@@ -2110,7 +2110,7 @@ fn double_projection_tests() -> Result<()> {
             }
         }
     }
-    "###;
+    "#;
     let value = PathAwareValue::try_from(resources_str)?;
     let mut eval = root_scope(&rules_file, Rc::new(value))?;
     let status = eval_rules_file(&rules_file, &mut eval, None)?;
@@ -2804,7 +2804,7 @@ fn rule_clause_tests() -> Result<()> {
 
 #[test]
 fn rule_test_type_blocks() -> Result<()> {
-    let r = r###"
+    let r = r"
     rule iam_basic_checks {
   AWS::IAM::Role {
     Properties.AssumeRolePolicyDocument.Version == /(\d{4})-(\d{2})-(\d{2})/
@@ -2812,9 +2812,9 @@ fn rule_test_type_blocks() -> Result<()> {
     Properties.Tags[*].Value == /[a-zA-Z0-9]+/
     Properties.Tags[*].Key   == /[a-zA-Z0-9]+/
   }
-}"###;
+}";
 
-    let value = r###"
+    let value = r#"
     {
         "Resources": {
             "iamrole": {
@@ -2852,7 +2852,7 @@ fn rule_test_type_blocks() -> Result<()> {
             }
         }
     }
-    "###;
+    "#;
 
     let root = PathAwareValue::try_from(serde_yaml::from_str::<serde_yaml::Value>(value)?)?;
     let rules_file = RulesFile::try_from(r)?;
@@ -2884,7 +2884,7 @@ fn rule_test_type_blocks() -> Result<()> {
 
 #[test]
 fn rules_file_tests_the_unituitive_all_clause_that_skips() -> Result<()> {
-    let file = r###"
+    let file = r#"
 let iam_resources = Resources.*[ Type == "AWS::IAM::Role" ]
 rule iam_resources_exists {
     %iam_resources !EMPTY
@@ -2905,9 +2905,9 @@ rule iam_basic_checks when iam_resources_exists {
         %iam_resources.Properties.Tags[*].Value == /[a-zA-Z0-9]+/
         %iam_resources.Properties.Tags[*].Key   == /[a-zA-Z0-9]+/
     }
-}"###;
+}"#;
 
-    let value = r###"
+    let value = r#"
     {
         "Resources": {
             "iamrole": {
@@ -2945,7 +2945,7 @@ rule iam_basic_checks when iam_resources_exists {
             }
         }
     }
-    "###;
+    "#;
 
     let root = PathAwareValue::try_from(value)?;
     let rules_file = RulesFile::try_from(file)?;
@@ -2958,7 +2958,7 @@ rule iam_basic_checks when iam_resources_exists {
 
 #[test]
 fn rules_file_tests_simpler_correct_form_using_newer_constructs() -> Result<()> {
-    let file = r###"
+    let file = r"
 rule iam_basic_checks {
     Resources[ Type == 'AWS::IAM::Role' ] {
         Properties {
@@ -2970,12 +2970,12 @@ rule iam_basic_checks {
             }
         }
     }
-}"###;
+}";
 
     //
     // Missing Tag properties
     //
-    let value = r###"
+    let value = r#"
     {
         "Resources": {
             "iamrole": {
@@ -3013,7 +3013,7 @@ rule iam_basic_checks {
             }
         }
     }
-    "###;
+    "#;
 
     let root = PathAwareValue::try_from(value)?;
     let rules_file = RulesFile::try_from(file)?;
@@ -3043,7 +3043,7 @@ rule iam_basic_checks {
     //
     // Empty Tag properties
     //
-    let value = r###"
+    let value = r#"
     {
         "Resources": {
             "iamrole": {
@@ -3082,7 +3082,7 @@ rule iam_basic_checks {
             }
         }
     }
-    "###;
+    "#;
 
     let root = PathAwareValue::try_from(value)?;
     let mut root_context = root_context.reset_root(Rc::new(root))?;
@@ -3119,7 +3119,7 @@ rule iam_basic_checks {
     Ok(())
 }
 
-const SAMPLE: &str = r###"
+const SAMPLE: &str = r#"
     {
         "Statement": [
             {
@@ -3142,11 +3142,11 @@ const SAMPLE: &str = r###"
             }
         ]
     }
-    "###;
+    "#;
 
 #[test]
 fn test_iam_statement_clauses() -> Result<()> {
-    let sample = r###"
+    let sample = r#"
     {
         "Statement": [
             {
@@ -3170,7 +3170,7 @@ fn test_iam_statement_clauses() -> Result<()> {
             }
         ]
     }
-    "###;
+    "#;
     let values = PathAwareValue::try_from(sample)?;
     let mut eval = BasicQueryTesting {
         root: Rc::new(values),
@@ -3198,7 +3198,7 @@ fn test_iam_statement_clauses() -> Result<()> {
     let status = eval_guard_clause(&parsed, &mut eval)?;
     assert_eq!(Status::PASS, status);
 
-    let sample = r###"
+    let sample = r#"
     {
         "Statement": [
             {
@@ -3207,7 +3207,7 @@ fn test_iam_statement_clauses() -> Result<()> {
                 "Action": "s3:PutObject"
             }
         ]
-    }"###;
+    }"#;
     let value = PathAwareValue::try_from(sample)?;
     let mut eval = BasicQueryTesting {
         root: Rc::new(value),
@@ -3216,7 +3216,7 @@ fn test_iam_statement_clauses() -> Result<()> {
     let status = eval_guard_clause(&parsed, &mut eval)?;
     assert_eq!(status, Status::FAIL);
 
-    let sample = r###"
+    let sample = r#"
     {
         "Statement": [
             {
@@ -3228,7 +3228,7 @@ fn test_iam_statement_clauses() -> Result<()> {
                 }
             }
         ]
-    }"###;
+    }"#;
     let value = PathAwareValue::try_from(sample)?;
     let mut eval = BasicQueryTesting {
         root: Rc::new(value),
@@ -3237,7 +3237,7 @@ fn test_iam_statement_clauses() -> Result<()> {
     let status = eval_guard_clause(&parsed, &mut eval)?;
     assert_eq!(status, Status::FAIL);
 
-    let sample = r###"
+    let sample = r#"
     {
         "Statement": [
             {
@@ -3250,7 +3250,7 @@ fn test_iam_statement_clauses() -> Result<()> {
                 }
             }
         ]
-    }"###;
+    }"#;
     let value = PathAwareValue::try_from(sample)?;
     let mut eval = BasicQueryTesting {
         root: Rc::new(value),
@@ -3273,7 +3273,7 @@ fn test_iam_statement_clauses() -> Result<()> {
 
 #[test]
 fn test_api_gateway() -> Result<()> {
-    let rule = r###"
+    let rule = r#"
 rule check_rest_api_private {
   AWS::ApiGateway::RestApi {
     # Endpoint configuration must only be private
@@ -3283,11 +3283,11 @@ rule check_rest_api_private {
     Properties.Policy.Statement[ Condition.*[ KEYS == /aws:[sS]ource(Vpc|VPC|Vpce|VPCE)/ ] !EMPTY ] !EMPTY
   }
 }
-    "###;
+    "#;
 
     let rule = Rule::try_from(rule)?;
 
-    let resources = r###"
+    let resources = r#"
     {
         "Resources": {
             "apigatewayapi": {
@@ -3321,7 +3321,7 @@ rule check_rest_api_private {
                 }
             }
         }
-    }"###;
+    }"#;
 
     let values = PathAwareValue::try_from(resources)?;
     let mut eval = BasicQueryTesting {
@@ -3336,7 +3336,7 @@ rule check_rest_api_private {
 
 #[test]
 fn test_api_gateway_cleaner_model() -> Result<()> {
-    let rule = r###"
+    let rule = r#"
 rule check_rest_api_private {
   AWS::ApiGateway::RestApi {
     Properties {
@@ -3348,11 +3348,11 @@ rule check_rest_api_private {
     }
   }
 }
-    "###;
+    "#;
 
     let rule = Rule::try_from(rule)?;
 
-    let resources = r###"
+    let resources = r#"
     {
         "Resources": {
             "apigatewayapi": {
@@ -3386,7 +3386,7 @@ rule check_rest_api_private {
                 }
             }
         }
-    }"###;
+    }"#;
 
     let values = PathAwareValue::try_from(resources)?;
     let mut eval = BasicQueryTesting {
@@ -3396,7 +3396,7 @@ rule check_rest_api_private {
     let status = eval_rule(&rule, &mut eval)?;
     assert_eq!(status, Status::PASS);
 
-    let resources = r###"
+    let resources = r#"
     {
         "Resources": {
             "apigatewayapi": {
@@ -3430,7 +3430,7 @@ rule check_rest_api_private {
                 }
             }
         }
-    }"###;
+    }"#;
 
     let values = PathAwareValue::try_from(resources)?;
     let mut eval = BasicQueryTesting {
@@ -3445,7 +3445,7 @@ rule check_rest_api_private {
 
 #[test]
 fn testing_iam_role_prov_serve() -> Result<()> {
-    let resources = r###"
+    let resources = r#"
     {
         "Resources": {
             "CounterTaskDefExecutionRole5959CB2D": {
@@ -3471,9 +3471,9 @@ fn testing_iam_role_prov_serve() -> Result<()> {
             }
         }
     }
-    "###;
+    "#;
 
-    let rules = r###"
+    let rules = r#"
 let iam_roles = Resources.*[ Type == "AWS::IAM::Role"  ]
 let ecs_tasks = Resources.*[ Type == "AWS::ECS::TaskDefinition" ]
 
@@ -3494,7 +3494,7 @@ rule deny_task_role_no_permission_boundary when %ecs_tasks !EMPTY {
     } or
     %task_role == /aws:arn/ # either a direct string or
 }
-    "###;
+    "#;
 
     let rules_file = RulesFile::try_from(rules)?;
     let value = PathAwareValue::try_from(resources)?;
@@ -3507,7 +3507,7 @@ rule deny_task_role_no_permission_boundary when %ecs_tasks !EMPTY {
 
 #[test]
 fn testing_sg_rules_pro_serve() -> Result<()> {
-    let sgs = r###"
+    let sgs = r#"
     [{
     "Resources": {
     "CounterServiceSecurityGroupF41A3908": {
@@ -3592,9 +3592,9 @@ fn testing_sg_rules_pro_serve() -> Result<()> {
     }
 }]
 
-    "###;
+    "#;
 
-    let rules = r###"
+    let rules = r#"
 let sgs = Resources.*[ Type == "AWS::EC2::SecurityGroup" ]
 
 rule deny_egress when %sgs NOT EMPTY {
@@ -3604,7 +3604,7 @@ rule deny_egress when %sgs NOT EMPTY {
                                          CidrIpv6 == "::/0" ] EMPTY
 }
 
-    "###;
+    "#;
 
     let rules_file = RulesFile::try_from(rules)?;
 
@@ -3625,7 +3625,7 @@ rule deny_egress when %sgs NOT EMPTY {
 
 #[test]
 fn test_s3_bucket_pro_serv() -> Result<()> {
-    let values = r###"
+    let values = r#"
     [
 {
     "Resources": {
@@ -3776,14 +3776,14 @@ fn test_s3_bucket_pro_serv() -> Result<()> {
     }
 }]
 
-    "###;
+    "#;
 
     let parsed_values = match PathAwareValue::try_from(values)? {
         PathAwareValue::List((_, v)) => v,
         _ => unreachable!(),
     };
 
-    let rule = r###"
+    let rule = r#"
     rule deny_s3_public_bucket {
     AWS::S3::Bucket {  # this is just a short form notation for Resources.*[ Type == "AWS::S3::Bucket" ]
         Properties.BlockPublicAcls NOT EXISTS or
@@ -3798,7 +3798,7 @@ fn test_s3_bucket_pro_serv() -> Result<()> {
     }
 }
 
-    "###;
+    "#;
 
     let s3_rule = RulesFile::try_from(rule)?;
     let expectations = [
@@ -3960,7 +3960,7 @@ fn using_resource_names_for_assessment() -> Result<()> {
 #[test]
 #[ignore]
 fn test_string_in_comparison() -> Result<()> {
-    let resources = r###"
+    let resources = r#"
     Resources:
       s3:
         Type: AWS::S3::Bucket
@@ -3971,7 +3971,7 @@ fn test_string_in_comparison() -> Result<()> {
             Statement:
               Resource:
                 Fn::Sub: "aws:arn:s3::${s3}"
-    "###;
+    "#;
     let value = PathAwareValue::try_from(serde_yaml::from_str::<serde_yaml::Value>(resources)?)?;
 
     let rules = r###"
@@ -3995,7 +3995,7 @@ fn test_string_in_comparison() -> Result<()> {
 
 #[test]
 fn test_searcher() -> Result<()> {
-    let resources = r###"
+    let resources = r#"
     Resources:
       s3:
         Type: AWS::S3::Bucket
@@ -4006,7 +4006,7 @@ fn test_searcher() -> Result<()> {
             Statement:
               Resource:
                 Fn::Sub: "aws:arn:s3::${s3}"
-    "###;
+    "#;
 
     use grep_matcher::Matcher;
     use grep_regex::RegexMatcher;

--- a/guard/src/rules/evaluate_tests.rs
+++ b/guard/src/rules/evaluate_tests.rs
@@ -6,7 +6,7 @@ use crate::rules::parser::{rules_file, Span};
 use std::convert::TryFrom;
 use std::fs::File;
 
-const RULES_FILES_EXAMPLE: &str = r###"
+const RULES_FILES_EXAMPLE: &str = r#"
 rule iam_role_exists {
     Resources.*[ Type == "AWS::IAM::Role" ] EXISTS
 }
@@ -19,7 +19,7 @@ rule iam_role_lambda_compliance when iam_role_exists {
     %select_lambda_service EMPTY or
     %select_lambda_service.Action.* == /sts:AssumeRole/
 }
-"###;
+"#;
 
 fn parse_rules<'c>(rules: &'c str, name: &'c str) -> Result<RulesFile<'c>> {
     let span = Span::new_extra(rules, name);
@@ -131,7 +131,7 @@ fn rule_clause_tests() -> Result<()> {
     let status = rule.evaluate(&value, &dummy)?;
     assert_eq!(Status::PASS, status);
 
-    let r = r###"
+    let r = r"
     rule iam_basic_checks {
   AWS::IAM::Role {
     Properties.AssumeRolePolicyDocument.Version == /(\d{4})-(\d{2})-(\d{2})/
@@ -139,7 +139,7 @@ fn rule_clause_tests() -> Result<()> {
     Properties.Tags[*].Value == /[a-zA-Z0-9]+/
     Properties.Tags[*].Key   == /[a-zA-Z0-9]+/
   }
-}"###;
+}";
     let _rule = Rule::try_from(r)?;
     Ok(())
 }
@@ -176,7 +176,7 @@ impl<'r> EvaluationContext for Reporter<'r> {
 
 #[test]
 fn rules_file_tests() -> Result<()> {
-    let file = r###"
+    let file = r#"
 let iam_resources = Resources.*[ Type == "AWS::IAM::Role" ]
 rule iam_resources_exists {
     %iam_resources !EMPTY
@@ -191,9 +191,9 @@ rule iam_basic_checks when iam_resources_exists {
         %iam_resources.Properties.Tags.Value == /[a-zA-Z0-9]+/
         %iam_resources.Properties.Tags.Key   == /[a-zA-Z0-9]+/
     }
-}"###;
+}"#;
 
-    let value = r###"
+    let value = r#"
     {
         "Resources": {
             "iamrole": {
@@ -213,7 +213,7 @@ rule iam_basic_checks when iam_resources_exists {
             }
         }
     }
-    "###;
+    "#;
 
     let root = Value::try_from(value)?;
     let root = PathAwareValue::try_from(root)?;
@@ -237,7 +237,7 @@ fn rules_not_in_tests() -> Result<()> {
     Ok(())
 }
 
-const SAMPLE: &str = r###"
+const SAMPLE: &str = r#"
     {
         "Statement": [
             {
@@ -260,11 +260,11 @@ const SAMPLE: &str = r###"
             }
         ]
     }
-    "###;
+    "#;
 
 #[test]
 fn test_iam_statement_clauses() -> Result<()> {
-    let sample = r###"
+    let sample = r#"
     {
         "Statement": [
             {
@@ -288,7 +288,7 @@ fn test_iam_statement_clauses() -> Result<()> {
             }
         ]
     }
-    "###;
+    "#;
     let value = Value::try_from(sample)?;
     let value = PathAwareValue::try_from(value)?;
 
@@ -322,7 +322,7 @@ fn test_iam_statement_clauses() -> Result<()> {
 
 #[test]
 fn test_api_gateway() -> Result<()> {
-    let rule = r###"
+    let rule = r#"
 rule check_rest_api_private {
   AWS::ApiGateway::RestApi {
     # Endpoint configuration must only be private
@@ -332,11 +332,11 @@ rule check_rest_api_private {
     Properties.Policy.Statement[ Condition.*[ KEYS == /aws:[sS]ource(Vpc|VPC|Vpce|VPCE)/ ] !EMPTY ] !EMPTY
   }
 }
-    "###;
+    "#;
 
     let rule = Rule::try_from(rule)?;
 
-    let resources = r###"
+    let resources = r#"
     {
         "Resources": {
             "apigatewayapi": {
@@ -370,7 +370,7 @@ rule check_rest_api_private {
                 }
             }
         }
-    }"###;
+    }"#;
 
     let value = Value::try_from(resources)?;
     let value = PathAwareValue::try_from(value)?;
@@ -383,7 +383,7 @@ rule check_rest_api_private {
 
 #[test]
 fn testing_iam_role_prov_serve() -> Result<()> {
-    let resources = r###"
+    let resources = r#"
     {
         "Resources": {
             "CounterTaskDefExecutionRole5959CB2D": {
@@ -409,9 +409,9 @@ fn testing_iam_role_prov_serve() -> Result<()> {
             }
         }
     }
-    "###;
+    "#;
 
-    let rules = r###"
+    let rules = r#"
 let iam_roles = Resources.*[ Type == "AWS::IAM::Role"  ]
 let ecs_tasks = Resources.*[ Type == "AWS::ECS::TaskDefinition" ]
 
@@ -432,7 +432,7 @@ rule deny_task_role_no_permission_boundary when %ecs_tasks !EMPTY {
     } or
     %task_role == /aws:arn/ # either a direct string or
 }
-    "###;
+    "#;
 
     let rules_file = RulesFile::try_from(rules)?;
     let value = PathAwareValue::try_from(resources)?;
@@ -447,7 +447,7 @@ rule deny_task_role_no_permission_boundary when %ecs_tasks !EMPTY {
 
 #[test]
 fn testing_sg_rules_pro_serve() -> Result<()> {
-    let sgs = r###"
+    let sgs = r#"
     [{
     "Resources": {
     "CounterServiceSecurityGroupF41A3908": {
@@ -532,9 +532,9 @@ fn testing_sg_rules_pro_serve() -> Result<()> {
     }
 }]
 
-    "###;
+    "#;
 
-    let rules = r###"
+    let rules = r#"
 let sgs = Resources.*[ Type == "AWS::EC2::SecurityGroup" ]
 
 rule deny_egress when %sgs NOT EMPTY {
@@ -544,7 +544,7 @@ rule deny_egress when %sgs NOT EMPTY {
                                          CidrIpv6 == "::/0" ] EMPTY
 }
 
-    "###;
+    "#;
 
     let rules_file = RulesFile::try_from(rules)?;
 
@@ -563,7 +563,7 @@ rule deny_egress when %sgs NOT EMPTY {
 
     let sample = r#"{ "Resources": {} }"#;
     let value = PathAwareValue::try_from(sample)?;
-    let rule = r###"
+    let rule = r#"
 rule deny_egress {
     # Ensure that none of the security group contain a rule
     # that has Cidr Ip set to any
@@ -571,7 +571,7 @@ rule deny_egress {
         .Properties.SecurityGroupEgress[ CidrIp   == "0.0.0.0/0" or
                                          CidrIpv6 == "::/0" ] EMPTY
 }
-    "###;
+    "#;
 
     let dummy = DummyEval {};
     let rule_parsed = Rule::try_from(rule)?;
@@ -583,7 +583,7 @@ rule deny_egress {
 
 #[test]
 fn test_s3_bucket_pro_serv() -> Result<()> {
-    let values = r###"
+    let values = r#"
     [
 {
     "Resources": {
@@ -734,14 +734,14 @@ fn test_s3_bucket_pro_serv() -> Result<()> {
     }
 }]
 
-    "###;
+    "#;
 
     let parsed_values = match PathAwareValue::try_from(values)? {
         PathAwareValue::List((_, v)) => v,
         _ => unreachable!(),
     };
 
-    let rule = r###"
+    let rule = r#"
     rule deny_s3_public_bucket {
     AWS::S3::Bucket {  # this is just a short form notation for Resources.*[ Type == "AWS::S3::Bucket" ]
         Properties.BlockPublicAcls NOT EXISTS or
@@ -756,7 +756,7 @@ fn test_s3_bucket_pro_serv() -> Result<()> {
     }
 }
 
-    "###;
+    "#;
 
     let s3_rule = Rule::try_from(rule)?;
     let dummy = DummyEval {};
@@ -770,7 +770,7 @@ fn test_s3_bucket_pro_serv() -> Result<()> {
 
 #[test]
 fn ecs_iam_role_relationship_assetions() -> Result<()> {
-    let _template = r###"
+    let _template = r#"
     # deny_task_role_no_permission_boundary is expected to be false so negate it to pass test
 {    "Resources": {
     "CounterTaskDef1468734E": {
@@ -891,7 +891,7 @@ fn ecs_iam_role_relationship_assetions() -> Result<()> {
     }
     }
 }
-    "###;
+    "#;
     Ok(())
 }
 
@@ -934,7 +934,7 @@ impl<'a, 'b> EvaluationContext for VariableResolver<'a, 'b> {
 
 #[test]
 fn test_iam_subselections() -> Result<()> {
-    let template = r###"
+    let template = r#"
     {
         Resources: {
             # NOT SELECTED
@@ -986,7 +986,7 @@ fn test_iam_subselections() -> Result<()> {
             }
         }
     }
-    "###;
+    "#;
 
     let value = Value::try_from(template)?;
     let value = PathAwareValue::try_from(value)?;
@@ -1049,7 +1049,7 @@ fn test_iam_subselections() -> Result<()> {
     assert_eq!(selected[0], &expected);
     assert_eq!(selected[1], &expected2);
 
-    let rules_file = r###"
+    let rules_file = r#"
 let iam_roles = Resources.*[ Type == "AWS::IAM::Role"  ]
 
 rule deny_permissions_boundary_iam_role when %iam_roles !EMPTY {
@@ -1060,7 +1060,7 @@ rule deny_permissions_boundary_iam_role when %iam_roles !EMPTY {
         Properties.PermissionsBoundary !EXISTS
     ] !EMPTY
 }
-    "###;
+    "#;
 
     let rules = RulesFile::try_from(rules_file)?;
     let root_scope = RootScope::new(&rules, &value)?;
@@ -1278,7 +1278,7 @@ fn double_projection_tests() -> Result<()> {
     }
     "###;
 
-    let resources_str = r###"
+    let resources_str = r#"
     {
         Resources: {
             ecs: {
@@ -1304,14 +1304,14 @@ fn double_projection_tests() -> Result<()> {
             }
         }
     }
-    "###;
+    "#;
     let value = PathAwareValue::try_from(resources_str)?;
     let dummy = DummyEval {};
     let rule = Rule::try_from(rule_str)?;
     let status = rule.evaluate(&value, &dummy)?;
     assert_eq!(status, Status::PASS);
 
-    let resources_str = r###"
+    let resources_str = r#"
     {
         Resources: {
             ecs2: {
@@ -1322,7 +1322,7 @@ fn double_projection_tests() -> Result<()> {
             }
         }
     }
-    "###;
+    "#;
     let value = PathAwareValue::try_from(resources_str)?;
     let status = rule.evaluate(&value, &dummy)?;
     println!("{}", status);
@@ -1501,12 +1501,12 @@ fn test_compare_lists() -> Result<()> {
 
 #[test]
 fn test_compare_rulegen() -> Result<()> {
-    let rulegen_created = r###"
+    let rulegen_created = r#"
 let aws_ec2_securitygroup_resources = Resources.*[ Type == 'AWS::EC2::SecurityGroup' ]
 rule aws_ec2_securitygroup when %aws_ec2_securitygroup_resources !empty {
   %aws_ec2_securitygroup_resources.Properties.SecurityGroupEgress == [{"CidrIp":"0.0.0.0/0","IpProtocol":-1},{"CidrIpv6":"::/0","IpProtocol":-1}]
-}"###;
-    let template = r###"
+}"#;
+    let template = r#"
 Resources:
 
   # SecurityGroups
@@ -1523,7 +1523,7 @@ Resources:
         - CidrIpv6: "::/0"
           IpProtocol: -1
       VpcId: vpc-123abc
-    "###;
+    "#;
     let rules = RulesFile::try_from(rulegen_created)?;
     let value = PathAwareValue::try_from(serde_yaml::from_str::<serde_yaml::Value>(template)?)?;
     let root = RootScope::new(&rules, &value)?;
@@ -1734,7 +1734,7 @@ rule redshift_is_not_internet_accessible when %local_subnet_refs !empty {
 
 }"###;
 
-    let value_str = r###"
+    let value_str = r#"
     Resources:
       rcsg:
         Type: 'AWS::Redshift::ClusterSubnetGroup'
@@ -1756,7 +1756,7 @@ rule redshift_is_not_internet_accessible when %local_subnet_refs !empty {
           RouteTableId: { Ref: rt }
       gw:
         Type: 'AWS::EC2::InternetGateway'
-    "###;
+    "#;
 
     let rules_files = RulesFile::try_from(rule)?;
     let value = serde_yaml::from_str::<serde_yaml::Value>(value_str)?;
@@ -1765,7 +1765,7 @@ rule redshift_is_not_internet_accessible when %local_subnet_refs !empty {
     let status = rules_files.evaluate(&value, &root)?;
     assert_eq!(status, Status::FAIL);
 
-    let value_str = r###"
+    let value_str = r#"
     Resources:
       rcsg:
         Type: 'AWS::Redshift::ClusterSubnetGroup'
@@ -1787,7 +1787,7 @@ rule redshift_is_not_internet_accessible when %local_subnet_refs !empty {
           RouteTableId: { Ref: rt }
       gw:
         Type: 'AWS::EC2::TransitGateway'
-    "###;
+    "#;
 
     let rules_files = RulesFile::try_from(rule)?;
     let value = serde_yaml::from_str::<serde_yaml::Value>(value_str)?;
@@ -1796,7 +1796,7 @@ rule redshift_is_not_internet_accessible when %local_subnet_refs !empty {
     let status = rules_files.evaluate(&value, &root)?;
     assert_eq!(status, Status::PASS);
 
-    let value_str = r###"
+    let value_str = r#"
     Resources:
       rcsg:
         Type: 'AWS::Redshift::ClusterSubnetGroup'
@@ -1816,7 +1816,7 @@ rule redshift_is_not_internet_accessible when %local_subnet_refs !empty {
         Properties:
           GatewayId: { Ref: gw }
           RouteTableId: { Ref: rt }
-    "###;
+    "#;
 
     let rules_files = RulesFile::try_from(rule)?;
     let value = serde_yaml::from_str::<serde_yaml::Value>(value_str)?;
@@ -2321,7 +2321,7 @@ fn test_in_comparison_operator_for_list_of_lists() -> Result<()> {
                 - !GetAtt Infra1.PrivateIp
     "###;
 
-    let rules = r###"
+    let rules = r#"
     let aws_route53_recordset_resources = Resources.*[ Type == 'AWS::Route53::RecordSet' ]
     rule aws_route53_recordset when %aws_route53_recordset_resources !empty {
       %aws_route53_recordset_resources.Properties.Comment == "DNS name for my instance."
@@ -2332,7 +2332,7 @@ fn test_in_comparison_operator_for_list_of_lists() -> Result<()> {
       %aws_route53_recordset_resources.Properties.TTL == "900"
       %aws_route53_recordset_resources.Properties.HostedZoneName == "HostedZoneName"
     }
-    "###;
+    "#;
 
     let value = PathAwareValue::try_from(serde_yaml::from_str::<serde_yaml::Value>(template)?)?;
     let rule_eval = RulesFile::try_from(rules)?;

--- a/guard/src/rules/parser_tests.rs
+++ b/guard/src/rules/parser_tests.rs
@@ -383,7 +383,7 @@ fn test_map_success() {
     assert_eq!(
         map.get("aurora").unwrap(),
         &Value::List(
-            vec!["audit", "error", "general", "slowquery"]
+            ["audit", "error", "general", "slowquery"]
                 .iter()
                 .map(|s| Value::String((*s).to_string()))
                 .collect::<Vec<Value>>()
@@ -535,12 +535,12 @@ fn test_parse_value_with_comments() {
     let cmp = unsafe { Span::new_from_raw_offset(s.len(), 2, "", "") };
     assert_eq!(parse_value(from_str2(s)), Ok((cmp, Value::Int(1234i64))));
 
-    let s = r###"
+    let s = r#"
 
         # this comment is skipped
         # this one too
         [ "value1", # this one is skipped as well
-          "value2" ]"###;
+          "value2" ]"#;
     let cmp = unsafe { Span::new_from_raw_offset(s.len(), 6, "", "") };
     assert_eq!(
         parse_value(from_str2(s)),
@@ -553,12 +553,12 @@ fn test_parse_value_with_comments() {
         ))
     );
 
-    let s = r###"{
+    let s = r#"{
         # this comment is skipped
         # this one as well
         key: # how about this
            "Value"
-        }"###;
+        }"#;
     let cmp = unsafe { Span::new_from_raw_offset(s.len(), 6, "", "") };
     assert_eq!(
         parse_value(from_str2(s)),
@@ -1681,8 +1681,7 @@ fn testing_access_with_cmp<'loc, A, C>(
             println!("Testing Access pattern = {}", access_pattern);
             let span = from_str2(&access_pattern);
             let result = clause(span);
-            if let Err(..) = result {
-                let parser_error = &result.unwrap_err();
+            if let Err(parser_error) = result {
                 let parser_error = match parser_error {
                     nom::Err::Error(p) | nom::Err::Failure(p) => {
                         format!("ParserError = {} fragment = {}", p, *p.span.fragment())
@@ -2392,16 +2391,16 @@ fn test_clauses() {
             }
 
 )))]
-#[case(r##"let ENGINE_LOGS = {
+#[case(r#"let ENGINE_LOGS = {
     'mariadb':       ["audit", "error", "general", "slowquery"],
     'aurora-postgresql': ["postgresql", "upgrade"]
-}"##, Ok((
+}"#, Ok((
         unsafe {
             Span::new_from_raw_offset(
-r##"let ENGINE_LOGS = {
+r#"let ENGINE_LOGS = {
     'mariadb':       ["audit", "error", "general", "slowquery"],
     'aurora-postgresql': ["postgresql", "upgrade"]
-}"##.len(),
+}"#.len(),
                 4,
                 "",
                 ""
@@ -2409,12 +2408,12 @@ r##"let ENGINE_LOGS = {
         },
         LetExpr {
             var: String::from("ENGINE_LOGS"),
-            value: LetValue::Value(PathAwareValue::try_from(r##"
+            value: LetValue::Value(PathAwareValue::try_from(r#"
         {
             'mariadb':       ["audit", "error", "general", "slowquery"],
             'aurora-postgresql': ["postgresql", "upgrade"]
         }
-                "##).unwrap())
+                "#).unwrap())
         }
         )))]
 fn test_assignments(#[case] each: &str, #[case] expected: IResult<Span, LetExpr>) {
@@ -3099,7 +3098,7 @@ fn test_rule_block() {
 
 #[test]
 fn test_rules_file() -> Result<(), Error> {
-    let s = r###"
+    let s = r#"
 #
 #  this is the set of rules for secure S3 bucket
 #  it must not be public AND
@@ -3128,7 +3127,7 @@ let kms_keys := [
 
 let encrypted := false
 let latest := "ami-6458235"
-        "###;
+        "#;
 
     let _rules_files = rules_file(from_str2(s))?;
     Ok(())
@@ -3153,12 +3152,12 @@ fn test_try_from_access() -> Result<(), Error> {
 
 #[test]
 fn test_try_from_rule_block() -> Result<(), Error> {
-    let rule = r###"
+    let rule = r#"
     rule s3_secure_exception {
         s3_secure or
         AWS::S3::Bucket tags.*.key in ["ExternalS3Approved"]
     }
-    "###;
+    "#;
     let rule_statement = Rule::try_from(rule)?;
     let expected = Rule {
         rule_name: String::from("s3_secure_exception"),
@@ -3251,7 +3250,7 @@ fn test_try_from_rule_block() -> Result<(), Error> {
 
 #[test]
 fn parse_list_of_map() -> Result<(), Error> {
-    let s = r###"let allowlist = [
+    let s = r#"let allowlist = [
      {
          "serviceAccount": "analytics",
          "images": ["banzaicloud/allspark:0.1.2", "banzaicloud/istio-proxyv2:1.7.0-bzc"],
@@ -3261,7 +3260,7 @@ fn parse_list_of_map() -> Result<(), Error> {
      }
  ]
 
-  "###;
+  "#;
 
     let value = assignment(from_str2(s))?.1;
     println!("{:?}", value);
@@ -3270,13 +3269,13 @@ fn parse_list_of_map() -> Result<(), Error> {
 
 #[test]
 fn parse_rule_block_with_mixed_assignment() -> Result<(), Error> {
-    let r = r###"
+    let r = r#"
     rule is_service_account_operation_valid {
      request.kind.kind == "Pod"
      request.operation == "CREATE"
      let service_name = request.object.spec.serviceAccountName
      %allowlist[ this.serviceAccount == %service_name ] !EMPTY
- }"###;
+ }"#;
     let rule = Rule::try_from(r)?;
     println!("{:?}", rule);
 
@@ -3294,7 +3293,7 @@ fn parse_rule_block_with_mixed_assignment() -> Result<(), Error> {
 
 #[test]
 fn parse_regex_tests() -> Result<(), Error> {
-    let inner = r#"(\d{4})-(\d{2})-(\d{2})"#;
+    let inner = "(\\d{4})-(\\d{2})-(\\d{2})";
     let regex = format!("/{}/", inner);
     let value = Value::try_from(regex.as_str())?;
     assert_eq!(Value::Regex(inner.to_string()), value);
@@ -3412,11 +3411,11 @@ fn select_any_one_from_list_clauses() -> Result<(), Error> {
 
 #[test]
 fn test_rules_file_default_rules() -> Result<(), Error> {
-    let s = r###"
+    let s = r#"
     AWS::AmazonMQ::Broker Properties.AutoMinorVersionUpgrade == false <<Version upgrades should be enabled to receive security updates>>
     AWS::AmazonMQ::Broker Properties.EncryptionOptions.UseAwsOwnedKey == false <<CMKs should be used instead of AWS-provided KMS keys>>
     AWS::ApiGateway::Method Properties.ResourceId == "ApiGatewayBadBot.RootResourceId" <<Should be root resource id>> or  AWS::ApiGateway::Method Properties.ResourceId == "ApiGatewayBadBotResource"
-    "###;
+    "#;
     let default_rule = Rule {
         rule_name: String::from("default"),
         conditions: None,
@@ -4394,7 +4393,7 @@ fn parameterized_rule_single_param_function_with_multiple_arguments() -> Result<
                     match_all: true,
                 }),
                 LetValue::Value(PathAwareValue::try_from(Value::String(
-                    r#"^arn:(\w+):(\w+):([\w0-9-]+):(\d+):(.+)$"#.to_string(),
+                    "^arn:(\\w+):(\\w+):([\\w0-9-]+):(\\d+):(.+)$".to_string(),
                 ))?),
                 LetValue::Value(PathAwareValue::try_from(Value::String(
                     "${1}/${4}/${3}/${2}-${5}".to_string(),
@@ -4435,7 +4434,7 @@ fn paramterized_clause_errors() -> Result<(), Error> {
 
 #[test]
 fn parameterized_clause_in_when_condition() -> Result<(), Error> {
-    let rule_when_clause = r###"rule call_parameterized when parameterized(%x) {
+    let rule_when_clause = r#"rule call_parameterized when parameterized(%x) {
         Resources[ Type == /IAM::Role/ ] {
             check_iam_statements(Properties.PolicyDocument.Statement[*], "some-hardcoded-param")
             when check_required_tags_present(Properties.Tags)
@@ -4444,7 +4443,7 @@ fn parameterized_clause_in_when_condition() -> Result<(), Error> {
                 some Properties.PolicyDocument.Statement[*].Principal == '*'
             }
         }
-    }"###;
+    }"#;
 
     let rule = Rule::try_from(rule_when_clause)?;
     assert_eq!(rule.rule_name.as_str(), "call_parameterized");
@@ -4614,7 +4613,7 @@ fn test_parse_regex_inner_when_regex_is_not_valid() {
 
 #[test]
 fn test_parse_regex_inner_when_regex_is_valid() {
-    let valid = r#"\w+/"#;
+    let valid = "\\w+/";
     let valid_cmp = unsafe { Span::new_from_raw_offset(valid.len(), 5, valid, "") };
 
     assert!(parse_regex_inner(valid_cmp).is_ok())

--- a/guard/src/rules/values_tests.rs
+++ b/guard/src/rules/values_tests.rs
@@ -216,7 +216,7 @@ fn test_query_on_value() -> Result<()> {
     //
     // Making it work with variable references
     //
-    let block = r###"
+    let block = r#"
     AWS::IAM::Role {
         let statements = Properties.Policies.*.PolicyDocument.Statement[ Effect == "Allow" ]
 
@@ -226,7 +226,7 @@ fn test_query_on_value() -> Result<()> {
         %statements.Resource != "*" # OR
         # %statements.Resource.* != "*"
     }
-    "###;
+    "#;
     let type_block = TypeBlock::try_from(block)?;
     let status = type_block.evaluate(&value, &dummy)?;
     assert_eq!(status, Status::FAIL);
@@ -265,7 +265,7 @@ fn test_type_block_with_var_query_evaluation() -> Result<()> {
     }
     let dummy = DummyResolver {};
 
-    let block = r###"
+    let block = r#"
     rule check_subnets when Resources.*[ Type == "AWS::EC2::VPC" ] !EMPTY {
         # Ensure that Zone is always set
         AWS::EC2::Subnet Properties.AvailabilityZone NOT EMPTY
@@ -284,7 +284,7 @@ fn test_type_block_with_var_query_evaluation() -> Result<()> {
             Properties.Ipv6CidrBlock NOT EXISTS
         }
     }
-    "###;
+    "#;
     let rule = Rule::try_from(block)?;
     let status = rule.evaluate(&value, &dummy)?;
     println!("Status = {:?}", status);
@@ -315,7 +315,7 @@ fn test_type_block_with_var_query_evaluation() -> Result<()> {
     println!("Status = {:?}", status);
     assert_eq!(status, Status::PASS);
 
-    let content = r###"
+    let content = r#"
     {
        "Resources": {
            "subnet": {
@@ -328,13 +328,13 @@ fn test_type_block_with_var_query_evaluation() -> Result<()> {
            }
        }
     }
-    "###;
+    "#;
     let value = PathAwareValue::try_from(content)?;
     let status = rule.evaluate(&value, &dummy)?;
     println!("Status = {:?}", status);
     assert_eq!(status, Status::FAIL);
 
-    let content = r###"
+    let content = r#"
     {
        "Resources": {
            "subnet": {
@@ -346,7 +346,7 @@ fn test_type_block_with_var_query_evaluation() -> Result<()> {
            }
        }
     }
-    "###;
+    "#;
     let value = PathAwareValue::try_from(content)?;
     let status = rule.evaluate(&value, &dummy)?;
     println!("Status = {:?}", status);
@@ -374,7 +374,7 @@ fn test_yaml_json_mapping() -> Result<()> {
           memory: 10
     "###;
 
-    let resources_json = r###"{
+    let resources_json = r#"{
         "Resources": {
             "s3": {
                "Type": "AWS::S3::Bucket",
@@ -384,7 +384,7 @@ fn test_yaml_json_mapping() -> Result<()> {
             }
         }
     }
-    "###;
+    "#;
 
     let value = super::read_from(resources)?;
     println!("{:?}", value);
@@ -400,7 +400,7 @@ fn test_yaml_json_mapping() -> Result<()> {
 
 #[test]
 fn test_yaml_json_mapping_2() -> Result<()> {
-    let resources = r###"
+    let resources = r#"
 MyNotCondition:
     !Not [!Equals [!Ref EnvironmentType, prod]]
 Resources:
@@ -422,7 +422,7 @@ Resources:
       Others: !Select [ "1", [ "apples", "grapes", "oranges", "mangoes" ] ]
       TestJoin: !Join [ ":", [ a, b, c ] ]
       TestJoinWithRef: !Join [ ":", [ !Ref A, b, c ] ]
-      "###;
+      "#;
 
     let value = super::read_from(resources)?;
     println!("{:?}", value);

--- a/guard/src/utils/mod.rs
+++ b/guard/src/utils/mod.rs
@@ -80,7 +80,7 @@ mod tests {
 
     #[test]
     fn read_cursor_test() {
-        let resources = r###"
+        let resources = r#"
     Resources:
       s3:
         Type: AWS::S3::Bucket
@@ -90,7 +90,7 @@ mod tests {
           PolicyDocument:
             Statement:
               Resource:
-                Fn::Sub: "aws:arn:s3::${s3}""###;
+                Fn::Sub: "aws:arn:s3::${s3}""#;
 
         let mut cursor = ReadCursor::new(resources);
         while let Some(line) = cursor.next() {


### PR DESCRIPTION
*Issue #, if available:*


*Description of changes:*
With the release of Rust 1.72 earlier today, there was some changes to clippy lints. This PR addresses some issues that were for the time being only warns, but our intention is to get ahead of any possible future errors from the linter. This will keep noise out of future PR's that have actual logical changes made to them. 

With the exception of 2 of them, most of these lints were due to this new lint https://rust-lang.github.io/rust-clippy/master/index.html#/needless_raw_string_hashes

---
*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
