### PR TITLE
[BugFix]: fixing panic in evaluator when query from typeblock is unresolved

### DIFF
--- a/guard/src/rules/eval.rs
+++ b/guard/src/rules/eval.rs
@@ -1778,8 +1778,24 @@ pub(in crate::rules) fn eval_type_block_clause<'value, 'loc: 'value>(
                     }
                 }
             }
+            QueryResult::UnResolved(ur) => {
+                resolver.end_record(
+                    &context,
+                    RecordType::TypeCheck(TypeBlockCheck {
+                        type_name: &type_block.type_name,
+                        block: BlockCheck {
+                            at_least_one_matches: false,
+                            status: Status::FAIL,
+                            message: ur.reason.clone(),
+                        },
+                    }),
+                )?;
 
-            QueryResult::UnResolved(_) => unreachable!(),
+                return Err(Error::MissingValue(format!(
+                    "Unable to resolve type block query: {}",
+                    type_block.type_name,
+                )));
+            }
         }
     }
 

--- a/guard/tests/validate.rs
+++ b/guard/tests/validate.rs
@@ -537,6 +537,18 @@ mod validate_tests {
     }
 
     #[test]
+    fn test_with_payload_failing_type_block() {
+        let payload = r#"{"data": [ "{}" ], "rules" : [ "d1z::Y\n\t\tm<0m<03333333" ]}"#;
+        let mut reader = Reader::new(ReadCursor(Cursor::new(Vec::from(payload.as_bytes()))));
+        let mut writer = Writer::new(WBVec(vec![]), WBVec(vec![]));
+        let status_code = ValidateTestRunner::default()
+            .payload()
+            .run(&mut writer, &mut reader);
+
+        assert_eq!(StatusCode::INTERNAL_FAILURE, status_code);
+    }
+
+    #[test]
     fn test_with_payload_flag_fail() {
         let payload = r#"{"data": ["{\"Resources\":{\"NewVolume\":{\"Type\":\"AWS::EC2::Volume\",\"Properties\":{\"Size\":500,\"Encrypted\":false,\"AvailabilityZone\":\"us-west-2b\"}},\"NewVolume2\":{\"Type\":\"AWS::EC2::Volume\",\"Properties\":{\"Size\":50,\"Encrypted\":false,\"AvailabilityZone\":\"us-west-2c\"}}},\"Parameters\":{\"InstanceName\":\"TestInstance\"}}","{\"Resources\":{\"NewVolume\":{\"Type\":\"AWS::EC2::Volume\",\"Properties\":{\"Size\":500,\"Encrypted\":false,\"AvailabilityZone\":\"us-west-2b\"}},\"NewVolume2\":{\"Type\":\"AWS::EC2::Volume\",\"Properties\":{\"Size\":50,\"Encrypted\":false,\"AvailabilityZone\":\"us-west-2c\"}}},\"Parameters\":{\"InstanceName\":\"TestInstance\"}}"], "rules" : [ "Parameters.InstanceName == \"TestInstance\"","Parameters.InstanceName == \"SomeRandomString\"" ]}"#;
         let mut reader = Reader::new(ReadCursor(Cursor::new(Vec::from(payload.as_bytes()))));


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
We discovered another panic when running our fuzzer, this was when a query from a type_block is unresolved. Previously this was considered unreachable. Now instead of it being unreachable we return a `MissingValue` error, with some contest as to why this error occurred. 

We have also added an integration test to catch this. 

---
*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
