### PR TITLE
fix: bump bytes crate to 1.11.1 to resolve CVE-2026-25541

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -198,9 +198,9 @@ checksum = "5ce89b21cab1437276d2650d57e971f9d548a2d9037cc231abdc0562b97498ce"
 
 [[package]]
 name = "bytes"
-version = "1.10.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f61dac84819c6588b558454b194026eb1f09c293b9036ae9b159e74e73ab6cf9"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cc"


### PR DESCRIPTION
## Summary

Resolves [Dependabot alert #66](https://github.com/aws-cloudformation/cloudformation-guard/security/dependabot/66) by bumping `bytes` from `1.10.0` to `1.11.1`.

## Vulnerability

**CVE-2026-25541** (Medium) — Integer overflow in `BytesMut::reserve` in the `bytes` crate versions `>= 1.2.1, < 1.11.1`.

## Changes

`Cargo.lock` only — version bump from `1.10.0` → `1.11.1`. No `Cargo.toml` changes needed since `bytes` is a transitive dependency (via `lambda_runtime` → `hyper` → `http`).

## Scope

This is a **runtime production dependency** used in `cfn-guard-lambda`.