### PR TITLE
[Enhancement] Only show errors/failures in output

### DIFF
--- a/guard/resources/validate/output-dir/advanced_regex_negative_lookbehind_compliant.out
+++ b/guard/resources/validate/output-dir/advanced_regex_negative_lookbehind_compliant.out
@@ -2,7 +2,3 @@ advanced_regex_negative_lookbehind_compliant.yaml Status = PASS
 PASS rules
 advanced_regex_negative_lookbehind_rule.guard/default    PASS
 ---
-Evaluation of rules advanced_regex_negative_lookbehind_rule.guard against data advanced_regex_negative_lookbehind_compliant.yaml
---
-Rule [advanced_regex_negative_lookbehind_rule.guard/default] is compliant for template [advanced_regex_negative_lookbehind_compliant.yaml]
---

--- a/guard/resources/validate/output-dir/rules_dir_against_data_dir.out
+++ b/guard/resources/validate/output-dir/rules_dir_against_data_dir.out
@@ -1,0 +1,275 @@
+s3-public-read-prohibited-template-compliant.yaml Status = FAIL
+FAILED rules
+advanced_regex_negative_lookbehind_rule.guard/default    FAIL
+---
+Evaluating data s3-public-read-prohibited-template-compliant.yaml against rules advanced_regex_negative_lookbehind_rule.guard
+Number of non-compliant resources 0
+s3-public-read-prohibited-template-non-compliant.yaml Status = FAIL
+FAILED rules
+advanced_regex_negative_lookbehind_rule.guard/default    FAIL
+---
+Evaluating data s3-public-read-prohibited-template-non-compliant.yaml against rules advanced_regex_negative_lookbehind_rule.guard
+Number of non-compliant resources 0
+s3-server-side-encryption-template-non-compliant.yaml Status = FAIL
+FAILED rules
+advanced_regex_negative_lookbehind_rule.guard/default    FAIL
+---
+Evaluating data s3-server-side-encryption-template-non-compliant.yaml against rules advanced_regex_negative_lookbehind_rule.guard
+Number of non-compliant resources 0
+advanced_regex_negative_lookbehind_non_compliant.yaml Status = FAIL
+FAILED rules
+advanced_regex_negative_lookbehind_rule.guard/default    FAIL
+---
+Evaluation of rules advanced_regex_negative_lookbehind_rule.guard against data advanced_regex_negative_lookbehind_non_compliant.yaml
+--
+Property [/NotAwsAccessKey] in data [advanced_regex_negative_lookbehind_non_compliant.yaml] is not compliant with [advanced_regex_negative_lookbehind_rule.guard/default] because provided value ["AKIAIOSFODNN7EXAMPLE"] did match expected value ["/(?<![A-Z0-9])[A-Z0-9]{20}(?![A-Z0-9])/"]. Error Message []
+Property [/NotSecretAccessKey] in data [advanced_regex_negative_lookbehind_non_compliant.yaml] is not compliant with [advanced_regex_negative_lookbehind_rule.guard/default] because provided value ["wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"] did match expected value ["/(?<![A-Za-z0-9\\/+=])[A-Za-z0-9\\/+=]{40}(?![A-Za-z0-9\\/+=])/"]. Error Message []
+--
+s3-server-side-encryption-template-compliant.yaml Status = FAIL
+FAILED rules
+advanced_regex_negative_lookbehind_rule.guard/default    FAIL
+---
+Evaluating data s3-server-side-encryption-template-compliant.yaml against rules advanced_regex_negative_lookbehind_rule.guard
+Number of non-compliant resources 0
+s3-public-read-prohibited-template-compliant.yaml Status = FAIL
+FAILED rules
+s3_bucket_logging_enabled.guard/S3_BUCKET_LOGGING_ENABLED    FAIL
+---
+Evaluating data s3-public-read-prohibited-template-compliant.yaml against rules s3_bucket_logging_enabled.guard
+Number of non-compliant resources 1
+Resource = MyBucket {
+  Type      = AWS::S3::Bucket
+  Rule = S3_BUCKET_LOGGING_ENABLED {
+    ALL {
+      Check =  %s3_buckets_bucket_logging_enabled[*].Properties.LoggingConfiguration EXISTS   {
+        Message {
+          Violation: S3 Bucket Logging needs to be configured to enable logging.
+          Fix: Set the S3 Bucket property LoggingConfiguration to start logging into S3 bucket.
+        }
+        RequiredPropertyError {
+          PropertyPath = /Resources/MyBucket/Properties[L:8,C:6]
+          MissingProperty = LoggingConfiguration
+          Reason = Could not find key LoggingConfiguration inside struct at path /Resources/MyBucket/Properties[L:8,C:6]
+          Code:
+                6.  MyBucket:
+                7.    Type: AWS::S3::Bucket
+                8.    Properties:
+                9.      PublicAccessBlockConfiguration:
+               10.        BlockPublicAcls: true
+               11.        BlockPublicPolicy: true
+        }
+      }
+    }
+  }
+}
+s3-public-read-prohibited-template-non-compliant.yaml Status = FAIL
+FAILED rules
+s3_bucket_logging_enabled.guard/S3_BUCKET_LOGGING_ENABLED    FAIL
+---
+Evaluating data s3-public-read-prohibited-template-non-compliant.yaml against rules s3_bucket_logging_enabled.guard
+Number of non-compliant resources 1
+Resource = MyBucket {
+  Type      = AWS::S3::Bucket
+  Rule = S3_BUCKET_LOGGING_ENABLED {
+    ALL {
+      Check =  %s3_buckets_bucket_logging_enabled[*].Properties.LoggingConfiguration EXISTS   {
+        Message {
+          Violation: S3 Bucket Logging needs to be configured to enable logging.
+          Fix: Set the S3 Bucket property LoggingConfiguration to start logging into S3 bucket.
+        }
+        RequiredPropertyError {
+          PropertyPath = /Resources/MyBucket/Properties[L:13,C:6]
+          MissingProperty = LoggingConfiguration
+          Reason = Could not find key LoggingConfiguration inside struct at path /Resources/MyBucket/Properties[L:13,C:6]
+          Code:
+               11.      #   BlockPublicPolicy: true
+               12.      #   IgnorePublicAcls: true
+               13.      #   RestrictPublicBuckets: true
+               14.      BucketEncryption:
+               15.        ServerSideEncryptionConfiguration:
+               16.          - ServerSideEncryptionByDefault:
+        }
+      }
+    }
+  }
+}
+s3-server-side-encryption-template-non-compliant.yaml Status = FAIL
+FAILED rules
+s3_bucket_logging_enabled.guard/S3_BUCKET_LOGGING_ENABLED    FAIL
+---
+Evaluating data s3-server-side-encryption-template-non-compliant.yaml against rules s3_bucket_logging_enabled.guard
+Number of non-compliant resources 1
+Resource = MyBucket {
+  Type      = AWS::S3::Bucket
+  Rule = S3_BUCKET_LOGGING_ENABLED {
+    ALL {
+      Check =  %s3_buckets_bucket_logging_enabled[*].Properties.LoggingConfiguration EXISTS   {
+        Message {
+          Violation: S3 Bucket Logging needs to be configured to enable logging.
+          Fix: Set the S3 Bucket property LoggingConfiguration to start logging into S3 bucket.
+        }
+        RequiredPropertyError {
+          PropertyPath = /Resources/MyBucket/Properties[L:8,C:6]
+          MissingProperty = LoggingConfiguration
+          Reason = Could not find key LoggingConfiguration inside struct at path /Resources/MyBucket/Properties[L:8,C:6]
+          Code:
+                6.  MyBucket:
+                7.    Type: AWS::S3::Bucket
+                8.    Properties:
+                9.      PublicAccessBlockConfiguration:
+               10.        BlockPublicAcls: true
+               11.        BlockPublicPolicy: true
+        }
+      }
+    }
+  }
+}
+s3-server-side-encryption-template-compliant.yaml Status = FAIL
+FAILED rules
+s3_bucket_logging_enabled.guard/S3_BUCKET_LOGGING_ENABLED    FAIL
+---
+Evaluating data s3-server-side-encryption-template-compliant.yaml against rules s3_bucket_logging_enabled.guard
+Number of non-compliant resources 1
+Resource = MyBucket {
+  Type      = AWS::S3::Bucket
+  Rule = S3_BUCKET_LOGGING_ENABLED {
+    ALL {
+      Check =  %s3_buckets_bucket_logging_enabled[*].Properties.LoggingConfiguration EXISTS   {
+        Message {
+          Violation: S3 Bucket Logging needs to be configured to enable logging.
+          Fix: Set the S3 Bucket property LoggingConfiguration to start logging into S3 bucket.
+        }
+        RequiredPropertyError {
+          PropertyPath = /Resources/MyBucket/Properties[L:8,C:6]
+          MissingProperty = LoggingConfiguration
+          Reason = Could not find key LoggingConfiguration inside struct at path /Resources/MyBucket/Properties[L:8,C:6]
+          Code:
+                6.  MyBucket:
+                7.    Type: AWS::S3::Bucket
+                8.    Properties:
+                9.      PublicAccessBlockConfiguration:
+               10.        BlockPublicAcls: true
+               11.        BlockPublicPolicy: true
+        }
+      }
+    }
+  }
+}
+s3-public-read-prohibited-template-non-compliant.yaml Status = FAIL
+FAILED rules
+s3_bucket_public_read_prohibited.guard/S3_BUCKET_PUBLIC_READ_PROHIBITED    FAIL
+---
+Evaluating data s3-public-read-prohibited-template-non-compliant.yaml against rules s3_bucket_public_read_prohibited.guard
+Number of non-compliant resources 1
+Resource = MyBucket {
+  Type      = AWS::S3::Bucket
+  Rule = S3_BUCKET_PUBLIC_READ_PROHIBITED {
+    ALL {
+      Check =  %s3_bucket_public_read_prohibited[*].Properties.PublicAccessBlockConfiguration EXISTS   {
+        RequiredPropertyError {
+          PropertyPath = /Resources/MyBucket/Properties[L:13,C:6]
+          MissingProperty = PublicAccessBlockConfiguration
+          Reason = Could not find key PublicAccessBlockConfiguration inside struct at path /Resources/MyBucket/Properties[L:13,C:6]
+          Code:
+               11.      #   BlockPublicPolicy: true
+               12.      #   IgnorePublicAcls: true
+               13.      #   RestrictPublicBuckets: true
+               14.      BucketEncryption:
+               15.        ServerSideEncryptionConfiguration:
+               16.          - ServerSideEncryptionByDefault:
+        }
+      }
+      Check =  %s3_bucket_public_read_prohibited[*].Properties.PublicAccessBlockConfiguration.BlockPublicAcls EQUALS  true {
+        RequiredPropertyError {
+          PropertyPath = /Resources/MyBucket/Properties[L:13,C:6]
+          MissingProperty = PublicAccessBlockConfiguration.BlockPublicAcls
+          Reason = Could not find key PublicAccessBlockConfiguration inside struct at path /Resources/MyBucket/Properties[L:13,C:6]
+          Code:
+               11.      #   BlockPublicPolicy: true
+               12.      #   IgnorePublicAcls: true
+               13.      #   RestrictPublicBuckets: true
+               14.      BucketEncryption:
+               15.        ServerSideEncryptionConfiguration:
+               16.          - ServerSideEncryptionByDefault:
+        }
+      }
+      Check =  %s3_bucket_public_read_prohibited[*].Properties.PublicAccessBlockConfiguration.BlockPublicPolicy EQUALS  true {
+        RequiredPropertyError {
+          PropertyPath = /Resources/MyBucket/Properties[L:13,C:6]
+          MissingProperty = PublicAccessBlockConfiguration.BlockPublicPolicy
+          Reason = Could not find key PublicAccessBlockConfiguration inside struct at path /Resources/MyBucket/Properties[L:13,C:6]
+          Code:
+               11.      #   BlockPublicPolicy: true
+               12.      #   IgnorePublicAcls: true
+               13.      #   RestrictPublicBuckets: true
+               14.      BucketEncryption:
+               15.        ServerSideEncryptionConfiguration:
+               16.          - ServerSideEncryptionByDefault:
+        }
+      }
+      Check =  %s3_bucket_public_read_prohibited[*].Properties.PublicAccessBlockConfiguration.IgnorePublicAcls EQUALS  true {
+        RequiredPropertyError {
+          PropertyPath = /Resources/MyBucket/Properties[L:13,C:6]
+          MissingProperty = PublicAccessBlockConfiguration.IgnorePublicAcls
+          Reason = Could not find key PublicAccessBlockConfiguration inside struct at path /Resources/MyBucket/Properties[L:13,C:6]
+          Code:
+               11.      #   BlockPublicPolicy: true
+               12.      #   IgnorePublicAcls: true
+               13.      #   RestrictPublicBuckets: true
+               14.      BucketEncryption:
+               15.        ServerSideEncryptionConfiguration:
+               16.          - ServerSideEncryptionByDefault:
+        }
+      }
+      Check =  %s3_bucket_public_read_prohibited[*].Properties.PublicAccessBlockConfiguration.RestrictPublicBuckets EQUALS  true {
+        Message {
+          Violation: S3 Bucket Public Write Access controls need to be restricted.
+          Fix: Set S3 Bucket PublicAccessBlockConfiguration properties for BlockPublicAcls, BlockPublicPolicy, IgnorePublicAcls, RestrictPublicBuckets parameters to true.
+        }
+        RequiredPropertyError {
+          PropertyPath = /Resources/MyBucket/Properties[L:13,C:6]
+          MissingProperty = PublicAccessBlockConfiguration.RestrictPublicBuckets
+          Reason = Could not find key PublicAccessBlockConfiguration inside struct at path /Resources/MyBucket/Properties[L:13,C:6]
+          Code:
+               11.      #   BlockPublicPolicy: true
+               12.      #   IgnorePublicAcls: true
+               13.      #   RestrictPublicBuckets: true
+               14.      BucketEncryption:
+               15.        ServerSideEncryptionConfiguration:
+               16.          - ServerSideEncryptionByDefault:
+        }
+      }
+    }
+  }
+}
+s3-server-side-encryption-template-non-compliant.yaml Status = FAIL
+FAILED rules
+s3_bucket_server_side_encryption_enabled.guard/S3_BUCKET_SERVER_SIDE_ENCRYPTION_ENABLED    FAIL
+---
+Evaluating data s3-server-side-encryption-template-non-compliant.yaml against rules s3_bucket_server_side_encryption_enabled.guard
+Number of non-compliant resources 1
+Resource = MyBucket {
+  Type      = AWS::S3::Bucket
+  Rule = S3_BUCKET_SERVER_SIDE_ENCRYPTION_ENABLED {
+    ALL {
+      Check =  %s3_buckets_server_side_encryption[*].Properties.BucketEncryption.ServerSideEncryptionConfiguration[*].ServerSideEncryptionByDefault.SSEAlgorithm IN  ["aws:kms","AES256"] {
+        Message {
+          Violation: S3 Bucket must enable server-side encryption.
+          Fix: Set the S3 Bucket property BucketEncryption.ServerSideEncryptionConfiguration.ServerSideEncryptionByDefault.SSEAlgorithm to either "aws:kms" or "AES256"
+        }
+        RequiredPropertyError {
+          PropertyPath = /Resources/MyBucket/Properties/BucketEncryption[L:13,C:23]
+          MissingProperty = ServerSideEncryptionConfiguration[*].ServerSideEncryptionByDefault.SSEAlgorithm
+          Reason = Attempting to retrieve from key ServerSideEncryptionConfiguration but type is not an struct type at path /Resources/MyBucket/Properties/BucketEncryption[L:13,C:23], Type = String, Value = String((Path("/Resources/MyBucket/Properties/BucketEncryption", Location { line: 13, col: 23 }), ""))
+          Code:
+               11.        BlockPublicPolicy: true
+               12.        IgnorePublicAcls: true
+               13.        RestrictPublicBuckets: true
+               14.      BucketEncryption:
+               15.      VersioningConfiguration:
+               16.        Status: Enabled
+        }
+      }
+    }
+  }
+}

