### PR TITLE
[BugFix]: cfn-guard no longer errors out when rule files are empty, or contain only comments

### DIFF
--- a/guard/resources/validate/comments.guard
+++ b/guard/resources/validate/comments.guard
@@ -1,0 +1,2 @@
+# this is a comment
+

--- a/guard/src/commands/helper.rs
+++ b/guard/src/commands/helper.rs
@@ -49,7 +49,7 @@ pub fn validate_and_return_json(
 
     let rules_file_name = rules.file_name;
     return match crate::rules::parser::rules_file(span) {
-        Ok(rules) => {
+        Ok(Some(rules)) => {
             let mut write_output = BufWriter::new(Vec::new());
             let root = input_data.path_value;
             let traversal = Traversal::from(&root);
@@ -79,6 +79,7 @@ pub fn validate_and_return_json(
                 Err(e) => Err(Error::ParseError(e.to_string())),
             }
         }
+        Ok(None) => Ok(String::default()),
         Err(e) => Err(Error::ParseError(e.to_string())),
     };
 }

--- a/guard/src/commands/test.rs
+++ b/guard/src/commands/test.rs
@@ -218,7 +218,7 @@ or failure testing.
                             writeln!(writer, "Parse Error on ruleset file {e}",)?;
                             exit_code = 1;
                         }
-                        Ok(rules) => {
+                        Ok(Some(rules)) => {
                             let data_test_files = each_rule_file
                                 .test_files
                                 .iter()
@@ -232,6 +232,7 @@ or failure testing.
                                 exit_code
                             }
                         }
+                        Ok(None) => {}
                     }
                     writeln!(writer, "---")?;
                 }
@@ -283,13 +284,14 @@ or failure testing.
                                 writeln!(writer, "Parse Error on ruleset file {e}")?;
                                 exit_code = 1;
                             }
-                            Ok(rules) => {
+                            Ok(Some(rules)) => {
                                 let curr_exit_code =
                                     test_with_data(&data_test_files, &rules, verbose, writer)?;
                                 if curr_exit_code != 0 {
                                     exit_code = curr_exit_code;
                                 }
                             }
+                            Ok(None) => {}
                         }
                     }
                 }

--- a/guard/src/commands/validate.rs
+++ b/guard/src/commands/validate.rs
@@ -540,7 +540,7 @@ fn evaluate_rule(
             return Ok(5);
         }
 
-        Ok(rule) => {
+        Ok(Some(rule)) => {
             let status = evaluate_against_data_input(
                 data_type,
                 output,
@@ -558,6 +558,7 @@ fn evaluate_rule(
                 return Ok(19);
             }
         }
+        Ok(None) => return Ok(0),
     }
 
     Ok(0)
@@ -577,7 +578,10 @@ fn deserialize_payload(payload: &str) -> Result<Payload> {
     }
 }
 
-fn parse_rules<'r>(rules_file_content: &'r str, rules_file_name: &'r str) -> Result<RulesFile<'r>> {
+fn parse_rules<'r>(
+    rules_file_content: &'r str,
+    rules_file_name: &'r str,
+) -> Result<Option<RulesFile<'r>>> {
     let span = crate::rules::parser::Span::new_extra(rules_file_content, rules_file_name);
     crate::rules::parser::rules_file(span)
 }

--- a/guard/src/commands/validate/structured.rs
+++ b/guard/src/commands/validate/structured.rs
@@ -50,7 +50,8 @@ impl<'eval> StructuredEvaluator<'eval> {
                         ))?;
                         self.exit_code = 5;
                     }
-                    Ok(rule) => rules.push(rule),
+                    Ok(Some(rule)) => rules.push(rule),
+                    Ok(None) => {}
                 }
                 Ok(rules)
             },

