### PR TITLE
Update Terraform plan cfn-guard examples

### DIFF
--- a/guard-examples/terraform-infra-related/check-s3-tags-present-tests.yaml
+++ b/guard-examples/terraform-infra-related/check-s3-tags-present-tests.yaml
@@ -1,0 +1,142 @@
+---
+- name: Terraform plan JSON for S3 with non-empty tags - PASS
+  input:
+    {
+      "format_version": "1.1",
+      "terraform_version": "1.2.9",
+      "planned_values": {
+        "root_module": {
+          "resources": [{
+            "address": "aws_s3_bucket.test_my_bucket",
+            "mode": "managed",
+            "type": "aws_s3_bucket",
+            "name": "test_my_bucket",
+            "provider_name": "registry.terraform.io/hashicorp/aws",
+            "schema_version": 0,
+            "values": {
+              "bucket": "my-tf-test-bucket",
+              "bucket_prefix": null,
+              "force_destroy": false,
+              "tags": {
+                "Environment": "Dev",
+                "Name": "My bucket"
+              },
+              "tags_all": {
+                "Environment": "Dev",
+                "Name": "My bucket"
+              },
+              "timeouts": null
+            },
+            "sensitive_values": {
+              "cors_rule": [],
+              "grant": [],
+              "lifecycle_rule": [],
+              "logging": [],
+              "object_lock_configuration": [],
+              "replication_configuration": [],
+              "server_side_encryption_configuration": [],
+              "tags": {},
+              "tags_all": {},
+              "versioning": [],
+              "website": []
+            }
+          }]
+        }
+      }
+    }
+  expectations:
+    rules:
+      assert_all_s3_resources_have_non_empty_tags: PASS
+
+- name: Terraform plan JSON for S3 with empty tags - FAIL
+  input:
+    {
+      "format_version": "1.1",
+      "terraform_version": "1.2.9",
+      "planned_values": {
+        "root_module": {
+          "resources": [{
+            "address": "aws_s3_bucket.test_my_bucket",
+            "mode": "managed",
+            "type": "aws_s3_bucket",
+            "name": "test_my_bucket",
+            "provider_name": "registry.terraform.io/hashicorp/aws",
+            "schema_version": 0,
+            "values": {
+              "bucket": "my-tf-test-bucket",
+              "bucket_prefix": null,
+              "force_destroy": false,
+              "tags": {},
+              "tags_all": {
+                "Environment": "Dev",
+                "Name": "My bucket"
+              },
+              "timeouts": null
+            },
+            "sensitive_values": {
+              "cors_rule": [],
+              "grant": [],
+              "lifecycle_rule": [],
+              "logging": [],
+              "object_lock_configuration": [],
+              "replication_configuration": [],
+              "server_side_encryption_configuration": [],
+              "tags": {},
+              "tags_all": {},
+              "versioning": [],
+              "website": []
+            }
+          }]
+        }
+      }
+    }
+  expectations:
+    rules:
+      assert_all_s3_resources_have_non_empty_tags: FAIL
+
+
+- name: Terraform plan JSON for S3 with null tags - FAIL
+  input:
+    {
+      "format_version": "1.1",
+      "terraform_version": "1.2.9",
+      "planned_values": {
+        "root_module": {
+          "resources": [{
+            "address": "aws_s3_bucket.test_my_bucket",
+            "mode": "managed",
+            "type": "aws_s3_bucket",
+            "name": "test_my_bucket",
+            "provider_name": "registry.terraform.io/hashicorp/aws",
+            "schema_version": 0,
+            "values": {
+              "bucket": "my-tf-test-bucket",
+              "bucket_prefix": null,
+              "force_destroy": false,
+              "tags": null,
+              "tags_all": {
+                "Environment": "Dev",
+                "Name": "My bucket"
+              },
+              "timeouts": null
+            },
+            "sensitive_values": {
+              "cors_rule": [],
+              "grant": [],
+              "lifecycle_rule": [],
+              "logging": [],
+              "object_lock_configuration": [],
+              "replication_configuration": [],
+              "server_side_encryption_configuration": [],
+              "tags": {},
+              "tags_all": {},
+              "versioning": [],
+              "website": []
+            }
+          }]
+        }
+      }
+    }
+  expectations:
+    rules:
+      assert_all_s3_resources_have_non_empty_tags: FAIL

--- a/guard-examples/terraform-infra-related/check-s3-tags-present.guard
+++ b/guard-examples/terraform-infra-related/check-s3-tags-present.guard
@@ -1,0 +1,30 @@
+#
+# This will retrieve all the resources of type 'aws_s3_bucket' from the Terraform plan 
+# input json. In this case we are using the values from the planned values section 
+# of the generated Terraform plan JSON file.
+#
+let s3_bucket = planned_values.root_module.resources[
+    type == 'aws_s3_bucket'
+]
+
+#
+# Here is a sample Terraform template with S3 resource with tags
+# this would PASS the rule assert_all_s3_resources_have_non_empty_tags
+# 
+# resource "aws_s3_bucket" "test_my_bucket" {
+#   bucket = "my-tf-test-bucket"
+#   tags = {
+#    Name        = "My bucket"
+#    Environment = "Dev"
+#   }
+# }
+
+
+# This rule will return 
+# 1) SKIP if there are no resources that were selected, protected by the guard clause !empty 
+# 2) FAIL if any one resource did have empty tags or did not have tags specified at all
+# 3) PASS when ALL resource do have non-empty tags
+#
+rule assert_all_s3_resources_have_non_empty_tags when %s3_bucket !empty {
+    %s3_bucket.values.tags.* != 'null'
+}


### PR DESCRIPTION
*Issue #, if available:*


This Pull request adds a terraform infrastructure related examples which is used for covering the Deployment safety check policies for Terraform files using cfn-guard rules


---
*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
