### PR TITLE
fix(pre-commit-hook): Handle multiple rules args

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
--   repo: https://github.com/aws-cloudformation/cloudformation-guard
-    rev: pre-commit-v0.0.1
+-   repo: https://github.com/dannyvassallo/cloudformation-guard
+    rev: pre-commit-hook-test
     hooks:
         -   id: cfn-guard
             args:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,9 @@
 repos:
+-   repo: https://gitlab.com/vojko.pribudic.foss/pre-commit-update
+    rev: v0.3.3
+    hooks:
+        - id: pre-commit-update
+          args: [--exclude, cfn-guard]
 -   repo: https://github.com/dannyvassallo/cloudformation-guard
     rev: pre-commit-hook-test
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,6 @@
 repos:
--   repo: https://gitlab.com/vojko.pribudic.foss/pre-commit-update
-    rev: v0.3.3
-    hooks:
-        - id: pre-commit-update
-          args: [--exclude, cfn-guard]
--   repo: https://github.com/dannyvassallo/cloudformation-guard
-    rev: pre-commit-hook-test
+-   repo: https://github.com/aws-cloudformation/cloudformation-guard
+    rev: pre-commit-v0.0.2
     hooks:
         -   id: cfn-guard
             args:

--- a/README.md
+++ b/README.md
@@ -639,7 +639,7 @@ Guard is available as a pre-commit hook and offers both the `test` and `validate
 ```yaml
 repos:
 -   repo: https://github.com/aws-cloudformation/cloudformation-guard
-    rev: pre-commit-v0.0.1
+    rev: pre-commit-v0.0.2
     hooks:
         # Validate
         -   id: cfn-guard
@@ -680,3 +680,4 @@ repos:
 ## License
 
 This project is licensed under the Apache-2.0 License.
+

--- a/pre_commit_hooks/cfn_guard.py
+++ b/pre_commit_hooks/cfn_guard.py
@@ -142,19 +142,20 @@ def main(argv: Union[Sequence[str], None] = None) -> int:
 
     parser = argparse.ArgumentParser()
     parser.add_argument("filenames", nargs="*", help="Files to validate")
-    parser.add_argument("--operation", action="append", help="cfn-guard operation", required=True)
+    parser.add_argument("--operation", help="cfn-guard operation", required=True)
     parser.add_argument("--rules", action="append", help="Rules file/directory")
-    parser.add_argument("--dir", action="append", help="Test & rules directory")
+    parser.add_argument("--dir", help="Test & rules directory")
 
     args = parser.parse_args(argv)
 
     exit_code = 0
 
     for filename in args.filenames:
-        if args.operation[0] == "validate":
-            cmd = f"validate --rules={args.rules[0]} --data={filename}"
-        elif args.operation[0] == "test":
-            cmd = f"test --dir={args.dir[0]}"
+        if args.operation == "validate":
+            rules_args = " ".join([f"--rules={r}" for r in args.rules])
+            cmd = f"validate {rules_args} --data={filename}"
+        elif args.operation == "test":
+            cmd = f"test --dir={args.dir}"
         else:
             raise CfnGuardPreCommitError(UNKNOWN_OPERATION_MSG)
 

--- a/pre_commit_hooks_tests/test_cfn_guard.py
+++ b/pre_commit_hooks_tests/test_cfn_guard.py
@@ -11,7 +11,7 @@ import os.path
 
 
 def get_guard_resource_path(relative_path):
-    return os.path.join(os.path.abspath(__file__ + "/../../")) + "/guard/resources/" + relative_path
+    return os.path.join(os.path.abspath(__file__ + "/../../")) + "/guard/resources" + relative_path
 
 
 def test_validate_failing_template():
@@ -30,17 +30,16 @@ def test_validate_failing_template():
 
 def test_validate_passing_template():
     """Test a success validate case."""
-    rule = get_guard_resource_path("/validate/rules-dir/s3_bucket_public_read_prohibited.guard")
+    first_rule = get_guard_resource_path(
+        "/validate/rules-dir/s3_bucket_public_read_prohibited.guard"
+    )
+    second_rule = get_guard_resource_path(
+        "/validate/rules-dir/s3_bucket_server_side_encryption_enabled.guard"
+    )
     data = get_guard_resource_path(
         "/validate/data-dir/s3-public-read-prohibited-template-compliant.yaml"
     )
-    ret = main(
-        [
-            data,
-            "--operation=validate",
-            f"--rules={rule}",
-        ]
-    )
+    ret = main([data, "--operation=validate", f"--rules={first_rule}", f"--rules={second_rule}"])
     assert ret == 0
 
 


### PR DESCRIPTION
*Issue #, if available:* 539

https://github.com/aws-cloudformation/cloudformation-guard/issues/539

*Description of changes:*

Update the arg parser for the pre-commit-hook to handle multiple rules params.

---
*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
