### PR TITLE
[BugFix]: Add check for control characters in regex

### DIFF
--- a/guard/src/rules/parser.rs
+++ b/guard/src/rules/parser.rs
@@ -257,6 +257,16 @@ fn parse_regex_inner(input: Span) -> IResult<Span, Value> {
 
         regex.push_str(fragment);
 
+        for c in regex.chars() {
+            if c.is_control() {
+                return Err(nom::Err::Error(ParserError {
+                    context: "Could not parse regular expression".to_string(),
+                    kind: ErrorKind::RegexpMatch,
+                    span: input,
+                }));
+            }
+        }
+
         return match Regex::try_from(regex.as_str()) {
             Ok(_) => Ok((remainder, Value::Regex(regex))),
             Err(e) => Err(nom::Err::Error(ParserError {

--- a/guard/src/rules/parser_tests.rs
+++ b/guard/src/rules/parser_tests.rs
@@ -4624,6 +4624,16 @@ fn test_parse_regex_inner_when_regex_is_valid() {
 }
 
 #[test]
+fn test_parse_regex_when_regex_contains_control_characters() {
+    let invalid = r#"t(/(FF      ()!t	(?(
+{),:?t.+
+                    "#;
+
+    let invalid_cmp = unsafe { Span::new_from_raw_offset(invalid.len(), 1, invalid, "") };
+    assert!(parse_regex_inner(invalid_cmp).is_err());
+}
+
+#[test]
 fn test_parse_value_when_strings_are_randomly_generated() {
     let values = vec!["weifhasidhhfasidf77627&^&*^**", "IiI+L1w="];
 


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
After running the guard fuzzer we found an issue where Fancy regex does not handle the case where a control character is present in the regex. To fix this we added a check before trying to create the regex, checking if any character in the string is a control character. 

I have also added a test to ensure the fix is correct. 

---
*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
