### PR TITLE
[BugFix]: fix for regression regarding delimiters for show summary

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -5,6 +5,9 @@ archtype = "archtype"
 ure = "ure"
 # Don't flag dne as a misspelling
 dne = "dne"
+# Don't flag kms as mispelling
+kms = "kms"
 [default.extend-identifiers]
 # Ignore ID in evaluate_tests.rs
 fooCounterTaskDef49BA9021 = "fooCounterTaskDef49BA9021"
+

--- a/guard/src/commands/validate.rs
+++ b/guard/src/commands/validate.rs
@@ -163,7 +163,7 @@ pub struct Validate {
     /// default is single-line-summary
     /// if junit is used, `structured` attributed must be set to true
     pub(crate) output_format: OutputFormatType,
-    #[arg(short=SHOW_SUMMARY.1, long, help=SHOW_SUMMARY_HELP, value_enum, default_values_t=vec![ShowSummaryType::Fail])]
+    #[arg(short=SHOW_SUMMARY.1, long, help=SHOW_SUMMARY_HELP, value_enum, default_values_t=vec![ShowSummaryType::Fail], value_delimiter=',')]
     /// Controls if the summary table needs to be displayed. --show-summary fail (default) or --show-summary pass,fail (only show rules that did pass/fail) or --show-summary none (to turn it off) or --show-summary all (to show all the rules that pass, fail or skip)
     /// default is failed
     /// must be set to none if used together with the structured flag

--- a/guard/tests/validate.rs
+++ b/guard/tests/validate.rs
@@ -782,4 +782,27 @@ mod validate_tests {
             writer
         );
     }
+
+    #[rstest::rstest]
+    #[case("single-line-summary", vec!["pass", "fail"])]
+    #[case("single-line-summary", vec!["skip", "fail"])]
+    #[case("single-line-summary", vec!["skip", "pass"])]
+    fn test_validate_with_show_summary_combinations(
+        #[case] output: &str,
+        #[case] show_summary: Vec<&str>,
+    ) {
+        let mut reader = Reader::default();
+        let mut writer = Writer::default();
+
+        let status_code = ValidateTestRunner::default()
+            .rules(vec!["/rules-dir"])
+            .data(vec![
+                "/data-dir/s3-public-read-prohibited-template-non-compliant.yaml",
+            ])
+            .show_summary(show_summary)
+            .output_format(Option::from(output))
+            .run(&mut writer, &mut reader);
+
+        assert_eq!(StatusCode::VALIDATION_ERROR, status_code);
+    }
 }


### PR DESCRIPTION
*Issue #, if available:*
#493 

*Description of changes:*
After migrating to clap derive, there was a regression regarding the delimiter specified for show-summary argument on the validate command. This PR addresses that issue, and provides integration tests to prevent something like this happening again

---
*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
