### PR TITLE
[Misc]: adding fuzzer to ci

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -8,6 +8,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  FUZZ_TIME: 420
 
 jobs:
   build:
@@ -38,6 +39,7 @@ jobs:
           components: rustfmt
       - name: Rustfmt Check
         uses: actions-rust-lang/rustfmt@v1
+
   installScript:
     name: Testing Install Script (install-guard.sh)
     runs-on: ubuntu-latest
@@ -59,8 +61,28 @@ jobs:
       - uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-
           args: -- -D warnings
+
+  fuzz:
+    strategy:
+      matrix:
+        target: ["guard_dsl", "yaml"]
+    runs-on: ubuntu-latest
+    name: Run Fuzz Checks
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+      - uses: actions-rs/cargo@v1
+        name: Install cargo-fuzz
+        with:
+          command: install
+          args: cargo-fuzz
+      - name: fuzz ${{ matrix.target }}
+        run: |
+          cd guard/fuzz
+          cargo +nightly fuzz run fuzz_${{ matrix.target }} -- -max_total_time=${{ env.FUZZ_TIME }}
 
   aws-guard-rules-registry-integration-tests-linux:
     strategy:


### PR DESCRIPTION
*Issue #, if available:*
NA

*Description of changes:*
This adds a workflow for our fuzzer to run for 7 mins for each target (dsl, and yaml). This job will run on each PR. 

Tested on a PR off of my own fork: https://github.com/joshfried-aws/cloudformation-guard/actions/runs/7131116699

---
*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
