### PR TITLE
[Misc]: adding apple silicon runner to os targets for registry job

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -97,10 +97,10 @@ jobs:
           cd guard/fuzz
           cargo +nightly fuzz run fuzz_${{ matrix.target }} -- -max_total_time=${{ env.FUZZ_TIME }}
 
-  aws-guard-rules-registry-integration-tests-linux:
+  aws-guard-rules-registry-integration-tests-linux-and-macos:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, macos-13-xlarge]
     runs-on: ${{ matrix.os }}
     name: Integration tests against aws-guard-rules-registry
     steps:


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Adding apple silicon target for job that runs integration tests for all registry rules

---
*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
