### PR TITLE
[BugFix]: Addressing issues with parsing newline characters on windows for conjunctions 

### DIFF
--- a/guard/src/rules/libyaml/event.rs
+++ b/guard/src/rules/libyaml/event.rs
@@ -9,10 +9,12 @@ pub(crate) enum Event<'input> {
     StreamEnd,
     DocumentStart,
     DocumentEnd,
+    #[allow(dead_code)]
     Alias(Anchor),
     Scalar(Scalar<'input>),
     SequenceStart(SequenceStart),
     SequenceEnd,
+    #[allow(dead_code)]
     MappingStart(MappingStart),
     MappingEnd,
 }

--- a/guard/src/rules/parser.rs
+++ b/guard/src/rules/parser.rs
@@ -1936,16 +1936,6 @@ impl<'a> TryFrom<&'a str> for GuardClause<'a> {
     }
 }
 
-pub(crate) struct ConjunctionsWrapper<'a>(pub(crate) Conjunctions<GuardClause<'a>>);
-impl<'a> TryFrom<&'a str> for ConjunctionsWrapper<'a> {
-    type Error = Error;
-
-    fn try_from(value: &'a str) -> Result<Self, Self::Error> {
-        let span = from_str2(value);
-        Ok(ConjunctionsWrapper(clauses(span)?.1))
-    }
-}
-
 impl<'a> TryFrom<&'a str> for TypeBlock<'a> {
     type Error = Error;
 

--- a/guard/src/rules/parser.rs
+++ b/guard/src/rules/parser.rs
@@ -6,7 +6,7 @@ use indexmap::map::IndexMap;
 use nom::branch::alt;
 use nom::bytes::complete::{is_not, take_while, take_while1};
 use nom::bytes::complete::{tag, take_till};
-use nom::character::complete::{alpha1, newline, space1};
+use nom::character::complete::{alpha1, space1};
 use nom::character::complete::{anychar, digit1, one_of};
 use nom::character::complete::{char, multispace0, multispace1, space0};
 use nom::combinator::{all_consuming, cut, peek};
@@ -1187,6 +1187,17 @@ fn single_clause(input: Span) -> IResult<Span, WhenGuardClause> {
 //
 //      rule_name\s+<<msg>>[ \t\n]+or[ \t\n]+
 //
+//
+//
+
+// fn testingstuff(input: Span) -> IResult<Span, Span> {
+//     tag("\r\n")(input)?
+// }
+
+fn newline(input: Span) -> IResult<Span, Span> {
+    alt((tag("\n"), tag("\r\n")))(input)
+}
+
 fn rule_clause(input: Span) -> IResult<Span, GuardClause> {
     let location = FileLocation {
         file_name: input.extra,

--- a/guard/src/rules/parser.rs
+++ b/guard/src/rules/parser.rs
@@ -1345,6 +1345,7 @@ fn single_clauses(input: Span) -> IResult<Span, Conjunctions<WhenGuardClause>> {
     )
 }
 
+#[allow(dead_code)] // TODO: investigate why this is unused
 fn clauses(input: Span) -> IResult<Span, Conjunctions<GuardClause>> {
     cnf_clauses(
         input,

--- a/guard/src/rules/parser.rs
+++ b/guard/src/rules/parser.rs
@@ -1190,10 +1190,6 @@ fn single_clause(input: Span) -> IResult<Span, WhenGuardClause> {
 //
 //
 
-// fn testingstuff(input: Span) -> IResult<Span, Span> {
-//     tag("\r\n")(input)?
-// }
-
 fn newline(input: Span) -> IResult<Span, Span> {
     alt((tag("\n"), tag("\r\n")))(input)
 }


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
After addressing the clippy lints mentioned below integration tests against the [rules registry](https://github.com/aws-cloudformation/aws-guard-rules-registry) started to fail due to newly added tests that include conjunctions on the when clauses of some rules. These failures occurred only in windows and it was due to using nom's builtin newline parsing function. To address this issue I created our own internal newline parsing function that alt's between the 2 possible escape sequences on windows and *nix systems. 

With the recent release of Rust 1.77 new lints were introduced, some caused failures in our CI. I have explicitly ignored most of the areas where this was causing our CI to fail, because we may want to use these unused variants in the future. 

I chose to ignore all the occurrences of these failures in our internal libyaml crate incase we decide to start using those unused variants. 

For the clauses function it is currently unused, but instead of removing it I am taking it as an action item upon myself to investigate why its unused. There has been cases in the past where unused implemented code was there for a reason (i.e. partly implemented feature).



---
*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
