### PR TITLE
[Misc]: Reverting previous changes + bumping up fancy-regex version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -272,12 +272,13 @@ dependencies = [
 
 [[package]]
 name = "fancy-regex"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7493d4c459da9f84325ad297371a6b2b8a162800873a22e3b6b6512e61d18c05"
+checksum = "531e46835a22af56d1e3b66f04844bed63158bc094a628bec1d321d9b4c44bf2"
 dependencies = [
  "bit-set",
- "regex",
+ "regex-automata 0.4.3",
+ "regex-syntax 0.8.2",
 ]
 
 [[package]]

--- a/guard/Cargo.toml
+++ b/guard/Cargo.toml
@@ -40,7 +40,7 @@ grep-matcher = "0.1.5"
 grep-regex = "0.1.9"
 unsafe-libyaml = "0.2.10"
 rstest = "0.15.0"
-fancy-regex = "0.12.0"
+fancy-regex = "0.13.0"
 indoc = "1.0.8"
 thiserror = "1.0.38"
 

--- a/guard/src/rules/parser.rs
+++ b/guard/src/rules/parser.rs
@@ -257,41 +257,6 @@ fn parse_regex_inner(input: Span) -> IResult<Span, Value> {
 
         regex.push_str(fragment);
 
-        let mut stack = vec![];
-        let chars = regex.chars().collect::<Vec<_>>();
-
-        for (i, c) in chars.iter().enumerate() {
-            if c.is_control() {
-                return Err(nom::Err::Error(ParserError {
-                    context: "Could not parse regular expression".to_string(),
-                    kind: ErrorKind::RegexpMatch,
-                    span: input,
-                }));
-            }
-            if *c == '(' {
-                if i == 0 || *chars.get(i - 1).unwrap() != '\\' {
-                    stack.push(c);
-                }
-            } else if *c == ')'
-                && (i == 0 || *chars.get(i - 1).unwrap() != '\\')
-                && stack.pop().is_none()
-            {
-                return Err(nom::Err::Error(ParserError {
-                    context: "Could not parse regular expression".to_string(),
-                    kind: ErrorKind::RegexpMatch,
-                    span: input,
-                }));
-            }
-        }
-
-        if !stack.is_empty() {
-            return Err(nom::Err::Error(ParserError {
-                context: "Could not parse regular expression".to_string(),
-                kind: ErrorKind::RegexpMatch,
-                span: input,
-            }));
-        }
-
         return match Regex::try_from(regex.as_str()) {
             Ok(_) => Ok((remainder, Value::Regex(regex))),
             Err(e) => Err(nom::Err::Error(ParserError {


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
In #429 we made a change that handled unmatched groupings, and in #428 we made changes to check for control characters in a regex. The maintainers of fancy-regex addressed this here: https://github.com/fancy-regex/fancy-regex/pull/125 

This PR bumps up our dependency to use fancy-regex 0.13.0 and removes the code changes we made to guard against these edge cases.  

---
*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