--- a/guard/resources/validate/output-dir/rules_dir_against_data_dir.out
+++ b/guard/resources/validate/output-dir/rules_dir_against_data_dir.out
@@ -1,3 +1,12 @@
+advanced_regex_negative_lookbehind_non_compliant.yaml Status = FAIL
+FAILED rules
+advanced_regex_negative_lookbehind_rule.guard/default    FAIL
+---
+Evaluation of rules advanced_regex_negative_lookbehind_rule.guard against data advanced_regex_negative_lookbehind_non_compliant.yaml
+--
+Property [/NotAwsAccessKey] in data [advanced_regex_negative_lookbehind_non_compliant.yaml] is not compliant with [advanced_regex_negative_lookbehind_rule.guard/default] because provided value ["AKIAIOSFODNN7EXAMPLE"] did match expected value ["/(?<![A-Z0-9])[A-Z0-9]{20}(?![A-Z0-9])/"]. Error Message []
+Property [/NotSecretAccessKey] in data [advanced_regex_negative_lookbehind_non_compliant.yaml] is not compliant with [advanced_regex_negative_lookbehind_rule.guard/default] because provided value ["wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"] did match expected value ["/(?<![A-Za-z0-9\\/+=])[A-Za-z0-9\\/+=]{40}(?![A-Za-z0-9\\/+=])/"]. Error Message []
+--
 s3-public-read-prohibited-template-compliant.yaml Status = FAIL
 FAILED rules
 advanced_regex_negative_lookbehind_rule.guard/default    FAIL
