### PR TITLE
[BugFix]: fix for converting serde_yaml::Value into internal Value type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -674,9 +674,9 @@ dependencies = [
 
 [[package]]
 name = "nom"
-version = "5.1.2"
+version = "5.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffb4262d26ed83a1c0a33a38fe2bb15797329c85770da05e6b828ddb782627af"
+checksum = "08959a387a676302eebf4ddbcbc611da04285579f76f88ee0506c63b1a61dd4b"
 dependencies = [
  "lexical-core",
  "memchr",


### PR DESCRIPTION
*Issue #, if available:*


*Description of changes:*
Using our fuzzer I discovered another bug involved with keys for maps. This time it was when trying to convert from serde_yaml -> our internal value type. We now error our if the value for the key in the `serde_yaml::Value::Map` is not a String. This is consistent with the logic throughout our project. Unfortunately since serde_yaml does not provide the location, our error message doesn't include the location where this error occurs. 

---
*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
