### PR TITLE
Updating release workflow 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,3 +83,13 @@ jobs:
           asset_path: ./cfn-guard-v3-aarch64-${{ matrix.os }}.tar.gz
           asset_name: cfn-guard-v3-aarch64-${{ matrix.os }}.tar.gz
           asset_content_type: application/octet-stream
+      - name: Upload Release Asset (Legacy)
+        id: upload-release-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.get_release.outputs.upload_url }}
+          asset_path: ./cfn-guard-v3-${{ matrix.os }}.tar.gz
+          asset_name: cfn-guard-v3-${{ matrix.os }}.tar.gz
+          asset_content_type: application/octet-stream

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,10 @@ jobs:
             cp ./target/x86_64-apple-darwin/release/cfn-guard ./cfn-guard-v3-x86_64-${{ matrix.os }}/
             cp README.md ./cfn-guard-v3-x86_64-${{ matrix.os }}/
             tar czvf ./cfn-guard-v3-x86_64-${{ matrix.os }}.tar.gz ./cfn-guard-v3-x86_64-${{ matrix.os }}
+            mkdir cfn-guard-v3-${{ matrix.os }}
+            cp ./target/x86_64-unknown-linux-musl/release/cfn-guard ./cfn-guard-v3-${{ matrix.os }}/
+            cp README.md ./cfn-guard-v3-${{ matrix.os }}/
+            tar czvf ./cfn-guard-v3-${{ matrix.os }}.tar.gz ./cfn-guard-v3-${{ matrix.os }}
 
             rustup target add aarch64-apple-darwin
             cargo build --release --target aarch64-apple-darwin

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
             cp README.md ./cfn-guard-v3-x86_64-${{ matrix.os }}/
             tar czvf ./cfn-guard-v3-x86_64-${{ matrix.os }}.tar.gz ./cfn-guard-v3-x86_64-${{ matrix.os }}
             mkdir cfn-guard-v3-${{ matrix.os }}
-            cp ./target/x86_64-unknown-linux-musl/release/cfn-guard ./cfn-guard-v3-${{ matrix.os }}/
+            cp ./target/x86_64-apple-darwin/release/cfn-guard ./cfn-guard-v3-${{ matrix.os }}/
             cp README.md ./cfn-guard-v3-${{ matrix.os }}/
             tar czvf ./cfn-guard-v3-${{ matrix.os }}.tar.gz ./cfn-guard-v3-${{ matrix.os }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,10 @@ jobs:
             cp ./target/x86_64-unknown-linux-musl/release/cfn-guard ./cfn-guard-v3-x86_64-${{ matrix.os }}/
             cp README.md ./cfn-guard-v3-x86_64-${{ matrix.os }}/
             tar czvf ./cfn-guard-v3-x86_64-${{ matrix.os }}.tar.gz ./cfn-guard-v3-x86_64-${{ matrix.os }}
+            mkdir cfn-guard-v3-${{ matrix.os }}
+            cp ./target/x86_64-unknown-linux-musl/release/cfn-guard ./cfn-guard-v3-${{ matrix.os }}/
+            cp README.md ./cfn-guard-v3-${{ matrix.os }}/
+            tar czvf ./cfn-guard-v3-${{ matrix.os }}.tar.gz ./cfn-guard-v3-${{ matrix.os }}
 
             sudo apt update
             sudo apt install gcc-aarch64-linux-gnu


### PR DESCRIPTION
*Issue #, if available:*


*Description of changes:*
This PR adds a redundancy for our uploaded artifact workflows on release. There will now be a guard artifact for x86 architecture using the old naming convention, and the new. The reasoning for this is below. This will be removed for our next release. 


Since we now run the installation script as part of the CI, this means we need to update our install script *after* our next release. Currently the workflow was going to add the guard artifacts in a new way to respect recent changes we did adding support for arm64 architecture. Inbetween this release and updating the install script we need to guarantee any customer running the install script as part of a workflow will not be impacted negatively.

For those interested this is what it would look like: https://github.com/joshfried-aws/cloudformation-guard/releases/tag/3.0.3

---
*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
