### PR TITLE
added examples for "Parameter" rules

### DIFF
--- a/guard-examples/parameter-schemas/check-default-parameters-tests.yaml
+++ b/guard-examples/parameter-schemas/check-default-parameters-tests.yaml
@@ -1,0 +1,78 @@
+---
+- input:
+    Parameters: {}
+  expectations:
+    rules:
+      assert_default_parameters_exists: SKIP
+      assert_default_parameter_configuration: SKIP
+      assert_ConstraintDescription: SKIP
+- input:
+    Description: "Test if default parameters exists PASS"
+    Parameters:
+      Parameter1: {}
+      Parameter2: {}
+      Stage: {}
+  expectations:
+    rules:
+      assert_default_parameters_exists: PASS
+      assert_default_parameter_configuration: FAIL
+      assert_ConstraintDescription: SKIP
+- input:
+    Description: "Test if default parameters exists FAILED "
+    Parameters:
+      Parameter1: {}
+      Parameter3: {}
+      Stage: {}
+  expectations:
+    rules:
+      assert_default_parameters_exists: FAIL
+      assert_default_parameter_configuration: SKIP
+      assert_ConstraintDescription: SKIP
+- input:
+    Description: "correct Parameter configuration"
+    Parameters:
+      Parameter1:
+        Description: 'Parameter1'
+        Type: String
+        AllowedPattern: '[a-z0-9]+'
+        ConstraintDescription: "Invalid input. Allowed Pattern = '[a-z0-9]+'. Parameter must not be empty."
+      Parameter2:
+        Description: 'Parameter2'
+        Type: String
+        AllowedPattern: '[a-z0-9]+'
+        ConstraintDescription: "Invalid input. Allowed Pattern = '[a-z0-9]+'. Parameter must not be empty."
+      Stage:
+        Type: String
+        Description: 'Stage setting'
+        AllowedValues:
+          - stage1
+          - stage2
+          - stage3
+  expectations:
+    rules:
+      assert_default_parameters_exists: PASS
+      assert_default_parameter_configuration: PASS
+      assert_ConstraintDescription: PASS
+- input:
+    Description: "wrong configuration Parameter1 (Missing Type and ConstraintDescription)"
+    Parameters:
+      Parameter1:
+        Description: 'Parameter1'
+        AllowedPattern: '[a-z0-9]+'
+      Parameter2:
+        Description: 'Parameter2'
+        Type: String
+        AllowedPattern: '[a-z0-9]+'
+        ConstraintDescription: "Invalid input. Allowed Pattern = '[a-z0-9]+'. Parameter must not be empty."
+      Stage:
+        Type: String
+        Description: 'Stage setting'
+        AllowedValues:
+          - stage1
+          - stage2
+          - stage3
+  expectations:
+    rules:
+      assert_default_parameters_exists: PASS
+      assert_default_parameter_configuration: FAIL
+      assert_ConstraintDescription: FAIL

--- a/guard-examples/parameter-schemas/check-default-parameters.guard
+++ b/guard-examples/parameter-schemas/check-default-parameters.guard
@@ -1,7 +1,7 @@
 # This ruleset checks if Parameters are configured correctly.
-# It is usefull if you must have the same parameters in multiple templates (e.g. for tagging or name schema)
+# It is useful if you must have the same parameters in multiple templates (e.g. for tagging or name schema)
 
