### PR TITLE
chore: adding check for cargo-audit job to skip forked repositories

### DIFF
--- a/.github/workflows/security_audit.yml
+++ b/.github/workflows/security_audit.yml
@@ -5,6 +5,7 @@ on:
 
 jobs:
   audit:
+    if: github.repository == 'aws-cloudformation/cloudformation-guard'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
*Issue #, if available:*


*Description of changes:*
When the cargo-audit CI job flags a dependency it creates a github issue. This should not be triggered on forked repositories, so this PR ensures that the job will only run on the main repository. 

---
*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
