### PR TITLE
[Misc]: split fuzz targets into 2

### DIFF
--- a/guard/fuzz/Cargo.lock
+++ b/guard/fuzz/Cargo.lock
@@ -297,9 +297,9 @@ dependencies = [
 
 [[package]]
 name = "fancy-regex"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b95f7c0680e4142284cf8b22c14a476e87d61b004a3a0861872b32ef7ead40a2"
+checksum = "7493d4c459da9f84325ad297371a6b2b8a162800873a22e3b6b6512e61d18c05"
 dependencies = [
  "bit-set",
  "regex",

--- a/guard/fuzz/Cargo.toml
+++ b/guard/fuzz/Cargo.toml
@@ -21,7 +21,13 @@ members = ["."]
 debug = 1
 
 [[bin]]
-name = "fuzz_run_checks"
-path = "fuzz_targets/fuzz_run_checks.rs"
+name = "fuzz_yaml"
+path = "fuzz_targets/fuzz_yaml.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "fuzz_guard_dsl"
+path = "fuzz_targets/fuzz_guard_dsl.rs"
 test = false
 doc = false

--- a/guard/fuzz/fuzz_targets/fuzz_guard_dsl.rs
+++ b/guard/fuzz/fuzz_targets/fuzz_guard_dsl.rs
@@ -16,17 +16,5 @@ fuzz_target!(|data: &[u8]| {
             },
             false,
         );
-
-        let _ = run_checks(
-            ValidateInput {
-                content: s,
-                file_name: "tmpl",
-            },
-            ValidateInput {
-                content: "let ec2 = []",
-                file_name: "rule",
-            },
-            false,
-        );
     }
 });

--- a/guard/fuzz/fuzz_targets/fuzz_yaml.rs
+++ b/guard/fuzz/fuzz_targets/fuzz_yaml.rs
@@ -1,0 +1,20 @@
+#![no_main]
+
+use cfn_guard::{run_checks, ValidateInput};
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    if let Ok(s) = std::str::from_utf8(data) {
+        let _ = run_checks(
+            ValidateInput {
+                content: s,
+                file_name: "tmpl",
+            },
+            ValidateInput {
+                content: "let ec2 = []",
+                file_name: "rule",
+            },
+            false,
+        );
+    }
+});


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
To make it easier to see which part is failing I decided to split up our fuzz targets so one target focuses on yaml, and the other focusses on the dsl. This allows us to speed up the debugging process if need be. 

---
*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