-# Exception that proves the rule. ;D Maybe you have templates which does not need those parameters. In this scenario we have the cloudformation templates from https://github.com/aws-solutions/aws-waf-security-automations in our template dir. The exlude list is based of the template description. You can use Metadata or other ways as well. 
+# Exception that proves the rule. ;D Maybe you have templates which does not need those parameters. In this scenario we have the cloudformation templates from https://github.com/aws-solutions/aws-waf-security-automations in our template dir. The exclude list is based of the template description. You can use Metadata or other ways as well. 
 let exclude = [
   /(SO0006-FA) - Security Automations for AWS WAF - FA:/,
   /(SO0006-WebACL) - Security Automations for AWS WAF:/,

--- a/guard-examples/parameter-schemas/check-default-parameters.guard
+++ b/guard-examples/parameter-schemas/check-default-parameters.guard
@@ -1,0 +1,44 @@
+# This ruleset checks if Parameters are configured correctly.
+# It is usefull if you must have the same parameters in multiple templates (e.g. for tagging or name schema)
+
+# Exception that proves the rule. ;D Maybe you have templates which does not need those parameters. In this scenario we have the cloudformation templates from https://github.com/aws-solutions/aws-waf-security-automations in our template dir. The exlude list is based of the template description. You can use Metadata or other ways as well. 
+let exclude = [
+  /(SO0006-FA) - Security Automations for AWS WAF - FA:/,
+  /(SO0006-WebACL) - Security Automations for AWS WAF:/,
+  /(SO0006) - Security Automations for AWS WAF:/
+  ]
+
+
+# Now we check if our default parameters exists in templates which we have not excluded
+rule assert_default_parameters_exists when Description not in %exclude {
+    Parameters.Parameter1 exists
+    Parameters.Parameter2 exists
+    Parameters.Stage exists
+}
+
+# our default parameters must have always the same configuration
+rule assert_default_parameter_configuration when assert_default_parameters_exists {
+    Parameters.Parameter1 {
+      Description == 'Parameter1'
+      Type == 'String'
+      AllowedPattern == '[a-z0-9]+'
+      ConstraintDescription == "Invalid input. Allowed Pattern = '[a-z0-9]+'. Parameter must not be empty."
+    }
+    Parameters.Parameter2 {
+      Description == 'Parameter2'
+      Type == 'String'
+      AllowedPattern == '[a-z0-9]+'
+      ConstraintDescription == "Invalid input. Allowed Pattern = '[a-z0-9]+'. Parameter must not be empty."
+    }
+    Parameters.Stage {
+      Type == 'String'
+      Description == 'Stage setting'
+      AllowedValues == ['stage1', 'stage2', 'stage3']
+    }
+}
+
+# All parameters with an AllowedPattern must have a ConstraintDescription
+let parameters  = some Parameters.*[AllowedPattern exists]
+rule assert_ConstraintDescription when %parameters exists {
+    %parameters.ConstraintDescription exists
+}


### PR DESCRIPTION
*Description of changes:*

Hello,
i have noticed, that there are no examples, how to check the existence of Parameters and there configuration.
It is usefull if you have multiple templates and you want to have in every template the same parameters. (e.g. tagging or name schema)

Hope that will help someone. 

Best regards,

Patrick 


Test output:
```
python3-virtualenv ~/git_other/cloudformation-guard/guard-examples/parameter-schemas on  parameter_schema ✓ ❯ cfn-guard test -r check-default-parameters.guard -t check-default-parameters-tests.yaml
Test Case #1
  PASS Rules:
    assert_default_parameter_configuration: Expected = SKIP
    assert_default_parameters_exists: Expected = SKIP
    assert_ConstraintDescription: Expected = SKIP

Test Case #2
  PASS Rules:
    assert_ConstraintDescription: Expected = SKIP
    assert_default_parameters_exists: Expected = PASS
    assert_default_parameter_configuration: Expected = FAIL

Test Case #3
  PASS Rules:
    assert_default_parameters_exists: Expected = FAIL
    assert_default_parameter_configuration: Expected = SKIP
    assert_ConstraintDescription: Expected = SKIP

Test Case #4
  PASS Rules:
    assert_ConstraintDescription: Expected = PASS
    assert_default_parameters_exists: Expected = PASS
    assert_default_parameter_configuration: Expected = PASS

Test Case #5
  PASS Rules:
    assert_default_parameters_exists: Expected = PASS
    assert_default_parameter_configuration: Expected = FAIL
    assert_ConstraintDescription: Expected = FAIL

```

---
*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
