### PR TITLE
Replace archived actions-rs/clippy-check with direct cargo clippy

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -90,10 +90,7 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           components: clippy
-      - uses: actions-rs/clippy-check@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          args: -- -D warnings
+      - run: cargo clippy -- -D warnings
 
   typocheck:
     name: Spell Check with Typos


### PR DESCRIPTION
*Issue #, if available:*


*Description of changes:*
## Fix failing Linting check (clippy) CI job

### Problem

The Linting check (clippy) job in the PR workflow is failing with Resource not accessible by integration. This is because
actions-rs/clippy-check@v1 uses the GitHub Checks API to post inline annotations, and the workflow token lacks
checks: write permission.

### Root Cause

The actions-rs organization is archived and no longer maintained. The clippy-check action requires elevated permissions (
checks: write) that aren't granted by default, and won't work at all for PRs from forks (which always get a read-only
token).

### Fix

Replace actions-rs/clippy-check@v1 with a direct cargo clippy invocation. This:

- Removes the dependency on an archived, unmaintained action
- Eliminates the need for extra token permissions
- Works consistently for both internal and fork PRs
- Preserves the same lint behavior (-D warnings fails the job on any warning)

### Trade-off

Inline PR annotations from the Checks API are no longer posted. Clippy warnings/errors will still appear in the job logs.

---
*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
