### PR TITLE
fix: adding a step to install rustc 1.81 to audit ci job

### DIFF
--- a/.github/workflows/security_audit.yml
+++ b/.github/workflows/security_audit.yml
@@ -1,11 +1,18 @@
 name: Security audit
 on:
   schedule:
-    - cron: '0 17 * * *'
+    - cron: "0 17 * * *"
+
 jobs:
   audit:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: 1.81
+          matcher: false
+          rustflags: ""
       - uses: actions/checkout@v4
       - uses: rustsec/audit-check@v1.4.1
         with:


### PR DESCRIPTION
*Issue #, if available:*


*Description of changes:*
Previous PR didnt fully fix the issue. This PR adds a step to install a different version of rustc than the MSRV for the cfn-guard project. 

tested this to ensure this is correct by making it run on pr in a previous commit: https://github.com/aws-cloudformation/cloudformation-guard/actions/runs/13141468423/job/36669402097?pr=607

---
*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
