### PR TITLE
fix(cfn-guard): canonicalize creates invalid json [DO NOT MERGE / REVIEW RUNNING AGAINST CI]

### DIFF
--- a/guard/src/commands/validate.rs
+++ b/guard/src/commands/validate.rs
@@ -282,9 +282,8 @@ impl Executable for Validate {
                         if file.path().is_file() {
                             let name = file
                                 .path()
-                                // path output occasionally includes double slashes '//'
-                                // without calling canonicalize()
-                                .canonicalize()?
+                                .to_path_buf()
+                                .into_os_string()
                                 .to_str()
                                 .map_or("".to_string(), String::from);
                             if has_a_supported_extension(&name, &DATA_FILE_SUPPORTED_EXTENSIONS) {


### PR DESCRIPTION
*Issue #, if available:* 536

The issue appears to be with paths. I encountered something similar in the TS lib but massaged the data in there as I assumed it was an issue with those changes and not guard itself.

*Description of changes:*

Use an OSString instead of a canonicalized PathBuf converted to a string. It generated invalid characters for JSON and SARIF.

https://github.com/rust-lang/rust/issues/81045#issuecomment-761076607
---
*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
