### PR TITLE
[Misc]: changing all walkdirs to use the same cmp operator

### DIFF
--- a/guard/src/commands/files.rs
+++ b/guard/src/commands/files.rs
@@ -1,4 +1,4 @@
-use std::cmp::Ordering;
+use std::cmp::{self, Ordering};
 use std::fs::File;
 use std::io::{BufReader, Read};
 use std::path::PathBuf;
@@ -102,4 +102,14 @@ pub(crate) fn regular_ordering(
     _second: &walkdir::DirEntry,
 ) -> Ordering {
     Ordering::Equal
+}
+
+pub(crate) fn walk_dir(
+    base: PathBuf,
+    cmp: fn(&walkdir::DirEntry, &walkdir::DirEntry) -> cmp::Ordering,
+) -> std::iter::Flatten<walkdir::IntoIter> {
+    walkdir::WalkDir::new(base)
+        .sort_by(cmp)
+        .into_iter()
+        .flatten()
 }

--- a/guard/src/commands/validate.rs
+++ b/guard/src/commands/validate.rs
@@ -13,7 +13,7 @@ use enumflags2::BitFlags;
 use serde::Deserialize;
 
 use crate::command::Command;
-use crate::commands::files::{alpabetical, iterate_over, last_modified};
+use crate::commands::files::{alpabetical, iterate_over, last_modified, walk_dir};
 use crate::commands::tracker::StatusContext;
 use crate::commands::validate::structured::StructuredEvaluator;
 use crate::commands::validate::summary_table::SummaryType;
@@ -307,7 +307,7 @@ or rules files.
                 for file_or_dir in list_of_file_or_dir {
                     validate_path(file_or_dir)?;
                     let base = PathBuf::from_str(file_or_dir)?;
-                    for file in walkdir::WalkDir::new(base).into_iter().flatten() {
+                    for file in walk_dir(base, cmp) {
                         if file.path().is_file() {
                             let name = file
                                 .file_name()
@@ -349,7 +349,7 @@ or rules files.
                     validate_path(file_or_dir)?;
                     let base = PathBuf::from_str(file_or_dir)?;
 
-                    for file in walkdir::WalkDir::new(base).into_iter().flatten() {
+                    for file in walk_dir(base, cmp) {
                         if file.path().is_file() {
                             let name = file
                                 .file_name()
@@ -396,11 +396,7 @@ or rules files.
                 if base.is_file() {
                     rules.push(base.clone())
                 } else {
-                    for entry in walkdir::WalkDir::new(base)
-                        .sort_by(cmp)
-                        .into_iter()
-                        .flatten()
-                    {
+                    for entry in walk_dir(base, cmp) {
                         if entry.path().is_file()
                             && entry
                                 .path()


### PR DESCRIPTION
*Issue #, if available:*


*Description of changes:*
While working on #448  the team noticed some discrepancies in the tests on different OS platforms when validating output. This was due to differences in the way different OS's default sort their files. To fix this we are now making all our walkers use the same sort as we are already using for our rule files.  

Changes in this PR update all the walking of directories, and create a single function that returns an IntoIterator for the walkdir crate. 

---
*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
