### PR TITLE
feat(install-script): add optional version flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ These tenets help guide the development of the Guard DSL:
 By default this is built for macOS-12 (Monterey). See [OS Matrix](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#github-hosted-runners)
 
 1. Open terminal of your choice. Default `Cmd+Space`, type `terminal`
-2. Cut-n-paste the commands below (change version=X for other versions)
+2. Cut-n-paste the commands below (default latest, add `-s -- -v <VERSION>` for other versions ie. `-s -- -v 3.1.1`)
 ```bash
 $ curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/aws-cloudformation/cloudformation-guard/main/install-guard.sh | sh
 ```
@@ -190,7 +190,7 @@ You would not need to modify `$PATH` this way.
 ##### Ubuntu
 
 1. Open any terminal of your choice
-2. Cut-n-paste the commands below (change version=X for other versions)
+2. Cut-n-paste the commands below (default latest, add `-s -- -v <VERSION>` for other versions ie. `-s -- -v 3.1.1`)
 ```bash
 $ curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/aws-cloudformation/cloudformation-guard/main/install-guard.sh | sh
 ```

--- a/install-guard.sh
+++ b/install-guard.sh
@@ -71,8 +71,8 @@ get_version() {
 		esac
 	done
 	# If version is not provided default to the latest version.
-	if [[ -z "$VERSION" ]] ; then
-		echo $(get_latest_release)
+	if [ -z "$VERSION" ] ; then
+		get_latest_release
 	else
 		echo "$VERSION"
 	fi

--- a/install-guard.sh
+++ b/install-guard.sh
@@ -1,8 +1,9 @@
 #!/bin/sh
-# This scripts downloads and installs cfn-guard latest version from github releases
-# It detects platforms, downloads the pre-built binary for the latest version installs
+# This script downloads and installs cfn-guard from GitHub releases.
+# It uses the latest release by default, but can be used to install a specific version using the -v option.
+# It detects platforms, downloads the pre-built binary for the specified version (default latest), installs
 # it in the ~/.guard/$MAJOR_VER/cfn-guard-v$MAJOR_VER-$OS_TYPE-latest/cfn-guard and symlinks ~/.guard/bin
-# to the latest one
+# to the last installed binary.
 
 main() {
 	if ! (check_cmd curl || check_cmd wget); then
@@ -17,19 +18,20 @@ main() {
 
 	get_os_type
 	get_arch_type
-	get_latest_release |
+	get_version "$@" |
 		while
-			read -r MAJOR_VER
 			read -r VERSION
 		do
+			echo "Installing cfn-guard version '${VERSION}'..."
+			MAJOR_VER=$(echo "$VERSION" | awk -F '.' '{ print $1 }')
 			mkdir -p ~/.guard/"$MAJOR_VER" ~/.guard/bin ||
 				err "unable to make directories ~/.guard/$MAJOR_VER, ~/.guard/bin"
 			get_os_type
-			download https://github.com/aws-cloudformation/cloudformation-guard/releases/download/"$VERSION"/cfn-guard-v"$MAJOR_VER"-"$ARCH_TYPE"-"$OS_TYPE"-latest.tar.gz >/tmp/guard.tar.gz ||
+			download https://github.com/aws-cloudformation/cloudformation-guard/releases/download/"$VERSION"/cfn-guard-v"$MAJOR_VER"-"$ARCH_TYPE"-"$OS_TYPE"-"$VERSION".tar.gz >/tmp/guard.tar.gz ||
 				err "unable to download https://github.com/aws-cloudformation/cloudformation-guard/releases/download/$VERSION/cfn-guard-v$MAJOR_VER-$ARCH_TYPE-$OS_TYPE-latest.tar.gz"
 			tar -C ~/.guard/"$MAJOR_VER" -xzf /tmp/guard.tar.gz ||
 				err "unable to untar /tmp/guard.tar.gz"
-			ln -sf ~/.guard/"$MAJOR_VER"/cfn-guard-v"$MAJOR_VER"-"$ARCH_TYPE"-"$OS_TYPE"-latest/cfn-guard ~/.guard/bin ||
+			ln -sf ~/.guard/"$MAJOR_VER"/cfn-guard-v"$MAJOR_VER"-"$ARCH_TYPE"-"$OS_TYPE"-"$VERSION"/cfn-guard ~/.guard/bin ||
 				err "unable to symlink to ~/.guard/bin directory"
 			~/.guard/bin/cfn-guard help ||
 				err "cfn-guard was not installed properly"
@@ -56,10 +58,29 @@ get_os_type() {
 	esac
 }
 
+get_version() {
+	# Get the version from the -v option, if provided.
+	while getopts 'v:' OPTION; do
+		case "$OPTION" in
+			v)
+				VERSION="$OPTARG"
+				;;
+			?)
+				err "Usage: install-guard.sh [-v <version>]"
+				;;
+		esac
+	done
+	# If version is not provided default to the latest version.
+	if [[ -z "$VERSION" ]] ; then
+		echo $(get_latest_release)
+	else
+		echo "$VERSION"
+	fi
+}
+
 get_latest_release() {
 	download https://api.github.com/repos/aws-cloudformation/cloudformation-guard/releases/latest |
-		awk -F '"' '/tag_name/ { print $4 }' |
-		awk -F '.' '{ print $1 "\n" $0 }'
+		awk -F '"' '/tag_name/ { print $4 }'
 }
 
 err() {
@@ -108,4 +129,5 @@ get_arch_type() {
 	esac
 }
 
-main
+# Pass any arguments provided to main function.
+main "$@"

--- a/install-guard.sh
+++ b/install-guard.sh
@@ -27,11 +27,11 @@ main() {
 			mkdir -p ~/.guard/"$MAJOR_VER" ~/.guard/bin ||
 				err "unable to make directories ~/.guard/$MAJOR_VER, ~/.guard/bin"
 			get_os_type
-			download https://github.com/aws-cloudformation/cloudformation-guard/releases/download/"$VERSION"/cfn-guard-v"$MAJOR_VER"-"$ARCH_TYPE"-"$OS_TYPE"-"$VERSION".tar.gz >/tmp/guard.tar.gz ||
+			download https://github.com/aws-cloudformation/cloudformation-guard/releases/download/"$VERSION"/cfn-guard-v"$MAJOR_VER"-"$ARCH_TYPE"-"$OS_TYPE"-latest.tar.gz >/tmp/guard.tar.gz ||
 				err "unable to download https://github.com/aws-cloudformation/cloudformation-guard/releases/download/$VERSION/cfn-guard-v$MAJOR_VER-$ARCH_TYPE-$OS_TYPE-latest.tar.gz"
 			tar -C ~/.guard/"$MAJOR_VER" -xzf /tmp/guard.tar.gz ||
 				err "unable to untar /tmp/guard.tar.gz"
-			ln -sf ~/.guard/"$MAJOR_VER"/cfn-guard-v"$MAJOR_VER"-"$ARCH_TYPE"-"$OS_TYPE"-"$VERSION"/cfn-guard ~/.guard/bin ||
+			ln -sf ~/.guard/"$MAJOR_VER"/cfn-guard-v"$MAJOR_VER"-"$ARCH_TYPE"-"$OS_TYPE"-latest/cfn-guard ~/.guard/bin ||
 				err "unable to symlink to ~/.guard/bin directory"
 			~/.guard/bin/cfn-guard help ||
 				err "cfn-guard was not installed properly"


### PR DESCRIPTION
*Description of changes:*
Adds optional version flag to install script.

We are looking to pin a specific version to ensure that we do not encounter unexpected breaking changes during a major version upgrade.  The existing install script works well for our team (we use OSX and Ubuntu via WSL) except we cannot specify a version during installation.

This change would allow users to optionally specify a version while running the installation while being backwards compatible.  If a version is not specified the script defaults to the latest version which is the current behavior.

It appears specifying the version during installation may have been possible in the past as indicated by this portion of the installation instructions in the README: `(change version=X for other versions)` - however `version=X` is no longer present in the current command.

*Alternative solutions:*
The ideal solution for us would be an [asdf plugin](https://asdf-vm.com/plugins/create.html).  We use [mise](https://mise.jdx.dev/) as our tool manager which is asdf compatible.  This has the following benefits over the bash script:

- Allows installation during tool manager initialization in a central location.
- Automatically adds/removes tool from PATH.
- Provides an easy un-install method.

However the development/maintenance of a full asdf plugin does not currently make sense when we can achieve the majority of the benefit with a small modification to the existing installation script.

If someone else would like create an asdf plugin and close this pull request I would welcome that contribution :)

We did try building using rust/cargo however this requires 70 seconds to complete every CICD run versus 2 seconds to use the script that gets the release binary, making it too time expensive to be viable.

Additionally we are aware of the pre-commit hooks for Guard unfortunately these are not part of our current local/CICD workflow but may be an excellent option for other teams.

*Testing done:*
It appears there is already a test for the default case in the [pr.yml](https://github.com/aws-cloudformation/cloudformation-guard/blob/main/.github/workflows/pr.yml) GitHub actions workflow.  If desired the following test could be prepended ahead of the current one to test installation of a known good version in CICD:
```
      - name: Test install script on ${{ matrix.os }} with specific version
        run: |
          set -e
          cd cloudformation-guard
          sh install-guard.sh -s -- -v 3.1.1
```

Tested the following scenarios manually:

No version flag specified - defaults to latest (backwards compatible):
```
╰❯ cat install-guard.sh | sh
Installing cfn-guard version '3.1.1'...
```

Version specified as a valid semver:
```
╰❯ cat install-guard.sh | sh -s -- -v 3.1.0
Installing cfn-guard version '3.1.0'...
```

Version specified as an invalid version:
```
╰❯ cat install-guard.sh | sh -s -- -v 1.2.3
Installing cfn-guard version '1.2.3'...
curl: (22) The requested URL returned error: 404
error attempting to download from the github repository
```


---
*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
