### PR TITLE
docs(pre-commit-hook): Add instructions on how to handle autoupdate tags

### DIFF
--- a/ATTRIBUTION
+++ b/ATTRIBUTION
@@ -2812,3 +2812,27 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
+
+--
+
+vojko.pribudic.foss/pre-commit-update
+
+Copyright (c) 2022 Vojko Pribudić
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Guard can be used for the following domains:
 Take this [survey](https://amazonmr.au1.qualtrics.com/jfe/form/SV_bpyzpfoYGGuuUl0) to provide feedback about cfn-guard
 
 ## Table of Contents
-
+<!-- no toc -->
 * [FAQs](#faqs)
 * [Guard DSL](#guard-dsl)
   * [Tenets](#tenets)
@@ -637,7 +637,19 @@ Guard is great for CI checks with the Junit output format, making the process of
 Guard is available as a pre-commit hook and offers both the `test` and `validate` operations. You can use them by adding a variation of the following configuration to your `.pre-commit-config.yaml` file:
 
 ```yaml
+# Since the cfn-guard hook's tagging strategy is incompatible
+# with pre-commit's autoupdate feature, you may want to make an
+# exclusion for it using the pre-commit-update hook. If you don't
+# require the autoupdate feature, you may skip the pre-commit-update
+# hook.
 repos:
+# pre-commit-update hook
+-   repo: https://gitlab.com/vojko.pribudic.foss/pre-commit-update
+    rev: v0.4.0
+    hooks:
+    -   id: pre-commit-update
+        args: [--exclude, cfn-guard]
+# cfn-guard pre-commit hook
 -   repo: https://github.com/aws-cloudformation/cloudformation-guard
     rev: pre-commit-v0.0.2
     hooks:
@@ -680,4 +692,3 @@ repos:
 ## License
 
 This project is licensed under the Apache-2.0 License.
-


### PR DESCRIPTION
*Issue #, if available:* 

https://github.com/aws-cloudformation/cloudformation-guard/issues/538

*Description of changes:*

Adds docs explaining how to handle autoupdate + attribution.

---
*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
