### PR TITLE
[fix] explicity set resolver=2 on root virtual workspace.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -246,7 +246,7 @@ dependencies = [
 
 [[package]]
 name = "cfn-guard-lambda"
-version = "3.1.1"
+version = "3.1.2"
 dependencies = [
  "cfn-guard",
  "lambda_runtime",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-
+resolver = "2"
 members = [
     "guard",
     "guard-lambda",


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-cloudformation/cloudformation-guard/issues/590

*Description of changes:*

previously, a [change](https://github.com/rustwasm/wasm-bindgen/commit/402dae7d9b89eb9626257a5f1b87754c4b0f3000) to wasm-bindgen was causing the build to fail (see: linked issue) when taking the newest version (i.e. by building the project using unlocked dependencies). the error message has been updated in an unreleased change in the wasm-bindgen macro crate [(ref)](https://github.com/rustwasm/wasm-bindgen/pull/4312).

note this warning when building the project:

```
> cargo build
warning: virtual workspace defaulting to `resolver = "1"` despite one or more workspace members being on edition 2021 which implies `resolver = "2"`
note: to keep the current resolver, specify `workspace.resolver = "1"` in the workspace root's manifest
note: to use the edition 2021 resolver, specify `workspace.resolver = "2"` in the workspace root's manifest
note: for more details see https://doc.rust-lang.org/cargo/reference/resolver.html#resolver-versions
...
```

https://doc.rust-lang.org/cargo/reference/resolver.html#resolver-versions

> If you are using a [virtual workspace](https://doc.rust-lang.org/cargo/reference/workspaces.html#virtual-workspace), you will still need to explicitly set the [resolver field](https://doc.rust-lang.org/cargo/reference/resolver.html#resolver-versions) in the [workspace] definition if you want to opt-in to the new resolver.

---
*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
