### PR TITLE
[Misc]: Removing unnecessary clones

### DIFF
--- a/guard/src/commands/test.rs
+++ b/guard/src/commands/test.rs
@@ -261,7 +261,7 @@ or failure testing.
 
             let path = PathBuf::try_from(file)?;
 
-            let rule_file = File::open(path.clone())?;
+            let rule_file = File::open(&path)?;
             if !rule_file.metadata()?.is_file() {
                 return Err(Error::IoError(std::io::Error::from(
                     std::io::ErrorKind::InvalidInput,

--- a/guard/src/commands/validate.rs
+++ b/guard/src/commands/validate.rs
@@ -292,7 +292,7 @@ or rules files.
                 for file_or_dir in list_of_file_or_dir {
                     validate_path(file_or_dir)?;
                     let base = PathBuf::from_str(file_or_dir)?;
-                    for file in walkdir::WalkDir::new(base.clone()).into_iter().flatten() {
+                    for file in walkdir::WalkDir::new(base).into_iter().flatten() {
                         if file.path().is_file() {
                             let name = file
                                 .file_name()
@@ -334,7 +334,7 @@ or rules files.
                     validate_path(file_or_dir)?;
                     let base = PathBuf::from_str(file_or_dir)?;
 
-                    for file in walkdir::WalkDir::new(base.clone()).into_iter().flatten() {
+                    for file in walkdir::WalkDir::new(base).into_iter().flatten() {
                         if file.path().is_file() {
                             let name = file
                                 .file_name()
@@ -381,7 +381,7 @@ or rules files.
                 if base.is_file() {
                     rules.push(base.clone())
                 } else {
-                    for entry in walkdir::WalkDir::new(base.clone())
+                    for entry in walkdir::WalkDir::new(base)
                         .sort_by(cmp)
                         .into_iter()
                         .flatten()

--- a/guard/src/rules/path_value.rs
+++ b/guard/src/rules/path_value.rs
@@ -26,7 +26,7 @@ use std::hash::{Hash, Hasher};
 //
 // crate level
 //
-#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, Default)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, Default)]
 pub(crate) struct Location {
     pub(crate) line: usize,
     pub(crate) col: usize,
@@ -122,7 +122,7 @@ impl Path {
         let mut copy = self.0.clone();
         copy.push('/');
         copy.push_str(part);
-        Path(copy, self.1.clone())
+        Path(copy, self.1)
     }
 
     pub(crate) fn extend_string(&self, part: &str) -> Path {
@@ -442,7 +442,7 @@ impl TryFrom<(MarkedValue, Path)> for PathAwareValue {
 
                 for (idx, each) in v.into_iter().enumerate() {
                     let sub_path = path.extend_usize(idx);
-                    let loc = each.location().clone();
+                    let loc = *each.location();
                     let value = PathAwareValue::try_from((each, sub_path.with_location(loc)))?;
                     result.push(value);
                 }
@@ -455,11 +455,11 @@ impl TryFrom<(MarkedValue, Path)> for PathAwareValue {
                 let mut values = indexmap::IndexMap::with_capacity(map.len());
                 for ((each_key, loc), each_value) in map {
                     let sub_path = path.extend_string(&each_key);
-                    let sub_path = sub_path.with_location(each_value.location().clone());
+                    let sub_path = sub_path.with_location(*each_value.location());
                     let value = PathAwareValue::try_from((each_value, sub_path))?;
                     values.insert(each_key.to_owned(), value);
                     keys.push(PathAwareValue::String((
-                        path.with_location(loc.clone()),
+                        path.with_location(loc),
                         each_key.to_string(),
                     )));
                 }


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
While going through the codebase i noticed unnecessary calls to `.clone()` in a few different locations. In addition to this I noticed the `Location` type was not `Copy`. I changed this to be `Copy`, and then was able to further remove some other calls to `.clone()`

---
*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
