### PR TITLE
Fixes typo in ABNF Grammar

### DIFF
--- a/guard/src/rules/parser.rs
+++ b/guard/src/rules/parser.rs
@@ -511,11 +511,11 @@ pub(crate) fn parse_value(input: Span) -> IResult<Span, Value> {
 ///  when_type                  = when 1*( (LWSP/comment) clause (LWSP/comment) )
 ///  when_rule                  = when 1*( (LWSP/comment) rule_clause (LWSP/comment) )
 ///  named_rule                 = "rule" 1*SP var_name "{"
-///                                   assignment 1*(LWPS/comment)   /
-///                                   (type_expr 1*(LWPS/comment))  /
+///                                   assignment 1*(LWSP/comment)   /
+///                                   (type_expr 1*(LWSP/comment))  /
 ///                                   (disjunctions_type_expr) *(LWSP/comment) "}"
 ///
-///  expressions                = 1*( (assignment / named_rule / type_expr / disjunctions_type_expr / comment) (LWPS/comment) )
+///  expressions                = 1*( (assignment / named_rule / type_expr / disjunctions_type_expr / comment) (LWSP/comment) )
 ///  ```
 ///
 ///

--- a/guard/src/rules/parser.rs
+++ b/guard/src/rules/parser.rs
@@ -484,7 +484,7 @@ pub(crate) fn parse_value(input: Span) -> IResult<Span, Value> {
 ///  clause                     = access 1*(LWSP/comment) cmp 1*(LWSP/comment) [(access/value)]
 ///  rule_clause                = rule_name / not_keyword rule_name / clause
 ///  rule_disjunction_clauses   = rule_clause 1*(or_term 1*(LWSP/comment) rule_clause)
-///  rule_conjunction_clauses   = rule_clause 1*( (LSWP/comment) rule_clause )
+///  rule_conjunction_clauses   = rule_clause 1*( (LWSP/comment) rule_clause )
 ///
 ///  type_clause                = type_name 1*SP clause
 ///  type_block                 = type_name *SP [when] "{" *(LWSP/comment) 1*clause "}"


### PR DESCRIPTION
Just a small typo in the grammar where LSWP should be LWSP 


---
*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
