### PR TITLE
chore: updating colored and simple_logger to address flagged dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -117,17 +117,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -329,13 +318,12 @@ checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "colored"
-version = "2.0.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3616f750b84d8f0de8a58bda93e08e2a81ad3f523089b05f1dffecab48c6cbd"
+checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
- "atty",
  "lazy_static",
- "winapi",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -579,15 +567,6 @@ name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
-
-[[package]]
-name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "hermit-abi"
@@ -842,7 +821,7 @@ version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
 dependencies = [
- "hermit-abi 0.2.6",
+ "hermit-abi",
  "libc",
 ]
 
@@ -1068,15 +1047,14 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "simple_logger"
-version = "4.0.0"
+version = "4.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e190a521c2044948158666916d9e872cbb9984f755e9bb3b5b75a836205affcd"
+checksum = "8e7e46c8c90251d47d08b28b8a419ffb4aede0f87c2eea95e17d1d5bacbf3ef1"
 dependencies = [
- "atty",
  "colored",
  "log",
  "time",
- "windows-sys 0.42.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/guard-lambda/Cargo.toml
+++ b/guard-lambda/Cargo.toml
@@ -14,7 +14,7 @@ lambda_runtime = "0.3.0"
 serde = { version = "1.0.92", features = ["derive"] }
 serde_json = "1.0.64"
 serde_derive = "1.0.92"
-simple_logger = "4.0.0"
+simple_logger = "4.3.3"
 log = "0.4.6"
 tokio = "1.24.2"
 cfn-guard = { version = "3.1.2", path = "../guard" }

--- a/guard/Cargo.toml
+++ b/guard/Cargo.toml
@@ -26,7 +26,7 @@ strip-ansi-escapes = "0.1.1"
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde_yaml = "0.9.10"
 walkdir = "2.3.1"
-colored = "2.0.0"
+colored = "2.2.0"
 heck = "0.3.1"
 lazy_static = "1.4.0"
 itertools = "0.4.7"


### PR DESCRIPTION
*Issue #, if available:*


*Description of changes:*
cargo-audit had flagged the atty dependency for being unmaintained. This dependency was used by both the simple_logger crate (cfn-guard-lambda), and colored (cfn-guard). This PR updates our dependency on both these crates to a newer version that does not depend on an unmaintained crate.

---
*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