@@ -10,26 +19,17 @@ advanced_regex_negative_lookbehind_rule.guard/default    FAIL
 ---
 Evaluating data s3-public-read-prohibited-template-non-compliant.yaml against rules advanced_regex_negative_lookbehind_rule.guard
 Number of non-compliant resources 0
-s3-server-side-encryption-template-non-compliant.yaml Status = FAIL
-FAILED rules
-advanced_regex_negative_lookbehind_rule.guard/default    FAIL
----
-Evaluating data s3-server-side-encryption-template-non-compliant.yaml against rules advanced_regex_negative_lookbehind_rule.guard
-Number of non-compliant resources 0
-advanced_regex_negative_lookbehind_non_compliant.yaml Status = FAIL
-FAILED rules
-advanced_regex_negative_lookbehind_rule.guard/default    FAIL
----
-Evaluation of rules advanced_regex_negative_lookbehind_rule.guard against data advanced_regex_negative_lookbehind_non_compliant.yaml
---
-Property [/NotAwsAccessKey] in data [advanced_regex_negative_lookbehind_non_compliant.yaml] is not compliant with [advanced_regex_negative_lookbehind_rule.guard/default] because provided value ["AKIAIOSFODNN7EXAMPLE"] did match expected value ["/(?<![A-Z0-9])[A-Z0-9]{20}(?![A-Z0-9])/"]. Error Message []
-Property [/NotSecretAccessKey] in data [advanced_regex_negative_lookbehind_non_compliant.yaml] is not compliant with [advanced_regex_negative_lookbehind_rule.guard/default] because provided value ["wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"] did match expected value ["/(?<![A-Za-z0-9\\/+=])[A-Za-z0-9\\/+=]{40}(?![A-Za-z0-9\\/+=])/"]. Error Message []
---
 s3-server-side-encryption-template-compliant.yaml Status = FAIL
 FAILED rules
 advanced_regex_negative_lookbehind_rule.guard/default    FAIL
 ---
 Evaluating data s3-server-side-encryption-template-compliant.yaml against rules advanced_regex_negative_lookbehind_rule.guard
