### PR TITLE
chore: updating pr.yml to use actions-rust-lang for toolchain setup

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -112,6 +112,7 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: nightly
+          matcher: false
       - uses: actions-rs/cargo@v1
         name: Install cargo-fuzz
         with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -113,6 +113,7 @@ jobs:
         with:
           toolchain: nightly
           matcher: false
+          rustflags: ""
       - uses: actions-rs/cargo@v1
         name: Install cargo-fuzz
         with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -83,10 +83,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: stable
-          override: true
           components: clippy
       - uses: actions-rs/clippy-check@v1
         with:
@@ -111,7 +109,7 @@ jobs:
     name: Run Fuzz Checks
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: nightly
       - uses: actions-rs/cargo@v1


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
This PR ensures all of our workflows are using version 1.77.2 of rust, when installing the toolchain. 

---
*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
