### PR TITLE
feat(cfn-guard): Initial implementation of date functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,6 +31,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -180,6 +195,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
 
 [[package]]
+name = "cc"
+version = "1.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9d013ecb737093c0e86b151a7b837993cf9ec6c502946cfb44bedc392421e0b"
+dependencies = [
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -190,6 +214,7 @@ name = "cfn-guard"
 version = "3.1.1"
 dependencies = [
  "Inflector",
+ "chrono",
  "clap",
  "clap_complete",
  "colored",
@@ -241,6 +266,20 @@ dependencies = [
  "serde_json",
  "simple_logger",
  "tokio",
+]
+
+[[package]]
+name = "chrono"
+version = "0.4.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
+dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "wasm-bindgen",
+ "windows-targets 0.52.0",
 ]
 
 [[package]]
@@ -308,6 +347,12 @@ dependencies = [
  "lazy_static",
  "winapi",
 ]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "diff"
@@ -611,6 +656,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7ffbb5a1b541ea2561f8c41c087286cc091e21e556a4f09a8f6cbf17b69b141"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -638,6 +706,15 @@ name = "itoa"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
+
+[[package]]
+name = "js-sys"
+version = "0.3.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
+dependencies = [
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "lambda_runtime"
@@ -748,6 +825,15 @@ dependencies = [
  "bytecount",
  "memchr",
  "nom",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -973,6 +1059,12 @@ checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
 dependencies = [
  "lazy_static",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "simple_logger"
@@ -1394,6 +1486,15 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-core"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
+ "windows-targets 0.52.0",
+]
 
 [[package]]
 name = "windows-sys"

--- a/guard/Cargo.toml
+++ b/guard/Cargo.toml
@@ -45,6 +45,7 @@ indoc = "1.0.8"
 thiserror = "1.0.38"
 quick-xml = "0.30.0"
 wasm-bindgen = "0.2.92"
+chrono = "0.4.38"
 
 [dev-dependencies]
 pretty_assertions = "1.4.0"

--- a/guard/resources/validate/functions/data/template.yaml
+++ b/guard/resources/validate/functions/data/template.yaml
@@ -9,6 +9,8 @@ Resources:
         }
       Arn: arn:aws:newservice:us-west-2:123456789012:Table/extracted
       Encoded: This%20string%20will%20be%20URL%20encoded
+      UpdatedAt: "2024-08-15T00:00:00Z"
+      CreatedAt: "2023-01-01T12:00:00Z"
     Collection:
       - a
       - b
@@ -24,6 +26,12 @@ Resources:
         BlockPublicPolicy: true
         IgnorePublicAcls: true
         RestrictPublicBuckets: true
+      Tags:
+        - Key: "Version"
+          Value: "2023-07-15T00:00:00Z"
+        - Key: "Description"
+          Value: "A bucket created for testing date-time handling"
+
   bucket:
     Type: AWS::S3::Bucket
     Properties:
@@ -32,6 +40,9 @@ Resources:
         BlockPublicPolicy: true
         IgnorePublicAcls: true
         RestrictPublicBuckets: true
+      Tags:
+        - Key: "CreatedAt"
+          Value: "2024-08-15T10:00:00Z"
   bucket2:
     Type: AWS::S3::Bucket
   bucket3:
@@ -47,3 +58,4 @@ Resources:
       DefaultInstanceWarmup: 1.5
       HealthCheckGracePeriod: 1
       HealthCheckType: "true"
+      UpdatedAt: "4024-08-10T00:00:00Z"

--- a/guard/resources/validate/functions/output/failing_complex_rule.out
+++ b/guard/resources/validate/functions/output/failing_complex_rule.out
@@ -24,7 +24,7 @@ Resource = newServer {
                     9.        }
                    10.      Arn: arn:aws:newservice:us-west-2:123456789012:Table/extracted
                    11.      Encoded: This%20string%20will%20be%20URL%20encoded
-                   12.    Collection:
+                   12.      UpdatedAt: "2024-08-15T00:00:00Z"
 
           }
         }

