### PR TITLE
[Misc]: bumping up all references of 3.0.2 to 3.0.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ Check `help` to see if it is working.
 
 ```bash
 $ cfn-guard help
-cfn-guard 3.0.2
+cfn-guard 3.0.3
 
   Guard is a general-purpose tool that provides a simple declarative syntax to define
   policy-as-code as rules to validate against any structured hierarchical data (like JSON/YAML).

--- a/guard-ffi/Cargo.toml
+++ b/guard-ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cfn-guard-ffi"
-version = "3.0.2"
+version = "3.0.3"
 edition = "2018"
 authors = ["Diwakar Chakravarthy", "John Tompkins", "Omkar Hegde", "Priya Padmanaban", "aws-cloudformation-developers <aws-cloudformation-developers@amazon.com>", "Tyler Southwick"]
 description = "AWS CloudFormation Guard is an open-source general-purpose policy-as-code evaluation tool. It provides developers with a simple-to-use, yet powerful and expressive domain-specific language (DSL) to define policies and enables developers to validate JSON- or YAML- formatted structured data with those policies."
@@ -14,5 +14,5 @@ keywords = ["policy-as-code", "guard", "cfn-guard", "security", "compliance"]
 crate-type = ["rlib", "dylib"]
 
 [dependencies]
-cfn-guard = { version = "3.0.2", path = "../guard" }
+cfn-guard = { version = "3.0.3", path = "../guard" }
 ffi-support = "0.4.4"

--- a/guard-lambda/Cargo.toml
+++ b/guard-lambda/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cfn-guard-lambda"
-version = "3.0.2"
+version = "3.0.3"
 authors = ["Diwakar Chakravarthy", "John Tompkins", "Omkar Hegde", "Priya Padmanaban",
     "Bryan Ayala", "Kexiang Wang", "Akshay Rane", "Josh Fried", "aws-cloudformation-developers <aws-cloudformation-developers@amazon.com>"]
 description = "Lambda version of cfn-guard. Checks JSON- or YAML- formatted structured data for policy compliance using a simple, policy-as-code, declarative syntax"
@@ -17,4 +17,4 @@ serde_derive = "1.0.92"
 simple_logger = "4.0.0"
 log = "0.4.6"
 tokio = "1.24.2"
-cfn-guard = { version = "3.0.2", path = "../guard" }
+cfn-guard = { version = "3.0.3", path = "../guard" }

--- a/guard/Cargo.toml
+++ b/guard/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cfn-guard"
-version = "3.0.2"
+version = "3.0.3"
 edition = "2018"
 authors = ["Diwakar Chakravarthy", "John Tompkins", "Omkar Hegde", "Priya Padmanaban",
     "Bryan Ayala", "Kexiang Wang", "Akshay Rane", "Tyler Southwick", "Josh Fried", "aws-cloudformation-developers <aws-cloudformation-developers@amazon.com>"]


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
In preparation for our release of 3.0.3 I am bumping up all references in the codebase and docs to 3.0.2 to now reference 3.0.3

---
*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
