### PR TITLE
feat: add optional parameter for function name

### DIFF
--- a/guard-lambda/template.yaml
+++ b/guard-lambda/template.yaml
@@ -1,11 +1,17 @@
 Transform: AWS::Serverless-2016-10-31
 
+Parameters:
+  FunctionName:
+    Type: String
+    Description: The name of the function
+
 Resources:
   CloudFormationGuardLambda:
     Type: AWS::Serverless::Function
     Properties:
       Runtime: provided.al2
       Handler: guard.handler
+      FunctionName: !Ref FunctionName
       # We need to point to the parent directory, so we can use ../guard/*
       CodeUri: ..
       Environment:


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Adds an optional parameter to the CloudFormation stack to be able to specify a `FunctionName` when installing with the SAM CLI. The README is updated with CI/CD (non-guided) instructions including how to specify the `parameter-override` for the `FunctionName`

---
*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