+Number of non-compliant resources 0
+s3-server-side-encryption-template-non-compliant.yaml Status = FAIL
+FAILED rules
+advanced_regex_negative_lookbehind_rule.guard/default    FAIL
+---
+Evaluating data s3-server-side-encryption-template-non-compliant.yaml against rules advanced_regex_negative_lookbehind_rule.guard
 Number of non-compliant resources 0
 s3-public-read-prohibited-template-compliant.yaml Status = FAIL
 FAILED rules
@@ -93,11 +93,11 @@ Resource = MyBucket {
     }
   }
 }
-s3-server-side-encryption-template-non-compliant.yaml Status = FAIL
+s3-server-side-encryption-template-compliant.yaml Status = FAIL
 FAILED rules
 s3_bucket_logging_enabled.guard/S3_BUCKET_LOGGING_ENABLED    FAIL
 ---
-Evaluating data s3-server-side-encryption-template-non-compliant.yaml against rules s3_bucket_logging_enabled.guard
+Evaluating data s3-server-side-encryption-template-compliant.yaml against rules s3_bucket_logging_enabled.guard
 Number of non-compliant resources 1
 Resource = MyBucket {
   Type      = AWS::S3::Bucket
@@ -124,11 +124,11 @@ Resource = MyBucket {
     }
   }
 }
