### PR TITLE
[Enhancement] use Amazon Linux 2023 runtime

### DIFF
--- a/guard-lambda/README.md
+++ b/guard-lambda/README.md
@@ -54,7 +54,7 @@ The Lambda version of the tool is a lightweight wrapper around the core [cfn-gua
     --function-name $LAMBDA_FUNCTION_NAME \
     --handler guard.handler \
     --zip-file fileb://./lambda.zip \
-    --runtime provided \
+    --runtime provided.al2023 \
     --role "arn:aws:iam::${AWS_ACCOUNT_ID}:role/${ROLE_NAME}" \
     --environment Variables={RUST_BACKTRACE=1} \
     --tracing-config Mode=Active \

--- a/guard-lambda/template.yaml
+++ b/guard-lambda/template.yaml
@@ -4,7 +4,7 @@ Resources:
   CloudFormationGuardLambda:
     Type: AWS::Serverless::Function
     Properties:
-      Runtime: provided.al2
+      Runtime: provided.al2023
       Handler: guard.handler
       # We need to point to the parent directory, so we can use ../guard/*
       CodeUri: ..


### PR DESCRIPTION
*Issue #, if available:*
n/a

*Description of changes:*
This change is about switching to the most recent OS-only provided runtime.
Two changes in this MR:
* in the CloudFormation template, migrate from `provided.al2` to `provided.al2023`
* in the README, switch from `provided` to `provided.al2023`, `provided` has already reached the `Block function create` stage of deprecation

See this blog post for more information: https://aws.amazon.com/blogs/compute/introducing-the-amazon-linux-2023-runtime-for-aws-lambda/


---
*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
