### PR TITLE
Add support for installing versions 3.0.0 and older

### DIFF
--- a/install-guard.sh
+++ b/install-guard.sh
@@ -27,11 +27,16 @@ main() {
 			mkdir -p ~/.guard/"$MAJOR_VER" ~/.guard/bin ||
 				err "unable to make directories ~/.guard/$MAJOR_VER, ~/.guard/bin"
 			get_os_type
-			download https://github.com/aws-cloudformation/cloudformation-guard/releases/download/"$VERSION"/cfn-guard-v"$MAJOR_VER"-"$ARCH_TYPE"-"$OS_TYPE"-latest.tar.gz >/tmp/guard.tar.gz ||
-				err "unable to download https://github.com/aws-cloudformation/cloudformation-guard/releases/download/$VERSION/cfn-guard-v$MAJOR_VER-$ARCH_TYPE-$OS_TYPE-latest.tar.gz"
+			if [ "$MAJOR_VER" -le 2 ] || [ "$VERSION" = "3.0.0" ]; then
+				FILENAME="cfn-guard-v$MAJOR_VER-$OS_TYPE-latest"
+			else
+				FILENAME="cfn-guard-v$MAJOR_VER-$ARCH_TYPE-$OS_TYPE-latest"
+			fi
+			download https://github.com/aws-cloudformation/cloudformation-guard/releases/download/"$VERSION/$FILENAME".tar.gz >/tmp/guard.tar.gz ||
+				err "unable to download https://github.com/aws-cloudformation/cloudformation-guard/releases/download/$VERSION/$FILENAME.tar.gz"
 			tar -C ~/.guard/"$MAJOR_VER" -xzf /tmp/guard.tar.gz ||
 				err "unable to untar /tmp/guard.tar.gz"
-			ln -sf ~/.guard/"$MAJOR_VER"/cfn-guard-v"$MAJOR_VER"-"$ARCH_TYPE"-"$OS_TYPE"-latest/cfn-guard ~/.guard/bin ||
+			ln -sf ~/.guard/"$MAJOR_VER/$FILENAME"/cfn-guard ~/.guard/bin ||
 				err "unable to symlink to ~/.guard/bin directory"
 			~/.guard/bin/cfn-guard help ||
 				err "cfn-guard was not installed properly"


### PR DESCRIPTION
*Issue #, if available:*
None

*Description of changes:*
Attempting to install versions 3.0.0 and older fail because the downloads don't include `ARCH_TYPE` in the file name. This corrects the download URL, and I believe the script can now install versions all the way back to 2.0.0.

I looked at updating the Powershell script as well, but it doesn't support installing older versions yet.

I need to install 2.x versions because I am testing AWS Config rules written in Guard and there is no 3.x runtime support yet.

---
*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
