### PR TITLE
docs(pre-commit-hook): pre-commit-update tag-prefix info

### DIFF
--- a/README.md
+++ b/README.md
@@ -713,17 +713,16 @@ Guard is available as a pre-commit hook and offers both the `test` and `validate
 
 ```yaml
 # Since the cfn-guard hook's tagging strategy is incompatible
-# with pre-commit's autoupdate feature, you may want to make an
-# exclusion for it using the pre-commit-update hook. If you don't
-# require the autoupdate feature, you may skip the pre-commit-update
-# hook.
+# with pre-commit's autoupdate feature, you may want to use
+# the pre-commit-update hook. If you don't require the autoupdate
+# feature, you may skip the pre-commit-update hook.
 repos:
 # pre-commit-update hook
 -   repo: https://gitlab.com/vojko.pribudic.foss/pre-commit-update
-    rev: v0.4.0
+    rev: v0.5.0
     hooks:
     -   id: pre-commit-update
-        args: [--exclude, cfn-guard]
+        args: [--tag-prefix, cloudformation-guard, pre-commit-v]
 # cfn-guard pre-commit hook
 -   repo: https://github.com/aws-cloudformation/cloudformation-guard
     rev: pre-commit-v0.0.2


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/aws-cloudformation/cloudformation-guard/issues/538

https://github.com/aws-cloudformation/cloudformation-guard/issues/538#issuecomment-2337587030

*Description of changes:*

New version of pre-commit-update allows us to trim the tags so updated the docs with proper use based on the authors reply on the issue.

---
*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
