### PR TITLE
[BugFix]: Fix panic occurring for regex with incomplete groupings

### DIFF
--- a/guard/src/rules/parser_tests.rs
+++ b/guard/src/rules/parser_tests.rs
@@ -4638,8 +4638,6 @@ fn test_parse_regex_when_regex_contains_complete_group_structure_and_escaped_ope
     let invalid = r#"/!w\(?()"Kuz>/"#;
 
     let invalid_cmp = unsafe { Span::new_from_raw_offset(invalid.len(), 1, invalid, "") };
-    let res = parse_regex(invalid_cmp);
-    dbg!(&res);
     assert!(parse_regex(invalid_cmp).is_ok());
 }
 

--- a/guard/src/rules/parser_tests.rs
+++ b/guard/src/rules/parser_tests.rs
@@ -4624,6 +4624,26 @@ fn test_parse_regex_inner_when_regex_is_valid() {
 }
 
 #[test]
+fn test_parse_regex_when_regex_contains_incomplete_group_structure() {
+    std::env::set_var("RUST_BACKTRACE", "1");
+
+    let invalid = r#"/!w(?()"Kuz>/"#;
+
+    let invalid_cmp = unsafe { Span::new_from_raw_offset(invalid.len(), 1, invalid, "") };
+    assert!(parse_regex(invalid_cmp).is_err());
+}
+
+#[test]
+fn test_parse_regex_when_regex_contains_complete_group_structure_and_escaped_opening_paren() {
+    let invalid = r#"/!w\(?()"Kuz>/"#;
+
+    let invalid_cmp = unsafe { Span::new_from_raw_offset(invalid.len(), 1, invalid, "") };
+    let res = parse_regex(invalid_cmp);
+    dbg!(&res);
+    assert!(parse_regex(invalid_cmp).is_ok());
+}
+
+#[test]
 fn test_parse_regex_when_regex_contains_control_characters() {
     let invalid = r#"t(/(FF      ()!t	(?(
 {),:?t.+


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
After running the guard fuzzer we found an issue where Fancy regex does not handle the case where an improper grouping is present in the regex. To fix this we added a check before trying to create the regex, checking if unescaped parenthesis are matched. If they are not matched, we error out. 

I have also added tests to ensure the fix is correct.
---
*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
