### PR TITLE
[Misc]: adding multiple targets for install script job

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -51,6 +51,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     name: Testing Install Script (install-guard.sh)
     steps:
+      - uses: actions/checkout@v3
+        name: Checkout cfn-guard
+        with:
+          path: cloudformation-guard
       - name: Test install script on ${{ matrix.os }}
         run: |
           cd cloudformation-guard

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -57,6 +57,7 @@ jobs:
           path: cloudformation-guard
       - name: Test install script on ${{ matrix.os }}
         run: |
+          set -e
           cd cloudformation-guard
           sh install-guard.sh
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -53,6 +53,7 @@ jobs:
     steps:
       - name: Test install script on ${{ matrix.os }}
         run: |
+          cd guard
           sh install-guard.sh
 
   linting:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -53,7 +53,7 @@ jobs:
     steps:
       - name: Test install script on ${{ matrix.os }}
         run: |
-          cd guard
+          cd cloudformation-guard
           sh install-guard.sh
 
   linting:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -45,10 +45,13 @@ jobs:
         uses: actions-rust-lang/rustfmt@v1
 
   installScript:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, macos-13-xlarge]
+    runs-on: ${{ matrix.os }}
     name: Testing Install Script (install-guard.sh)
-    runs-on: ubuntu-latest
     steps:
-      - name: Test install script on ubuntu-latest
+      - name: Test install script on ${{ matrix.os }}
         run: |
           curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/aws-cloudformation/cloudformation-guard/main/install-guard.sh | sh
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -53,7 +53,7 @@ jobs:
     steps:
       - name: Test install script on ${{ matrix.os }}
         run: |
-          curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/aws-cloudformation/cloudformation-guard/main/install-guard.sh | sh
+          sh install-guard.sh
 
   linting:
     name: Linting check (clippy)

--- a/install-guard.sh
+++ b/install-guard.sh
@@ -25,7 +25,7 @@ main() {
 			mkdir -p ~/.guard/"$MAJOR_VER" ~/.guard/bin ||
 				err "unable to make directories ~/.guard/$MAJOR_VER, ~/.guard/bin"
 			get_os_type
-			download https://github.com/aws-cloudformation/cloudformation-guard/releases/download/"$VERSION"/cfn-guard-v"$MAJOR_VER"-"$ARCH_TYPE"-"$OS_TYPE"-latest.tar.gz >/tmp/guard.tar.gz ||
+			download https://agithub.com/aws-cloudformation/cloudformation-guard/releases/download/"$VERSION"/cfn-guard-v"$MAJOR_VER"-"$ARCH_TYPE"-"$OS_TYPE"-latest.tar.gz >/tmp/guard.tar.gz ||
 				err "unable to download https://github.com/aws-cloudformation/cloudformation-guard/releases/download/$VERSION/cfn-guard-v$MAJOR_VER-$ARCH_TYPE-$OS_TYPE-latest.tar.gz"
 			tar -C ~/.guard/"$MAJOR_VER" -xzf /tmp/guard.tar.gz ||
 				err "unable to untar /tmp/guard.tar.gz"

--- a/install-guard.sh
+++ b/install-guard.sh
@@ -25,7 +25,7 @@ main() {
 			mkdir -p ~/.guard/"$MAJOR_VER" ~/.guard/bin ||
 				err "unable to make directories ~/.guard/$MAJOR_VER, ~/.guard/bin"
 			get_os_type
-			download https://agithub.com/aws-cloudformation/cloudformation-guard/releases/download/"$VERSION"/cfn-guard-v"$MAJOR_VER"-"$ARCH_TYPE"-"$OS_TYPE"-latest.tar.gz >/tmp/guard.tar.gz ||
+			download https://github.com/aws-cloudformation/cloudformation-guard/releases/download/"$VERSION"/cfn-guard-v"$MAJOR_VER"-"$ARCH_TYPE"-"$OS_TYPE"-latest.tar.gz >/tmp/guard.tar.gz ||
 				err "unable to download https://github.com/aws-cloudformation/cloudformation-guard/releases/download/$VERSION/cfn-guard-v$MAJOR_VER-$ARCH_TYPE-$OS_TYPE-latest.tar.gz"
 			tar -C ~/.guard/"$MAJOR_VER" -xzf /tmp/guard.tar.gz ||
 				err "unable to untar /tmp/guard.tar.gz"


### PR DESCRIPTION
*Issue #, if available:*
#385 

*Description of changes:*
Previously we were just testing the already merged version of the script, this PR makes it so we test the local version of it. We also added both 2 new macos targets to test our install script works on supported platforms except for arm64 linux since Github does not yet have a runner for this. 

Previous commits were done to test, and ensure jobs fail when the script fails. 

---
*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
