### PR TITLE
[Misc]: bumping up nom to version 5.1.3

### DIFF
--- a/guard/Cargo.toml
+++ b/guard/Cargo.toml
@@ -17,7 +17,7 @@ path = "src/lib.rs"
 crate-type = ["rlib"]
 
 [dependencies]
-nom = "5.1.2"
+nom = "5.1.3"
 nom_locate = "2.0.0"
 indexmap = { version = "1.6.0", features = ["serde-1"] }
 clap_complete = "4.1.2"


### PR DESCRIPTION
*Issue #, if available:*
NA

*Description of changes:*
Nom version 5.1.2 had some code that would trigger compiler warnings saying that it will be rejected by a future version of rust. This PR bumps up our dependency to nom 5.1.3 which addresses this issue. 

---
*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
