### PR TITLE
Omit ource from typos check

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -7,6 +7,8 @@ ure = "ure"
 dne = "dne"
 # Don't flag kms as mispelling
 kms = "kms"
+# Don't flag ource in regex patterns like /aws:[sS]ource.../
+ource = "ource"
 [default.extend-identifiers]
 # Ignore ID in evaluate_tests.rs
 fooCounterTaskDef49BA9021 = "fooCounterTaskDef49BA9021"


### PR DESCRIPTION
*Issue #, if available:*


*Description of changes:*
- ignore `ource` from typos check as it is part of a regex

---
*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
