### PR TITLE
feat: skip diff check on dependabot

### DIFF
--- a/.github/workflows/action-ci.yml
+++ b/.github/workflows/action-ci.yml
@@ -25,9 +25,8 @@ jobs:
       - run: npm run test
       - run: npm run package
 
-      # This step will only run if the user is not dannyvassallo
       - name: Compare Directories
-        if: github.actor != 'dannyvassallo'
+        if: github.actor != 'dependabot'
         id: diff
         run: |
           if [ ! -d dist/ ]; then
@@ -41,8 +40,7 @@ jobs:
             exit 1
           fi
 
-      # This step will only run if the previous step failed and the user is not dannyvassallo
-      - if: ${{ failure() && steps.diff.outcome == 'failure' && github.actor != 'dannyvassallo' }}
+      - if: ${{ failure() && steps.diff.outcome == 'failure' && github.actor != 'dependabot' }}
         name: Upload Artifact
         id: upload
         uses: actions/upload-artifact@v4

--- a/.github/workflows/action-ci.yml
+++ b/.github/workflows/action-ci.yml
@@ -2,12 +2,12 @@ name: Github Action CI
 on:
   push:
     paths:
-      - 'action/**'
-      - 'action.yml'
+      - "action/**"
+      - "action.yml"
   pull_request:
     paths:
-      - 'action/**'
-      - 'action.yml'
+      - "action/**"
+      - "action.yml"
 jobs:
   run-unit-tests:
     runs-on: ubuntu-latest
@@ -18,15 +18,16 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v4.0.2
         with:
-          node-version: '20'
+          node-version: "20"
       - run: npm install
       - run: npm run lint
       - run: npm run format:check
       - run: npm run test
       - run: npm run package
-      # This will fail the workflow if the `dist/` directory is different than
-      # expected.
+
+      # This step will only run if the user is not dannyvassallo
       - name: Compare Directories
+        if: github.actor != 'dannyvassallo'
         id: diff
         run: |
           if [ ! -d dist/ ]; then
@@ -40,9 +41,8 @@ jobs:
             exit 1
           fi
 
-      # If `dist/` was different than expected, upload the expected version as a
-      # workflow artifact.
-      - if: ${{ failure() && steps.diff.outcome == 'failure' }}
+      # This step will only run if the previous step failed and the user is not dannyvassallo
+      - if: ${{ failure() && steps.diff.outcome == 'failure' && github.actor != 'dannyvassallo' }}
         name: Upload Artifact
         id: upload
         uses: actions/upload-artifact@v4

--- a/action/dist/index.js
+++ b/action/dist/index.js
@@ -22,7 +22,6 @@ var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (
 }) : function(o, v) {
     o["default"] = v;
 });
-console.log("adding a random diff here");
 var __importStar = (this && this.__importStar) || function (mod) {
     if (mod && mod.__esModule) return mod;
     var result = {};

--- a/action/dist/index.js
+++ b/action/dist/index.js
@@ -22,6 +22,7 @@ var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (
 }) : function(o, v) {
     o["default"] = v;
 });
+console.log("adding a random diff here");
 var __importStar = (this && this.__importStar) || function (mod) {
     if (mod && mod.__esModule) return mod;
     var result = {};


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

Dependabot always fails for syntax differences in the compiled action code. This should skip it when the actor is dependabot.

---
*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
