### PR TITLE
[Misc]: bumping up fancy-regex to 0.12.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -289,9 +289,9 @@ dependencies = [
 
 [[package]]
 name = "fancy-regex"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b95f7c0680e4142284cf8b22c14a476e87d61b004a3a0861872b32ef7ead40a2"
+checksum = "7493d4c459da9f84325ad297371a6b2b8a162800873a22e3b6b6512e61d18c05"
 dependencies = [
  "bit-set",
  "regex",

--- a/guard/Cargo.toml
+++ b/guard/Cargo.toml
@@ -40,7 +40,7 @@ grep-matcher = "0.1.5"
 grep-regex = "0.1.9"
 unsafe-libyaml = "0.2.2"
 rstest = "0.15.0"
-fancy-regex = "0.11.0"
+fancy-regex = "0.12.0"
 indoc = "1.0.8"
 thiserror = "1.0.38"
 

--- a/guard/src/rules/parser.rs
+++ b/guard/src/rules/parser.rs
@@ -257,8 +257,7 @@ fn parse_regex_inner(input: Span) -> IResult<Span, Value> {
 
         regex.push_str(fragment);
 
-        let validate_regex = Regex::new(regex.as_str());
-        return match validate_regex {
+        return match Regex::try_from(regex.as_str()) {
             Ok(_) => Ok((remainder, Value::Regex(regex))),
             Err(e) => Err(nom::Err::Error(ParserError {
                 context: format!("Could not parse regular expression: {}", e),


### PR DESCRIPTION

*Issue #, if available:*
N/A

*Description of changes:*
This PR bumps up our dependency on fancy-regex so we can take a more idiomatic approach to creating regex's by using the `try_from` trait instead of calling `new` on a constructor that can fail. 

---
*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