--- a/guard/resources/validate/functions/output/failing_join_show_summary_all.out
+++ b/guard/resources/validate/functions/output/failing_join_show_summary_all.out
@@ -10,37 +10,37 @@ Resource = newServer {
     ALL {
       Check =  %res EQUALS  "a,b" {
         ComparisonError {
-          Error            = Check was not compliant as property value [Path=/Resources/newServer/Collection/0[L:12,C:8] Value="a,b,c"] not equal to value [Path=[L:0,C:0] Value="a,b"].
-          PropertyPath    = /Resources/newServer/Collection/0[L:12,C:8]
+          Error            = Check was not compliant as property value [Path=/Resources/newServer/Collection/0[L:14,C:8] Value="a,b,c"] not equal to value [Path=[L:0,C:0] Value="a,b"].
+          PropertyPath    = /Resources/newServer/Collection/0[L:14,C:8]
           Operator        = EQUAL
           Value           = "a,b,c"
           ComparedWith    = "a,b"
           Code:
-               10.      Arn: arn:aws:newservice:us-west-2:123456789012:Table/extracted
-               11.      Encoded: This%20string%20will%20be%20URL%20encoded
-               12.    Collection:
-               13.      - a
-               14.      - b
-               15.      - c
+               12.      UpdatedAt: "2024-08-15T00:00:00Z"
+               13.      CreatedAt: "2023-01-01T12:00:00Z"
+               14.    Collection:
+               15.      - a
+               16.      - b
+               17.      - c
 
         }
       }
       Check =  a,b EQUALS  join(%collection, ",") {
         ComparisonError {
           Message          = Violation: The joined value does not match the expected result
-          Error            = Check was not compliant as property [/Resources/newServer/Collection/0[L:12,C:8]] was not present in [(resolved, Path=/Resources/newServer/Collection/0[L:12,C:8] Value="a,b,c")]
+          Error            = Check was not compliant as property [/Resources/newServer/Collection/0[L:14,C:8]] was not present in [(resolved, Path=/Resources/newServer/Collection/0[L:14,C:8] Value="a,b,c")]
         }
-          PropertyPath    = /Resources/newServer/Collection/0[L:12,C:8]
+          PropertyPath    = /Resources/newServer/Collection/0[L:14,C:8]
           Operator        = EQUAL
           Value           = "a,b,c"
           ComparedWith    = ["a,b,c"]
           Code:
-               10.      Arn: arn:aws:newservice:us-west-2:123456789012:Table/extracted
-               11.      Encoded: This%20string%20will%20be%20URL%20encoded
-               12.    Collection:
-               13.      - a
-               14.      - b
-               15.      - c
+               12.      UpdatedAt: "2024-08-15T00:00:00Z"
+               13.      CreatedAt: "2023-01-01T12:00:00Z"
+               14.    Collection:
+               15.      - a
+               16.      - b
+               17.      - c
 
       }
     }

--- a/guard/resources/validate/functions/rules/now.guard
+++ b/guard/resources/validate/functions/rules/now.guard
@@ -1,0 +1,11 @@
+let current_time = now()
+let auto_scaling_group = Resources.*[ Type == 'AWS::AutoScaling::AutoScalingGroup' ]
+let updated_at_time = parse_epoch(%auto_scaling_group.Properties.UpdatedAt)
+
+rule CHECK_UPDATED_AT when %auto_scaling_group !empty {
+  %current_time < %updated_at_time
+  <<
+     VIOLATION: AutoScalingGroup is old
+     FIX: Update AutoScalingGroup
+  >>
+}

--- a/guard/resources/validate/functions/rules/parse_epoch.guard
+++ b/guard/resources/validate/functions/rules/parse_epoch.guard
@@ -1,0 +1,11 @@
+let auto_scaling_group = Resources.*[ Type == 'AWS::AutoScaling::AutoScalingGroup' ]
+let updated_at_time = parse_epoch(%auto_scaling_group.Properties.UpdatedAt)
+let thousand_years_from_now = parse_epoch("3023-05-24T15:22:56.123Z")
+
+rule CHECK_UPDATED_AT when %auto_scaling_group !empty {
+  %thousand_years_from_now < %updated_at_time
+  <<
+     VIOLATION: AutoScalingGroup is old
+     FIX: Update AutoScalingGroup
+  >>
+}

--- a/guard/src/rules/functions.rs
+++ b/guard/src/rules/functions.rs
@@ -1,3 +1,4 @@
 pub(crate) mod collections;
 pub mod converters;
+pub mod date_time;
 pub(crate) mod strings;

--- a/guard/src/rules/functions/date_time.rs
+++ b/guard/src/rules/functions/date_time.rs
@@ -1,0 +1,48 @@
+use crate::rules::{
+    path_value::{Path, PathAwareValue},
+    QueryResult,
+};
+use chrono::prelude::*;
+use chrono::Utc;
+
+pub(crate) fn parse_epoch(
+    args: &[QueryResult],
+) -> crate::rules::Result<Vec<Option<PathAwareValue>>> {
+    let mut aggr = vec![];
+    for entry in args.iter() {
+        match entry {
+            QueryResult::Literal(val) | QueryResult::Resolved(val) => match &**val {
+                PathAwareValue::String((path, val)) => {
+                    let datetime = DateTime::parse_from_rfc3339(val)
+                        .map_err(|e| {
+                            crate::Error::ParseError(format!(
+                                "Failed to parse datetime: {val} at {path}: {e}"
+                            ))
+                        })?
+                        .with_timezone(&Utc);
+                    let epoch = datetime.timestamp();
+                    aggr.push(Some(PathAwareValue::Int((path.clone(), epoch))));
+                }
+                _ => {
+                    aggr.push(None);
+                }
+            },
+            _ => {
+                aggr.push(None);
+            }
+        }
+    }
+
+    Ok(aggr)
+}
+
+pub(crate) fn now() -> crate::rules::Result<Vec<Option<PathAwareValue>>> {
+    let now = Utc::now().timestamp();
+    let path = Path::root();
+    let path_aware_value = PathAwareValue::Int((path, now));
+    Ok(vec![Some(path_aware_value)])
+}
+
+#[cfg(test)]
+#[path = "date_time_tests.rs"]
+mod date_time_tests;

--- a/guard/src/rules/functions/date_time_tests.rs
+++ b/guard/src/rules/functions/date_time_tests.rs
@@ -1,0 +1,92 @@
+use std::{convert::TryFrom, rc::Rc};
+
+use crate::rules::{
+    eval_context::eval_context_tests::BasicQueryTesting,
+    exprs::AccessQuery,
+    functions::date_time::{now, parse_epoch},
+    path_value::PathAwareValue,
+    EvalContext, QueryResult,
+};
+use chrono::Utc;
+use pretty_assertions::assert_eq;
+use rstest::rstest;
+
+const VALUE_STR: &str = r#"
+{
+    "Resources": {
+        "LambdaFunction": {
+            "Type": "AWS::Lambda::Function",
+            "Properties": {
+                "UpdatedAt": "2024-08-21T00:00:00Z",
+                "CreatedAt": "2024-08-13T00:00:00Z",
+                "BadValue": "not-a-date"
+            }
+        }
+    }
+}
+    "#;
+
+#[rstest]
+#[case(r#"UpdatedAt"#, 1724198400, false)]
+#[case(r#"CreatedAt"#, 1723507200, false)]
+#[case(r#"BadValue"#, 1723507200, true)]
+fn test_parse_epoch(
+    #[case] query_str: &str,
+    #[case] _expected_epoch: i64,
+    #[case] should_error: bool,
+) -> crate::rules::Result<()> {
+    let value = PathAwareValue::try_from(serde_yaml::from_str::<serde_yaml::Value>(VALUE_STR)?)?;
+
+    let mut eval = BasicQueryTesting {
+        root: Rc::new(value),
+        recorder: None,
+    };
+    let root_query =
+        format!(r#"Resources[ Type == 'AWS::Lambda::Function' ].Properties.{query_str}"#,);
+    let query = AccessQuery::try_from(root_query.as_str())?;
+    let results = eval.query(&query.query)?;
+    match results[0].clone() {
+        QueryResult::Literal(val) | QueryResult::Resolved(val) => {
+            assert!(matches!(&*val, PathAwareValue::String(_)));
+        }
+        _ => unreachable!(),
+    }
+
+    let epoch_values = parse_epoch(&results);
+    if should_error {
+        assert!(epoch_values.is_err());
+    } else {
+        assert!(epoch_values.is_ok());
+        let epoch_values = epoch_values.unwrap();
+        assert_eq!(epoch_values.len(), 1);
+        assert!(matches!(
+            epoch_values[0].as_ref().unwrap(),
+            PathAwareValue::Int((_, _expected_epoch))
+        ));
+    }
+
+    Ok(())
+}
+
+#[rstest]
+fn test_now() {
+    let now_result = now();
+    assert!(now_result.is_ok());
+
+    let now_vec = now_result.unwrap();
+    assert_eq!(now_vec.len(), 1);
+
+    let now_option = now_vec.first().unwrap();
+    assert!(now_option.is_some());
+
+    let now_value = now_option.as_ref().unwrap();
+
+    let timestamp = match now_value {
+        PathAwareValue::Int((_, timestamp)) => *timestamp,
+        _ => unreachable!(),
+    };
+
+    let now = Utc::now().timestamp();
+
+    assert!((now - timestamp).abs() <= 1);
+}

--- a/guard/src/rules/functions/date_time_tests.rs
+++ b/guard/src/rules/functions/date_time_tests.rs
@@ -35,7 +35,7 @@ fn test_parse_epoch(
     #[case] _expected_epoch: i64,
     #[case] should_error: bool,
 ) -> crate::rules::Result<()> {
-    let value = PathAwareValue::try_from(serde_yaml::from_str::<serde_yaml::Value>(VALUE_STR)?)?;
+    let value = PathAwareValue::try_from(serde_json::from_str::<serde_json::Value>(VALUE_STR)?)?;
 
     let mut eval = BasicQueryTesting {
         root: Rc::new(value),

--- a/guard/tests/validate.rs
+++ b/guard/tests/validate.rs
@@ -707,6 +707,8 @@ mod validate_tests {
     }
 
     #[rstest::rstest]
+    #[case("now.guard")]
+    #[case("parse_epoch.guard")]
     #[case("regex_replace.guard")]
     #[case("substring.guard")]
     #[case("json_parse.guard")]


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/aws-cloudformation/cloudformation-guard/issues/521

*Description of changes:*

Introduces 2 date functions to Guard:

1. `parse_epoch` parses dates from templates into Unix timestamps.
2. `now` returns the current Unix timestamp.

---
*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