--- a/guard/src/rules/evaluate_tests.rs
+++ b/guard/src/rules/evaluate_tests.rs
@@ -23,7 +23,7 @@ rule iam_role_lambda_compliance when iam_role_exists {
 
 fn parse_rules<'c>(rules: &'c str, name: &'c str) -> Result<RulesFile<'c>> {
     let span = Span::new_extra(rules, name);
-    rules_file(span)
+    Ok(rules_file(span)?.unwrap())
 }
 
 fn read_data(file: File) -> Result<Value> {

--- a/guard/src/rules/parser_tests.rs
+++ b/guard/src/rules/parser_tests.rs
@@ -3643,11 +3643,11 @@ fn test_rules_file_default_rules() -> Result<(), Error> {
     let rules_file = rules_file(from_str2(s))?;
     assert_eq!(
         rules_file,
-        RulesFile {
+        Some(RulesFile {
             assignments: vec![],
             guard_rules: vec![default_rule],
             parameterized_rules: vec![],
-        }
+        })
     );
     Ok(())
 }

--- a/guard/tests/validate.rs
+++ b/guard/tests/validate.rs
@@ -187,11 +187,11 @@ mod validate_tests {
     )]
     #[case(vec!["s3-server-side-encryption-template-non-compliant-2.yaml"], vec!["malformed-rule.guard"], StatusCode::INTERNAL_FAILURE)]
     #[case(vec!["malformed-template.yaml"], vec!["s3_bucket_server_side_encryption_enabled_2.guard"], StatusCode::INTERNAL_FAILURE)]
-    #[case(vec!["s3-server-side-encryption-template-non-compliant-2.yaml"], vec!["blank-rule.guard"], StatusCode::PARSING_ERROR)]
+    #[case(vec!["s3-server-side-encryption-template-non-compliant-2.yaml"], vec!["blank-rule.guard"], StatusCode::SUCCESS)]
     #[case(
         vec!["s3-server-side-encryption-template-non-compliant-2.yaml"],
         vec!["s3_bucket_server_side_encryption_enabled_2.guard", "blank-rule.guard"],
-        StatusCode::PARSING_ERROR
+        StatusCode::VALIDATION_ERROR
     )]
     #[case(vec!["blank-template.yaml"], vec!["s3_bucket_server_side_encryption_enabled_2.guard"], StatusCode::INTERNAL_FAILURE)]
     #[case(

--- a/guard/tests/validate.rs
+++ b/guard/tests/validate.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub(crate) mod utils;
-
 #[cfg(test)]
 mod validate_tests {
     use std::io::{stderr, stdout, Cursor};
@@ -202,6 +201,7 @@ mod validate_tests {
     #[case(vec!["dne.yaml"], vec!["rules-dir/s3_bucket_public_read_prohibited.guard"], StatusCode::INTERNAL_FAILURE)]
     #[case(vec!["data-dir/s3-public-read-prohibited-template-non-compliant.yaml"], vec!["dne.guard"], StatusCode::INTERNAL_FAILURE)]
     #[case(vec!["blank.yaml"], vec!["rules-dir/s3_bucket_public_read_prohibited.guard"], StatusCode::INTERNAL_FAILURE)]
+    #[case(vec!["s3-server-side-encryption-template-non-compliant-2.yaml"], vec!["comments.guard"], StatusCode::SUCCESS)]
     fn test_single_data_file_single_rules_file_status(
         #[case] data_arg: Vec<&str>,
         #[case] rules_arg: Vec<&str>,


### PR DESCRIPTION
*Issue #, if available:*
#376 

*Description of changes:*
Added a check before parsing for the grammar, that discards all leading comments, or empty space, and made the `crate::rules::parser::rules_file` function now return `Result<Option<RulesFile>, Error>` instead of `Result<RulesFile, Error>` calling functions of this now also return the same `Result<Option<RulesFile>, E>` struct, and functions such as `evaluate_rule` now return 0 if it receives `Ok(None)` functions such as the evaluator in our structured_reporter now just skip the step of appending to the list of rules. 

Also updated expected results of some test cases, and added a new test case for when using the validate command with  a file that contains only comments 

---
*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
