### PR TITLE
Remove macos-13-xlarge from os matrix to prevent CI failures

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -20,7 +20,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, macos-13-xlarge, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - name: set git to use LF
@@ -55,7 +55,7 @@ jobs:
   installScript:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, macos-13-xlarge]
+        os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     name: Testing Install Script (install-guard.sh)
     steps:
@@ -131,7 +131,7 @@ jobs:
   aws-guard-rules-registry-integration-tests-linux-and-macos:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, macos-13-xlarge]
+        os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     name: Integration tests against aws-guard-rules-registry
     steps:


### PR DESCRIPTION
*Issue #, if available:*


*Description of changes:*
- `macos-13-xlarge` is no longer supported.
- `macos-latest` already part of matrix, making the xlarge redundant

---
*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
