### PR TITLE
fix(opeartor): != not working as expected

### DIFF
--- a/guard/src/rules/eval/operators.rs
+++ b/guard/src/rules/eval/operators.rs
@@ -662,10 +662,12 @@ impl Comparator for (crate::rules::CmpOperator, bool) {
                                 ValueEvalResult::ComparisonResult(ComparisonResult::Fail(c)) => {
                                     match c {
                                         Compare::QueryIn(qin) => {
-                                            let reverse_diff = if lhs.len() > rhs.len() {
-                                                reverse_diff(qin.diff, &qin.lhs)
-                                            } else {
+                                            let reverse_diff = if rhs.len() > lhs.len()
+                                                && matches!(self.0, crate::rules::CmpOperator::Eq)
+                                            {
                                                 reverse_diff(qin.diff, &qin.rhs)
+                                            } else {
+                                                reverse_diff(qin.diff, &qin.lhs)
                                             };
 
                                             if reverse_diff.is_empty() {

--- a/guard/src/rules/eval/operators.rs
+++ b/guard/src/rules/eval/operators.rs
@@ -662,7 +662,7 @@ impl Comparator for (crate::rules::CmpOperator, bool) {
                                 ValueEvalResult::ComparisonResult(ComparisonResult::Fail(c)) => {
                                     match c {
                                         Compare::QueryIn(qin) => {
-                                            let reverse_diff = if rhs.len() > lhs.len()
+                                            let reverse_diff = if rhs.len() >= lhs.len()
                                                 && matches!(self.0, crate::rules::CmpOperator::Eq)
                                             {
                                                 reverse_diff(qin.diff, &qin.rhs)


### PR DESCRIPTION
*Issue #, if available:*
#478 

*Description of changes:*
This PR addresses an issue where the guard evaluation engine was not properly handling successful `!=` checks. 

This was due to an inconsistency [here](https://github.com/aws-cloudformation/cloudformation-guard/blob/main/guard/src/rules/eval/operators.rs#L571) where we compare sizes of lhs and rhs, and depending on which one is bigger, we use that to construct the diff (filtering for elements that are not in the other). The problem with this is when we checked to negate the clause [here](https://github.com/aws-cloudformation/cloudformation-guard/blob/main/guard/src/rules/eval/operators.rs#L656) it was always constructed using the LHS. To fix this, we need to follow the same logic as in the previous link, except we need to invert the size check for lhs and rhs, and also ensure the operator is an Eq, and then we can construct the diff 

---
*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