-s3-server-side-encryption-template-compliant.yaml Status = FAIL
+s3-server-side-encryption-template-non-compliant.yaml Status = FAIL
 FAILED rules
 s3_bucket_logging_enabled.guard/S3_BUCKET_LOGGING_ENABLED    FAIL
 ---
-Evaluating data s3-server-side-encryption-template-compliant.yaml against rules s3_bucket_logging_enabled.guard
+Evaluating data s3-server-side-encryption-template-non-compliant.yaml against rules s3_bucket_logging_enabled.guard
 Number of non-compliant resources 1
 Resource = MyBucket {
   Type      = AWS::S3::Bucket

--- a/guard/src/commands/helper.rs
+++ b/guard/src/commands/helper.rs
@@ -1,6 +1,8 @@
 // Copyright Amazon Web Services, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use enumflags2::BitFlags;
+
 use crate::commands::validate::generic_summary::GenericSummary;
 use crate::commands::validate::{DataFile, OutputFormatType, Reporter};
 use crate::rules::errors::Error;
@@ -61,7 +63,7 @@ pub fn validate_and_return_json(
                 return Ok(serde_json::to_string_pretty(&root_record)?);
             }
 
-            let reporter = &GenericSummary::new() as &dyn Reporter;
+            let reporter = &GenericSummary::new(BitFlags::empty()) as &dyn Reporter;
 
             reporter.report_eval(
                 &mut write_output,

--- a/guard/src/commands/validate.rs
+++ b/guard/src/commands/validate.rs
@@ -639,7 +639,7 @@ fn evaluate_against_data_input<'r>(
 ) -> Result<Status> {
     let mut overall = Status::PASS;
     let generic: Box<dyn Reporter> =
-        Box::new(generic_summary::GenericSummary::new()) as Box<dyn Reporter>;
+        Box::new(generic_summary::GenericSummary::new(summary_table)) as Box<dyn Reporter>;
     let tf: Box<dyn Reporter> = Box::new(TfAware::new_with(generic.as_ref())) as Box<dyn Reporter>;
     let cfn: Box<dyn Reporter> =
         Box::new(cfn::CfnAware::new_with(tf.as_ref())) as Box<dyn Reporter>;

--- a/guard/src/commands/validate/cfn.rs
+++ b/guard/src/commands/validate/cfn.rs
@@ -224,15 +224,18 @@ fn single_line(
 
     writeln!(
         writer,
-        "Evaluating data {} against rules {} another",
+        "Evaluating data {} against rules {}",
         data_file, rules_file
     )?;
+
     let num_of_resources = format!("{}", by_resources.len()).bold();
+
     writeln!(
         writer,
         "Number of non-compliant resources {}",
         num_of_resources
     )?;
+
     for (_resource_name, resource) in by_resources {
         writeln!(writer, "Resource = {} {{", resource.name.yellow().bold())?;
         let prefix = String::from("  ");

--- a/guard/src/commands/validate/cfn.rs
+++ b/guard/src/commands/validate/cfn.rs
@@ -224,7 +224,7 @@ fn single_line(
 
     writeln!(
         writer,
-        "Evaluating data {} against rules {}",
+        "Evaluating data {} against rules {} another",
         data_file, rules_file
     )?;
     let num_of_resources = format!("{}", by_resources.len()).bold();

--- a/guard/src/commands/validate/generic_summary.rs
+++ b/guard/src/commands/validate/generic_summary.rs
@@ -17,16 +17,12 @@ use crate::rules::values::CmpOperator;
 
 #[derive(Debug)]
 pub(crate) struct GenericSummary {
-    summary_table: BitFlags<SummaryType>
+    summary_table: BitFlags<SummaryType>,
 }
 
 impl GenericSummary {
-    pub(crate) fn new(
-        summary_table: BitFlags<SummaryType>
-    ) -> Self {
-        GenericSummary {
-            summary_table
-        }
+    pub(crate) fn new(summary_table: BitFlags<SummaryType>) -> Self {
+        GenericSummary { summary_table }
     }
 }
 
@@ -43,17 +39,18 @@ impl Reporter for GenericSummary {
         _: &Traversal<'_>,
         output_format_type: OutputFormatType,
     ) -> crate::rules::Result<()> {
-        let renderer =
-            match output_format_type {
-                OutputFormatType::SingleLineSummary => {
-                    Box::new(SingleLineSummary { summary_table: self.summary_table }) as Box<dyn GenericReporter>
-                }
-                OutputFormatType::JSON => Box::new(StructuredSummary::new(StructureType::JSON))
-                    as Box<dyn GenericReporter>,
-                OutputFormatType::YAML => Box::new(StructuredSummary::new(StructureType::YAML))
-                    as Box<dyn GenericReporter>,
-                OutputFormatType::Junit => unreachable!(),
-            };
+        let renderer = match output_format_type {
+            OutputFormatType::SingleLineSummary => Box::new(SingleLineSummary {
+                summary_table: self.summary_table,
+            }) as Box<dyn GenericReporter>,
+            OutputFormatType::JSON => {
+                Box::new(StructuredSummary::new(StructureType::JSON)) as Box<dyn GenericReporter>
+            }
+            OutputFormatType::YAML => {
+                Box::new(StructuredSummary::new(StructureType::YAML)) as Box<dyn GenericReporter>
+            }
+            OutputFormatType::Junit => unreachable!(),
+        };
         let failed = if !failed_rules.is_empty() {
             let mut by_rule = HashMap::with_capacity(failed_rules.len());
             for each_failed_rule in failed_rules {
@@ -139,7 +136,9 @@ impl Reporter for GenericSummary {
                 writer,
                 data_file,
                 rules_file,
-                &(SingleLineSummary { summary_table: self.summary_table }),
+                &(SingleLineSummary {
+                    summary_table: self.summary_table,
+                }),
             )?,
             OutputFormatType::Junit => unreachable!(),
         };
@@ -150,7 +149,7 @@ impl Reporter for GenericSummary {
 
 #[derive(Debug)]
 struct SingleLineSummary {
-    summary_table: BitFlags<SummaryType>
+    summary_table: BitFlags<SummaryType>,
 }
 
 impl SingleLineSummary {
@@ -165,11 +164,11 @@ impl SingleLineSummary {
         }
 
         if self.summary_table.contains(SummaryType::FAIL) {
-            return !failed.is_empty()
+            return !failed.is_empty();
         }
 
         if self.summary_table.contains(SummaryType::PASS) {
-            return !passed.is_empty()
+            return !passed.is_empty();
         }
 
         !skipped.is_empty() && self.summary_table.contains(SummaryType::SKIP)
@@ -250,7 +249,10 @@ fn print_rules_output(
         writeln!(writer, "--")?;
     }
     for rule in rules {
-        writeln!(writer, "Rule [{rule}] is {descriptor} for template [{data_file_name}]")?;
+        writeln!(
+            writer,
+            "Rule [{rule}] is {descriptor} for template [{data_file_name}]"
+        )?;
     }
 
     Ok(())
@@ -268,7 +270,7 @@ impl GenericReporter for SingleLineSummary {
         longest_rule_len: usize,
     ) -> crate::rules::Result<()> {
         if !self.is_reportable(&failed, &passed, &skipped) {
-            return Ok(())
+            return Ok(());
         }
         writeln!(
             writer,

--- a/guard/src/commands/validate/generic_summary.rs
+++ b/guard/src/commands/validate/generic_summary.rs
@@ -1,7 +1,6 @@
 use std::collections::{HashMap, HashSet};
 use std::fmt::Debug;
 use std::io::Write;
-use std::iter::Sum;
 
 use enumflags2::BitFlags;
 
@@ -10,8 +9,8 @@ use crate::commands::validate::common::find_all_failing_clauses;
 use crate::commands::validate::{OutputFormatType, Reporter};
 use crate::rules::{EvaluationType, Status};
 
-use super::{common::*, summary_table};
-use super::summary_table::{SummaryTable, SummaryType};
+use super::common::*;
+use super::summary_table::SummaryType;
 use crate::rules::eval_context::{simplifed_json_from_root, EventRecord};
 use crate::rules::path_value::traversal::Traversal;
 use crate::rules::values::CmpOperator;

--- a/guard/src/commands/validate/summary_table.rs
+++ b/guard/src/commands/validate/summary_table.rs
@@ -15,7 +15,7 @@ use std::io::Write;
 #[repr(u8)]
 #[derive(Debug, Copy, Clone, Eq, PartialOrd, PartialEq)]
 #[allow(clippy::upper_case_acronyms)]
-pub(super) enum SummaryType {
+pub enum SummaryType {
     PASS = 0b0001,
     FAIL = 0b0010,
     SKIP = 0b0100,

--- a/guard/tests/validate.rs
+++ b/guard/tests/validate.rs
@@ -403,6 +403,22 @@ mod validate_tests {
         assert_eq!(StatusCode::VALIDATION_ERROR, status_code);
     }
 
+    #[test]
+    fn test_updated_summary_output() {
+        let mut writer = Writer::new(WBVec(vec![]), Stderr(stderr()));
+        let mut reader = Reader::new(Stdin(std::io::stdin()));
+        let status_code = ValidateTestRunner::default()
+            .data(vec!["data-dir"])
+            .rules(vec!["rules-dir"])
+            .run(&mut writer, &mut reader);
+
+        assert_eq!(StatusCode::VALIDATION_ERROR, status_code);
+        assert_output_from_file_eq!(
+            "resources/validate/output-dir/rules_dir_against_data_dir.out",
+            writer
+        )
+    }
+
     #[rstest::rstest]
     #[case(
         vec!["db_resource.yaml"],


### PR DESCRIPTION
*Issue #, if available:* [425](https://github.com/aws-cloudformation/cloudformation-guard/issues/425)


*Description of changes:*

* Implements `is_reportable` check on `SingleLineSummary`
* Refactors rules output print statements into helper
* Updates test fixtures to expect new output
* Adds test to check summary on `"[rules & data]-dir"`
---
*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
