### PR TITLE
Fix a mixed-numeric comparison and a type-block scoping trap that silently disarm rules, and pin the evaluator paths that had no test

### DIFF
--- a/docs/CLAUSES.md
+++ b/docs/CLAUSES.md
@@ -231,6 +231,33 @@ Resources.NewVolume.Properties.VolumeType IN [ 'io1','io2','gp3' ]
 
 > While these examples illustrate using `S3Bucket`, `NewVolume` in the query, often these are user defined and can be arbitrarily named in an IaC template. To write a rule that is generic and applies to all `AWS::S3::Bucket` resources defined in the template the most common form of query used is `Resources.*[ Type == ‘AWS::S3::Bucket’ ]` to select them. See [Guard: Query and Filtering](QUERY_AND_FILTERING.md) for details on usage and explore the examples directory.
 
+#### Comparing against a query that resolves to no values
+
+When the RHS of a binary operator is a query, it can resolve to no values at all. This usually happens because the query selects a resource type that the input does not contain:
+
+```
+# %denied is empty for any template that defines no KMS keys
+let denied = Resources.*[ Type == 'AWS::KMS::Key' ].Properties.KeyId
+
+rule bucket_name_is_not_denied {
+    Resources.*[ Type == 'AWS::S3::Bucket' ].Properties.BucketName != %denied
+}
+```
+
+There is nothing to compare the LHS against, so the clause cannot be decided and it `FAIL`s. This applies to both polarities: `IN %denied` and `!= %denied` both fail when `%denied` resolves to no values. The failure message says that the reference resolved to no values, so the fault is not mistaken for one in the input.
+
+Failing here is deliberate, and it is a change from earlier versions, which reported `SKIP`. A `SKIP` exits `0` and is indistinguishable from a `PASS` at a CI gate, so the rule above reported success for every template while comparing nothing, including a template whose bucket name was on the denylist that the query failed to populate.
+
+If a query is expected to resolve to no values, state that with a `when` guard. The condition fails, so the rule does not apply and is reported as `SKIP`:
+
+```
+rule bucket_name_is_not_denied when %denied !empty {
+    Resources.*[ Type == 'AWS::S3::Bucket' ].Properties.BucketName != %denied
+}
+```
+
+This is the same `when %query !empty` idiom used to scope a rule to templates that contain the resources it checks. A comparison written directly as a `when` condition is also reported as `SKIP` rather than `FAIL` when its reference is empty, because a failing condition would drop the block it guards.
+
 ## Custom Message
 
 You can add a custom message to a clause. A custom message is added at the end of a clause as follows:

--- a/docs/CLAUSES.md
+++ b/docs/CLAUSES.md
@@ -199,6 +199,18 @@ rule large_volumes_are_encrypted when Resources.*[ Type == 'AWS::EC2::Volume' ].
 
 now applies to a template whose `Size` is `50.5` as it always did to one whose `Size` is `50`.
 
+A comparison across kinds that are not both numeric is a sharper problem in the same place, and one to be aware of when writing conditions. CloudFormation templates frequently carry numbers as strings — `Size: "50"` rather than `Size: 50` — and a string cannot be compared against `10`. The condition cannot be decided, so it does not pass, so the rule is reported as not applicable and the block it guards is never checked. The run exits `0`, exactly as it would for a rule that genuinely did not apply.
+
+Guard reports which of the two happened. A rule skipped because a condition could not be decided says so, naming the operand kinds:
+
+```
+Rule [large_volumes_are_encrypted] is not applicable for template [...]
+  large_volumes_are_encrypted: the rule did not apply because one of its conditions could not
+  be decided: PathAwareValues are not comparable String, int
+```
+
+A rule skipped because its condition was decided and simply not met prints no such line, so the message appears only where something needs attention. If you see it, the fix is in the rule or the input rather than in Guard: compare against a value of the same kind, or guard the clause so the mismatch is explicit.
+
 Below are a couple of examples of clauses using binary operators:
 
 - Based on the Template-1 example template:

--- a/docs/CLAUSES.md
+++ b/docs/CLAUSES.md
@@ -187,6 +187,18 @@ A value literal can be from any of the following supported categories,
 
 - arrays of primitive/associative array types
 
+Comparisons are between values of the same kind, with one exception: `integer` and `float` compare against each other as numbers. `Size > 10` holds for a `Size` of `50.5`, and `Size == 50` holds for a `Size` of `50.0`. Earlier versions treated the two as different types and reported that they could not be compared, which failed the clause. Comparing across kinds that are not both numeric — a `string` against an `integer`, say — still cannot be decided, and the clause fails rather than guessing.
+
+The distinction matters most inside a `when` condition. A condition that cannot be decided does not pass, and a rule whose condition does not pass is reported as not applicable, so the block it guards is never checked. A rule written as
+
+```
+rule large_volumes_are_encrypted when Resources.*[ Type == 'AWS::EC2::Volume' ].Properties.Size > 10 {
+    Resources.*[ Type == 'AWS::EC2::Volume' ].Properties.Encrypted == true
+}
+```
+
+now applies to a template whose `Size` is `50.5` as it always did to one whose `Size` is `50`.
+
 Below are a couple of examples of clauses using binary operators:
 
 - Based on the Template-1 example template:

--- a/docs/COMPLEX_COMPOSITION.md
+++ b/docs/COMPLEX_COMPOSITION.md
@@ -253,6 +253,48 @@ Resources:
         - CertificateArn: 'arn:aws:acm...'
 ```
 
+## Type blocks
+
+A type block names a resource type and applies its clauses to every resource of that type in the input. Inside the block, queries are relative to the resource being checked rather than to the root of the document:
+
+```
+rule volumes_are_encrypted {
+    AWS::EC2::Volume {
+        Properties.Encrypted == true
+    }
+}
+```
+
+`Properties.Encrypted` above is read from each `AWS::EC2::Volume` in turn. If the input contains no volumes, the rule does not apply and is reported as such.
+
+A type block can carry a `when` condition, which decides per resource whether the clauses apply to it:
+
+```
+rule large_volumes_are_encrypted {
+    AWS::EC2::Volume when Properties.Size > 10 {
+        Properties.Encrypted == true
+    }
+}
+```
+
+The condition is evaluated against the same resource as the clauses it guards, so `Properties.Size` here refers to the volume under consideration. A volume of 5 GiB is exempt and contributes nothing to the outcome; a volume of 50 GiB is checked. A rule reports a failure if any resource the condition selected failed, passes if at least one was selected and none failed, and is reported as not applicable if the condition selected none of them.
+
+Being exempt is not the same as passing. A template whose volumes are all under the threshold produces "not applicable" for the rule above, and Guard says which of the two reasons applied — that no resource of the type was present, or that the condition exempted all of them. That distinction is worth reading, because a rule that never fires and a rule that passes both exit `0`.
+
+Earlier versions evaluated the condition once against the root of the document rather than per resource, which made the form above match nothing: `Properties` does not exist at the document root, so the condition could not be decided, and the rule was reported as not applicable for every input. Conditions written against the root — either as a variable, or as a full path such as `Resources.MyVolume.Properties.Size > 10` — should now be expressed relative to the resource, or moved to the enclosing rule:
+
+```
+let volumes = Resources.*[ Type == 'AWS::EC2::Volume' ]
+
+rule large_volumes_are_encrypted when %volumes !empty {
+    AWS::EC2::Volume when Properties.Size > 10 {
+        Properties.Encrypted == true
+    }
+}
+```
+
+Conditions on the enclosing `rule`, as in the `when %volumes !empty` above, are still evaluated against the document root. Only the condition attached to the type block itself is per resource.
+
 ## Validating Multiple Rules against Multiple Data Files
 
 Guard is purpose-built for policy definition and evaluation on structured JSON- and YAML- formatted data. For better maintainability of rules, rule authors can write rules into multiple files and section them however they see fit and still be able to validate multiple rule files against a data file or multiple data files. The cfn-guard validate command can take a directory of files for the `--data` and `--rules` options. More information can be found in the [cfn-guard README](../guard/README.md).

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -32,6 +32,8 @@ let api_gws = Resources.*[ Type == 'AWS::ApiGateway::RestApi' ]
 ```
 
 2. When performing `!=` comparison, if the values are incompatible like comparing a `string` to `int`, an error is thrown internally but currently suppressed and converted to `false` to satisfy the requirements of Rust’s [PartialEq](https://doc.rust-lang.org/std/cmp/trait.PartialEq.html). We are tracking to release a fix for this issue soon.
+
+   `integer` and `float` are no longer among the incompatible pairs: they compare against each other as numbers, so `Size > 10` holds for a `Size` of `50.5` and `Size == 50` holds for a `Size` of `50.0`. See [Guard: Clauses](CLAUSES.md) for the details, including why it mattered inside a `when` condition.
 3. `exists` and `empty` checks do not display the JSON pointer path inside the document in the error messages. Both these clauses often have retrieval errors which does not maintain this traversal information today. We are tracking to resolve this issue.
 4. <a name="function-limitation"></a> **No support for calling functions inline on the LHS of an operator**
 

--- a/guard/resources/parse-tree/output-dir/test_rule_iterate_through_json_list_without_key.yaml
+++ b/guard/resources/parse-tree/output-dir/test_rule_iterate_through_json_list_without_key.yaml
@@ -56,9 +56,7 @@ guard_rules:
           - Key: Tags
           - MapKeyFilter:
             - null
-            - comparator:
-              - Eq
-              - false
+            - comparator: Eq
               compare_with:
                 Value:
                   path: ''

--- a/guard/resources/validate/bucket-with-no-kms-keys-template.yaml
+++ b/guard/resources/validate/bucket-with-no-kms-keys-template.yaml
@@ -1,0 +1,13 @@
+#
+# One S3 bucket and deliberately no KMS keys, so a denylist query selecting
+# AWS::KMS::Key resolves to no values.
+#
+# Kept out of data-dir/ on purpose: test_updated_summary_output runs every rules file in
+# rules-dir/ against every data file in data-dir/ and compares the result to the checked-in
+# golden output, so anything added there changes that cross product.
+#
+Resources:
+  S3Bucket:
+    Type: "AWS::S3::Bucket"
+    Properties:
+      BucketName: "my-service-bucket"

--- a/guard/resources/validate/denied_names_from_empty_reference.guard
+++ b/guard/resources/validate/denied_names_from_empty_reference.guard
@@ -1,0 +1,17 @@
+#
+# The denylist is derived from a resource type the input does not contain, so %denied
+# resolves to no values and the comparison has nothing to compare against.
+#
+# The rule carries no other check. If that comparison is skipped rather than failed, the
+# run exits 0 having enforced nothing, and at a CI gate that is indistinguishable from a
+# genuine pass.
+#
+# Kept out of rules-dir/ on purpose: test_updated_summary_output runs every rules file in
+# rules-dir/ against every data file in data-dir/ and compares the result to the checked-in
+# golden output, so anything added there changes that cross product.
+#
+let denied = Resources.*[ Type == 'AWS::KMS::Key' ].Properties.KeyId
+
+rule bucket_name_is_not_denied {
+    Resources.*[ Type == 'AWS::S3::Bucket' ].Properties.BucketName != %denied
+}

--- a/guard/resources/validate/denied_names_guarded_by_not_empty.guard
+++ b/guard/resources/validate/denied_names_guarded_by_not_empty.guard
@@ -1,0 +1,15 @@
+#
+# The same denylist comparison as denied_names_from_empty_reference.guard, with the
+# expectation that the reference may be empty stated explicitly.
+#
+# The `!empty` condition fails when %denied resolves to no values, so the rule does not
+# apply and is reported SKIP instead of FAIL. This is the escape hatch for a reference
+# that is legitimately allowed to be empty.
+#
+# Kept out of rules-dir/ for the same reason as denied_names_from_empty_reference.guard.
+#
+let denied = Resources.*[ Type == 'AWS::KMS::Key' ].Properties.KeyId
+
+rule bucket_name_is_not_denied when %denied !empty {
+    Resources.*[ Type == 'AWS::S3::Bucket' ].Properties.BucketName != %denied
+}

--- a/guard/resources/validate/large_volumes_encrypted_gate.guard
+++ b/guard/resources/validate/large_volumes_encrypted_gate.guard
@@ -1,0 +1,10 @@
+# A gate comparing a numeric property against a literal.
+#
+# Fixture for an_undecidable_condition_says_so_in_the_output. Against a template whose Size is a
+# number this rule enforces encryption. Against one whose Size is the string "50" -- which
+# CloudFormation templates produce routinely -- the comparison cannot be decided, so the condition
+# does not pass and the body never runs. The rule reports "not applicable" and exits 0 either way,
+# which is why the explanation matters.
+rule large_volumes_are_encrypted when Resources.*[ Type == 'AWS::EC2::Volume' ].Properties.Size > 10 {
+    Resources.*[ Type == 'AWS::EC2::Volume' ].Properties.Encrypted == true
+}

--- a/guard/resources/validate/large_volumes_encrypted_type_block.guard
+++ b/guard/resources/validate/large_volumes_encrypted_type_block.guard
@@ -1,0 +1,11 @@
+# A type block whose `when` condition exempts small volumes.
+#
+# Fixture for a_skipped_type_block_explains_itself_in_the_output. The point is the two ways this
+# rule can decline to check anything: no volumes in the template at all, or volumes that the
+# condition exempts. Both report SKIP and exit 0, and without an explanation neither is
+# distinguishable from a rule that ran and passed.
+rule large_volumes_are_encrypted {
+    AWS::EC2::Volume when Properties.Size > 10 {
+        Properties.Encrypted == true
+    }
+}

--- a/guard/resources/validate/many-allowed-values-template.yaml
+++ b/guard/resources/validate/many-allowed-values-template.yaml
@@ -1,0 +1,48 @@
+# Nine SNS topics whose names form the allow-list, plus one volume that is not on it.
+#
+# Fixture for a_long_in_comparison_is_truncated_with_a_total. The point is nine *separate*
+# right-hand values: a literal list like ['a','b'] is one value however long it is, so it never
+# reaches the reporter's truncation path.
+Resources:
+  Allowed0:
+    Type: AWS::SNS::Topic
+    Properties:
+      Name: n0
+  Allowed1:
+    Type: AWS::SNS::Topic
+    Properties:
+      Name: n1
+  Allowed2:
+    Type: AWS::SNS::Topic
+    Properties:
+      Name: n2
+  Allowed3:
+    Type: AWS::SNS::Topic
+    Properties:
+      Name: n3
+  Allowed4:
+    Type: AWS::SNS::Topic
+    Properties:
+      Name: n4
+  Allowed5:
+    Type: AWS::SNS::Topic
+    Properties:
+      Name: n5
+  Allowed6:
+    Type: AWS::SNS::Topic
+    Properties:
+      Name: n6
+  Allowed7:
+    Type: AWS::SNS::Topic
+    Properties:
+      Name: n7
+  Allowed8:
+    Type: AWS::SNS::Topic
+    Properties:
+      Name: n8
+  NonCompliantVolume:
+    Type: AWS::EC2::Volume
+    Properties:
+      VolumeType: gp9
+      Size: 50
+      AvailabilityZone: us-west-2b

--- a/guard/resources/validate/no-volumes-template.yaml
+++ b/guard/resources/validate/no-volumes-template.yaml
@@ -1,0 +1,7 @@
+# No EC2 volumes at all, so the type block's query matches nothing. This is the ordinary and
+# correct reason for a rule not to apply, and the explanation should say which of the two it is.
+Resources:
+  Queue:
+    Type: AWS::SQS::Queue
+    Properties:
+      QueueName: a-queue

--- a/guard/resources/validate/volume-below-threshold-template.yaml
+++ b/guard/resources/validate/volume-below-threshold-template.yaml
@@ -1,0 +1,9 @@
+# One volume, under the type block's 10 GiB threshold, and unencrypted. The condition exempts it,
+# so nothing is checked -- the case where a rule looks like it passed and in fact never ran.
+Resources:
+  SmallVolume:
+    Type: AWS::EC2::Volume
+    Properties:
+      Size: 5
+      Encrypted: false
+      AvailabilityZone: us-west-2b

--- a/guard/resources/validate/volume-size-as-string-template.yaml
+++ b/guard/resources/validate/volume-size-as-string-template.yaml
@@ -1,0 +1,9 @@
+# Size is a string, so the gate's comparison against 10 cannot be decided. The volume is
+# unencrypted, so a rule that applied would fail it.
+Resources:
+  StringSizedVolume:
+    Type: AWS::EC2::Volume
+    Properties:
+      Size: "50"
+      Encrypted: false
+      AvailabilityZone: us-west-2b

--- a/guard/resources/validate/volume-type-in-allowed-names.guard
+++ b/guard/resources/validate/volume-type-in-allowed-names.guard
@@ -1,0 +1,7 @@
+# Compares against a variable that resolves to nine separate values, so the failure message has
+# more to print than it should. The reporter caps the list at five and reports the total.
+let allowed_names = Resources.*[ Type == 'AWS::SNS::Topic' ].Properties.Name
+
+rule volume_type_is_allowed {
+    Resources.*[ Type == 'AWS::EC2::Volume' ].Properties.VolumeType IN %allowed_names
+}

--- a/guard/resources/validate/volume-under-gate-threshold-template.yaml
+++ b/guard/resources/validate/volume-under-gate-threshold-template.yaml
@@ -1,0 +1,9 @@
+# Size is a number and below the gate's threshold, so the condition is decided and false. The rule
+# genuinely does not apply, and that needs no explanation -- the negative control for the test.
+Resources:
+  SmallVolume:
+    Type: AWS::EC2::Volume
+    Properties:
+      Size: 5
+      Encrypted: false
+      AvailabilityZone: us-west-2b

--- a/guard/src/commands/reporters/validate/cfn.rs
+++ b/guard/src/commands/reporters/validate/cfn.rs
@@ -438,7 +438,53 @@ fn single_line(
         writeln!(writer, "}}")?;
     }
 
+    // Failures that belong to no resource.
+    //
+    // Everything above is organised by resource, because a violation normally points at a value in
+    // the input. A clause that failed *because it had nothing to compare* points at nothing, so it
+    // never reaches a resource bucket, and `pprint_clauses` renders a block through its `unresolved`
+    // query, which such a block does not have either. The result was a run that correctly exited 19
+    // and printed "Number of non-compliant resources 0" with no reason given anywhere -- the
+    // explanation was recorded and then dropped on the floor.
+    let mut unattributed = Vec::new();
+    for each_rule in &failure_report.not_compliant {
+        collect_unattributed_explanations(each_rule, &mut unattributed);
+    }
+    if !unattributed.is_empty() {
+        writeln!(writer, "Clauses that could not be evaluated:")?;
+        for (context, message) in unattributed {
+            writeln!(writer, "  {context}")?;
+            writeln!(writer, "    {message}")?;
+        }
+    }
+
     Ok(())
+}
+
+/// Collect `(context, explanation)` for failed blocks that carry a message but no resolved value.
+///
+/// `unresolved.is_none()` is the discriminator: a block that failed while traversing a query keeps
+/// the value it got to, and the per-resource output renders that. A block with no such value failed
+/// for a reason that is only in its message.
+fn collect_unattributed_explanations(clause: &ClauseReport<'_>, out: &mut Vec<(String, String)>) {
+    match clause {
+        ClauseReport::Block(blk) if blk.unresolved.is_none() => {
+            if let Some(explanation) = &blk.messages.error_message {
+                out.push((blk.context.to_string(), explanation.clone()));
+            }
+        }
+        ClauseReport::Block(_) | ClauseReport::Clause(_) => {}
+        ClauseReport::Rule(rule) => {
+            for child in &rule.checks {
+                collect_unattributed_explanations(child, out);
+            }
+        }
+        ClauseReport::Disjunctions(ors) => {
+            for child in &ors.checks {
+                collect_unattributed_explanations(child, out);
+            }
+        }
+    }
 }
 
 ///

--- a/guard/src/commands/reporters/validate/cfn.rs
+++ b/guard/src/commands/reporters/validate/cfn.rs
@@ -40,6 +40,21 @@ lazy_static! {
         .unwrap();
 }
 
+/// First line of the source snippet shown above a reported violation.
+///
+/// Starts two lines above the violation so there is context, but never below line
+/// 1 because line numbers are 1-based.
+///
+/// This was previously written inline as `max(1, line - 2)`, which evaluated the
+/// subtraction *before* the clamp. On an unsigned line number of 0 or 1 that
+/// underflows: a panic in a debug build, and a silent wrap to ~`usize::MAX` in a
+/// release build, where the subsequent seek runs past EOF and the snippet is
+/// dropped from the report without any diagnostic. `saturating_sub` clamps the
+/// input rather than the result.
+fn context_start_line(line: usize) -> usize {
+    line.saturating_sub(2).max(1)
+}
+
 #[derive(Debug)]
 pub(crate) struct CfnAware<'reporter> {
     next: Option<&'reporter dyn Reporter>,
@@ -397,7 +412,9 @@ fn single_line(
                     ) -> rules::Result<()> {
                         writeln!(writer, "{prefix}Code:", prefix = prefix)?;
                         let new_prefix = format!("{}  ", prefix);
-                        if let Some((num, line)) = self.code_segment.seek_line(max(1, line - 2)) {
+                        if let Some((num, line)) =
+                            self.code_segment.seek_line(context_start_line(line))
+                        {
                             let line =
                                 format!("{num:>5}.{line}", num = num, line = line).bright_green();
                             writeln!(writer, "{prefix}{line}", prefix = new_prefix, line = line)?;
@@ -500,4 +517,37 @@ fn handle_resource_aggr<'record, 'value: 'record>(
     }
 
     Some(())
+}
+
+#[cfg(test)]
+mod context_start_line_tests {
+    use super::context_start_line;
+
+    /// These three inputs are the regression. With the original
+    /// `max(1, line - 2)` they panic in a debug build (which is what a test
+    /// binary is) and wrap to ~usize::MAX in release.
+    #[test]
+    fn does_not_underflow_at_or_below_line_two() {
+        assert_eq!(1, context_start_line(0));
+        assert_eq!(1, context_start_line(1));
+        assert_eq!(1, context_start_line(2));
+    }
+
+    #[test]
+    fn keeps_two_lines_of_context_above_the_violation() {
+        assert_eq!(1, context_start_line(3));
+        assert_eq!(3, context_start_line(5));
+        assert_eq!(98, context_start_line(100));
+    }
+
+    /// Line numbers are 1-based, so 0 is never a valid answer.
+    #[test]
+    fn never_returns_zero() {
+        for line in 0..16usize {
+            assert!(
+                context_start_line(line) >= 1,
+                "context_start_line({line}) returned 0, which is not a valid 1-based line"
+            );
+        }
+    }
 }

--- a/guard/src/commands/reporters/validate/cfn.rs
+++ b/guard/src/commands/reporters/validate/cfn.rs
@@ -546,7 +546,8 @@ mod context_start_line_tests {
         for line in 0..16usize {
             assert!(
                 context_start_line(line) >= 1,
-                "context_start_line({line}) returned 0, which is not a valid 1-based line"
+                "context_start_line({}) returned 0, which is not a valid 1-based line",
+                line
             );
         }
     }

--- a/guard/src/commands/reporters/validate/cfn.rs
+++ b/guard/src/commands/reporters/validate/cfn.rs
@@ -1,6 +1,6 @@
 use fancy_regex::Regex;
 use std::{
-    cmp::max,
+    cmp::min,
     collections::{BTreeSet, HashMap, HashSet},
     io::Write,
     rc::Rc,
@@ -333,14 +333,21 @@ fn single_line(
                         bc: &InComparison,
                         prefix: &str,
                     ) -> rules::Result<usize> {
-                        let cut_off = max(bc.to.len(), 5);
-                        let mut collected = Vec::with_capacity(10);
-                        for (idx, each) in bc.to.iter().enumerate() {
-                            collected.push(ValueOnlyDisplay(Rc::clone(each)));
-                            if idx >= cut_off {
-                                break;
-                            }
-                        }
+                        // `min`, not `max`. With `max(len, 5)` the cut-off was never below the
+                        // number of values, so the loop never broke early and the branch below
+                        // that reports a `Total` was unreachable -- a rule comparing against a
+                        // denylist of five hundred entries printed all five hundred, in every
+                        // failure message, for every resource. The dead branch is what gives the
+                        // intent away: it exists to say how many there were when not all are
+                        // shown. Pinned by
+                        // `a_long_in_comparison_is_truncated_with_a_total`.
+                        let cut_off = min(bc.to.len(), 5);
+                        let collected = bc
+                            .to
+                            .iter()
+                            .take(cut_off)
+                            .map(|each| ValueOnlyDisplay(Rc::clone(each)))
+                            .collect::<Vec<_>>();
                         let collected = format!("{:?}", collected);
                         let width = "PropertyPath".len() + 4;
                         if cut_off >= bc.to.len() {

--- a/guard/src/commands/reporters/validate/cfn_reporter.rs
+++ b/guard/src/commands/reporters/validate/cfn_reporter.rs
@@ -6,7 +6,8 @@ use fancy_regex::Regex;
 use lazy_static::*;
 
 use crate::commands::reporters::validate::common::{
-    find_all_failing_clauses, GenericReporter, NameInfo, StructureType, StructuredSummary,
+    find_all_failing_clauses, GenericReporter, NameInfo, SkippedRules, StructureType,
+    StructuredSummary,
 };
 use crate::commands::tracker::StatusContext;
 use crate::commands::validate::{OutputFormatType, Reporter};
@@ -111,10 +112,13 @@ impl Reporter for CfnReporter {
                 Some(Status::SKIP) => true,
                 _ => false,
             });
+        // The StatusContext path carries no record tree, so there is nothing to mine a reason
+        // from: every skip here is reported without one. This is the pre-record reporting path;
+        // the record-based path in `common::report_from_events` is where reasons come from.
         let skipped = skipped
             .iter()
-            .map(|s| s.context.clone())
-            .collect::<HashSet<String>>();
+            .map(|s| (s.context.clone(), None))
+            .collect::<SkippedRules>();
         let passed = passed
             .iter()
             .map(|s| s.context.clone())
@@ -175,7 +179,7 @@ impl super::common::GenericReporter for SingleLineReporter {
         data_file_name: &str,
         by_resource_name: HashMap<String, Vec<NameInfo<'_>>>,
         passed: HashSet<String>,
-        skipped: HashSet<String>,
+        skipped: SkippedRules,
         longest_rule_len: usize,
     ) -> crate::rules::Result<()> {
         writeln!(
@@ -233,6 +237,8 @@ impl super::common::GenericReporter for SingleLineReporter {
                 },
             )?;
         }
+        // This reporter does not surface skip reasons, so the names are all it needs.
+        let skipped = skipped.into_keys().collect::<HashSet<String>>();
         super::common::print_compliant_skipped_info(
             writer,
             &passed,

--- a/guard/src/commands/reporters/validate/common.rs
+++ b/guard/src/commands/reporters/validate/common.rs
@@ -3,8 +3,9 @@ use serde::Serialize;
 
 use crate::commands::tracker::StatusContext;
 use crate::rules::eval_context::{
-    BinaryCheck, BinaryComparison, ClauseReport, EventRecord, FileReport, GuardClauseReport,
-    InComparison, UnaryCheck, UnaryComparison, ValueComparisons, ValueUnResolved,
+    find_skip_reason, BinaryCheck, BinaryComparison, ClauseReport, EventRecord, FileReport,
+    GuardClauseReport, InComparison, UnaryCheck, UnaryComparison, ValueComparisons,
+    ValueUnResolved,
 };
 
 use crate::rules::values::CmpOperator;
@@ -59,6 +60,14 @@ impl<'a> Default for NameInfo<'a> {
     }
 }
 
+/// Rules that did not apply, each with the evaluator's reason when it recorded one.
+///
+/// One map rather than a name set plus a parallel reason map: the reason belongs to the skip, and
+/// two collections keyed by rule name can drift. `None` is the ordinary case -- most skips are a
+/// condition that legitimately did not match -- and `Some` is for the skips where the evaluator
+/// knows something the reader cannot infer from a bare "not applicable".
+pub(super) type SkippedRules = HashMap<String, Option<String>>;
+
 pub(super) trait GenericReporter: Debug {
     #[allow(clippy::too_many_arguments)]
     fn report(
@@ -68,7 +77,7 @@ pub(super) trait GenericReporter: Debug {
         data_file_name: &str,
         failed: HashMap<String, Vec<NameInfo<'_>>>,
         passed: HashSet<String>,
-        skipped: HashSet<String>,
+        skipped: SkippedRules,
         longest_rule_len: usize,
     ) -> crate::rules::Result<()>;
 }
@@ -97,6 +106,12 @@ struct DataOutput<'a> {
     rules_from: &'a str,
     not_compliant: HashMap<String, Vec<NameInfo<'a>>>,
     not_applicable: HashSet<String>,
+    /// Omitted entirely when no skip carried a reason, which keeps the document shape identical
+    /// to what consumers parse today. BTreeMap rather than HashMap so the order is stable across
+    /// runs -- a reporter that reshuffles its own output on every invocation is unusable in a
+    /// diff.
+    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
+    not_applicable_reasons: BTreeMap<String, String>,
     compliant: HashSet<String>,
 }
 
@@ -108,15 +123,20 @@ impl GenericReporter for StructuredSummary {
         data_file_name: &str,
         failed: HashMap<String, Vec<NameInfo<'_>>>,
         passed: HashSet<String>,
-        skipped: HashSet<String>,
+        skipped: SkippedRules,
         _: usize,
     ) -> crate::rules::Result<()> {
+        let not_applicable_reasons = skipped
+            .iter()
+            .filter_map(|(rule, reason)| reason.clone().map(|reason| (rule.clone(), reason)))
+            .collect::<BTreeMap<String, String>>();
         let value = DataOutput {
             rules_from: rules_file_name,
             data_from: data_file_name,
             not_compliant: failed,
             compliant: passed,
-            not_applicable: skipped,
+            not_applicable: skipped.into_keys().collect(),
+            not_applicable_reasons,
         };
 
         match &self.hierarchy_type {
@@ -339,7 +359,7 @@ pub(super) fn report_from_events(
 ) -> crate::rules::Result<()> {
     let mut longest_rule_length = 0;
     let mut failed = HashMap::new();
-    let mut skipped = HashSet::new();
+    let mut skipped = SkippedRules::new();
     let mut success = HashSet::new();
     for each_rule in &root_record.children {
         if let Some(RecordType::RuleCheck(NamedStatus { status, name, .. })) = &each_rule.container
@@ -361,7 +381,7 @@ pub(super) fn report_from_events(
                 }
 
                 Status::SKIP => {
-                    skipped.insert(name.to_string());
+                    skipped.insert(name.to_string(), find_skip_reason(each_rule));
                 }
             }
         }

--- a/guard/src/commands/reporters/validate/generic_summary.rs
+++ b/guard/src/commands/reporters/validate/generic_summary.rs
@@ -95,10 +95,13 @@ impl Reporter for GenericSummary {
                 Some(Status::SKIP) => true,
                 _ => false,
             });
+        // The StatusContext path carries no record tree, so there is nothing to mine a reason
+        // from: every skip here is reported without one. This is the pre-record reporting path;
+        // the record-based path in `common::report_from_events` is where reasons come from.
         let skipped = skipped
             .iter()
-            .map(|s| s.context.clone())
-            .collect::<HashSet<String>>();
+            .map(|s| (s.context.clone(), None))
+            .collect::<SkippedRules>();
         let passed = passed
             .iter()
             .map(|s| s.context.clone())
@@ -158,7 +161,7 @@ impl SingleLineSummary {
         &self,
         failed: &HashMap<String, Vec<NameInfo<'_>>>,
         passed: &HashSet<String>,
-        skipped: &HashSet<String>,
+        skipped: &SkippedRules,
     ) -> bool {
         if self.summary_table.is_empty() {
             return false;
@@ -259,6 +262,36 @@ fn print_rules_output(
     Ok(())
 }
 
+/// Skipped rules, each followed by the evaluator's reason when it recorded one.
+///
+/// Separate from `print_rules_output` rather than a flag on it: that function also prints the
+/// compliant set, which has no reasons, and threading an always-`None` argument through it to
+/// serve one caller reads worse than two small functions.
+fn print_skipped_rules_output(
+    writer: &mut dyn Write,
+    rules: SkippedRules,
+    data_file_name: &str,
+) -> crate::rules::Result<()> {
+    if !rules.is_empty() {
+        writeln!(writer, "--")?;
+    }
+    // Sorted so two runs over the same input produce the same output. The map is a HashMap, so
+    // iterating it directly would reorder the lines between runs.
+    let mut rules = rules.into_iter().collect::<Vec<(String, Option<String>)>>();
+    rules.sort_by(|(left, _), (right, _)| left.cmp(right));
+    for (rule, reason) in rules {
+        writeln!(
+            writer,
+            "Rule [{rule}] is not applicable for template [{data_file_name}]"
+        )?;
+        if let Some(reason) = reason {
+            writeln!(writer, "  {reason}")?;
+        }
+    }
+
+    Ok(())
+}
+
 impl GenericReporter for SingleLineSummary {
     fn report(
         &self,
@@ -267,7 +300,7 @@ impl GenericReporter for SingleLineSummary {
         data_file_name: &str,
         failed: HashMap<String, Vec<NameInfo<'_>>>,
         passed: HashSet<String>,
-        skipped: HashSet<String>,
+        skipped: SkippedRules,
         longest_rule_len: usize,
     ) -> crate::rules::Result<()> {
         if !self.is_reportable(&failed, &passed, &skipped) {
@@ -299,7 +332,7 @@ impl GenericReporter for SingleLineSummary {
             print_rules_output(writer, passed, "compliant", data_file_name)?;
         }
         if self.summary_table.contains(SummaryType::SKIP) {
-            print_rules_output(writer, skipped, "not applicable", data_file_name)?;
+            print_skipped_rules_output(writer, skipped, data_file_name)?;
         }
         writeln!(writer, "--")?;
         Ok(())

--- a/guard/src/commands/reporters/validate/summary_table.rs
+++ b/guard/src/commands/reporters/validate/summary_table.rs
@@ -1,7 +1,7 @@
 use crate::commands::reporters::validate::common::colored_string;
 use crate::commands::tracker::StatusContext;
 use crate::commands::validate::{OutputFormatType, Reporter};
-use crate::rules::eval_context::EventRecord;
+use crate::rules::eval_context::{find_skip_reason, EventRecord};
 use crate::rules::parser::get_rule_name;
 use crate::rules::path_value::traversal::Traversal;
 use crate::rules::RecordType;
@@ -161,6 +161,10 @@ impl<'r> Reporter for SummaryTable<'r> {
     ) -> crate::rules::Result<()> {
         let mut passed = indexmap::IndexMap::with_capacity(_root_record.children.len());
         let mut skipped = indexmap::IndexMap::with_capacity(_root_record.children.len());
+        // Why each skipped rule did not apply, for the ones the evaluator can explain. A rule that
+        // reports "not applicable" and nothing else is indistinguishable from one that ran and
+        // passed, and both exit 0.
+        let mut skip_reasons: indexmap::IndexMap<&str, String> = indexmap::IndexMap::new();
         let mut failed = indexmap::IndexMap::with_capacity(_root_record.children.len());
         let mut longest = 0;
         for each_rule in &_root_record.children {
@@ -170,7 +174,12 @@ impl<'r> Reporter for SummaryTable<'r> {
                 match status {
                     Status::PASS => passed.insert(*name, *status),
                     Status::FAIL => failed.insert(*name, *status),
-                    Status::SKIP => skipped.insert(*name, *status),
+                    Status::SKIP => {
+                        if let Some(reason) = find_skip_reason(each_rule) {
+                            skip_reasons.insert(*name, reason);
+                        }
+                        skipped.insert(*name, *status)
+                    }
                 };
                 let child_rule_name_length = get_rule_name(_rules_file, name).len(); //get_rule_name(_rules_file, name).len();
                 if longest < child_rule_name_length {
@@ -180,6 +189,7 @@ impl<'r> Reporter for SummaryTable<'r> {
         }
 
         skipped.retain(|key, _| !(passed.contains_key(key) || failed.contains_key(key)));
+        skip_reasons.retain(|key, _| skipped.contains_key(key));
 
         let mut wrote_header_line = false;
         if self.summary_type.contains(SummaryType::SKIP) && !skipped.is_empty() {
@@ -192,6 +202,13 @@ impl<'r> Reporter for SummaryTable<'r> {
             wrote_header_line = true;
             writeln!(_write, "{}", "SKIP rules".bold())?;
             print_summary(_write, _rules_file, longest, &skipped)?;
+            for (rule_name, reason) in skip_reasons.iter() {
+                writeln!(
+                    _write,
+                    "  {rule}: {reason}",
+                    rule = get_rule_name(_rules_file, rule_name)
+                )?;
+            }
         }
 
         if self.summary_type.contains(SummaryType::PASS) && !passed.is_empty() {

--- a/guard/src/rules/eval.rs
+++ b/guard/src/rules/eval.rs
@@ -1627,11 +1627,33 @@ pub(in crate::rules) fn eval_guard_block_clause<'value, 'loc: 'value>(
     Ok(status)
 }
 
+/// `role` is the role of the context this `when` block appears in, and it is inherited by the
+/// guarded body.
+///
+/// Required rather than defaulted on purpose. This function used to take no role and hardcode
+/// [`ClauseRole::Assertion`] for the body, on the reasoning that a guarded block holds the rule's
+/// own assertions however its conditions were evaluated. That is true of a rule evaluated as an
+/// assertion and false of one evaluated as a gate: the body of a gate is part of deciding whether
+/// the gate applies, so an unevaluatable clause in it has to SKIP rather than fail closed.
+///
+/// Getting it wrong produced the exact wrong-PASS this module exists to prevent. A parameterized
+/// rule used as a gate, whose body wrapped an empty-reference clause in `when { ... }`, failed that
+/// clause as an assertion; `eval_conjunction_clauses` counts a FAIL and absorbs a SKIP, and answers
+/// FAIL before PASS, so the failure outranked a passing sibling condition, the enclosing rule was
+/// treated as inapplicable, and its guarded checks were dropped at exit 0. Spelling the same rule
+/// without the inner `when` exited 19.
+///
+/// Taking it as a parameter with no default means a caller that forgets to thread it does not
+/// compile, which is a stronger guarantee than any test:
+/// `nested_when_inherits_the_enclosing_role` and the generated matrix in
+/// `the_role_reaching_a_leaf_clause_survives_every_nesting` pin the behaviour, but only this
+/// signature prevents the omission being reintroduced silently.
 fn eval_when_condition_block<'value, 'loc: 'value>(
     context: String,
     conditions: &'value WhenConditions<'loc>,
     block: &'value Block<'loc, GuardClause<'loc>>,
     resolver: &mut dyn EvalContext<'value, 'loc>,
+    role: ClauseRole,
 ) -> Result<Status> {
     resolver.start_record(&context)?;
     let when_context = format!("{}/When", context);
@@ -1672,11 +1694,12 @@ fn eval_when_condition_block<'value, 'loc: 'value>(
     };
 
     Ok(
-        // The guarded block holds the rule's actual assertions, regardless of how
-        // the conditions were evaluated.
-        match eval_general_block_clause(block, resolver, |gc, r| {
-            eval_guard_clause(gc, r, ClauseRole::Assertion)
-        }) {
+        // The guarded body inherits the role of the context the `when` block sits in, rather than
+        // assuming it is an assertion. Its own conditions were evaluated as gates above -- that is
+        // what `eval_when_clause` does and it is unconditional -- but the body is only assertions
+        // when the enclosing context is one. See this function's doc comment for what assuming
+        // otherwise cost.
+        match eval_general_block_clause(block, resolver, |gc, r| eval_guard_clause(gc, r, role)) {
             Ok(status) => {
                 resolver.end_record(
                     &context,
@@ -1896,6 +1919,7 @@ pub(in crate::rules) fn eval_guard_clause<'value, 'loc: 'value>(
             conditions,
             block,
             resolver,
+            role,
         ),
         GuardClause::ParameterizedNamedRule(prc) => {
             eval_parameterized_rule_call(prc, resolver, role)
@@ -2116,7 +2140,7 @@ pub(in crate::rules) fn eval_rule_clause<'value, 'loc: 'value>(
         RuleClause::Clause(gc) => eval_guard_clause(gc, resolver, role),
         RuleClause::TypeBlock(tb) => eval_type_block_clause(tb, resolver, role),
         RuleClause::WhenBlock(conditions, block) => {
-            eval_when_condition_block("RuleClause".to_string(), conditions, block, resolver)
+            eval_when_condition_block("RuleClause".to_string(), conditions, block, resolver, role)
         }
     }
 }

--- a/guard/src/rules/eval.rs
+++ b/guard/src/rules/eval.rs
@@ -2313,6 +2313,27 @@ pub(crate) fn eval_rules_file<'value, 'loc: 'value>(
     Ok(overall)
 }
 
+/// The clause type a disjunction is over, spelled the same way by every compiler.
+///
+/// `std::any::type_name` is documented as being for diagnostics only, with no guarantee of
+/// stability across versions, and this one is not confined to diagnostics: it goes into a record
+/// context, which reaches verbose output and is compared byte for byte by four golden-file tests.
+/// rustc 1.77.2 renders `cfn_guard::rules::exprs::GuardClause<'_>` and later versions render the
+/// path without the elided lifetime, so those tests fail on any newer toolchain -- they had to be
+/// skipped to measure coverage on nightly at all, which is how this surfaced.
+///
+/// Taking the path before the generic arguments is stable on both and keeps what the context is
+/// for: saying which kind of clause the disjunction holds. Dropping the name entirely and writing
+/// `disjunction` would also be stable, and was rejected because the type is the only thing
+/// distinguishing one disjunction record from another in a nested rule.
+fn disjunction_type_name<T>() -> &'static str {
+    let name = std::any::type_name::<T>();
+    match name.find('<') {
+        Some(generics_start) => &name[..generics_start],
+        None => name,
+    }
+}
+
 #[allow(clippy::never_loop)]
 pub(in crate::rules) fn eval_conjunction_clauses<'value, 'loc: 'value, T, E>(
     conjunctions: &'value Conjunctions<T>,
@@ -2325,7 +2346,7 @@ where
     Ok(loop {
         let mut num_passes = 0;
         let mut num_fails = 0;
-        let context = format!("{}#disjunction", std::any::type_name::<T>());
+        let context = format!("{}#disjunction", disjunction_type_name::<T>());
         'conjunction: for conjunction in conjunctions {
             let mut num_of_disjunction_fails = 0;
             let multiple_ors_present = conjunction.len() > 1;

--- a/guard/src/rules/eval.rs
+++ b/guard/src/rules/eval.rs
@@ -1147,10 +1147,24 @@ pub(in crate::rules) fn eval_guard_access_clause<'value, 'loc: 'value>(
                 )));
             }
         };
+        // Clause-level negation (a leading `not`/`!`, parser.rs:969) must be applied
+        // here. The unary path takes it as an argument, but this path previously
+        // dropped it entirely, so `not <query> == <value>` evaluated as plain
+        // `== <value>` -- the exact inverse of the author's intent -- while the
+        // report still displayed the `not`.
+        //
+        // `comparator.1` is the operator's own not-flag (from `!=` / `not in`).
+        // The two negations compose by XOR, matching invert_closure in the
+        // superseded evaluator (evaluate.rs:293-307), which applies `clause_not`
+        // and `not` as independent flips.
+        let comparator = (
+            gac.access_clause.comparator.0,
+            gac.access_clause.comparator.1 ^ gac.negation,
+        );
         binary_operation(
             &gac.access_clause.query.query,
             &rhs,
-            gac.access_clause.comparator,
+            comparator,
             format!("{}", gac),
             gac.access_clause.custom_message.clone(),
             resolver,

--- a/guard/src/rules/eval.rs
+++ b/guard/src/rules/eval.rs
@@ -20,7 +20,15 @@ fn element_empty_operation(value: &QueryResult) -> Result<bool> {
             PathAwareValue::List((_, list)) => list.is_empty(),
             PathAwareValue::Map((_, map)) => map.is_empty(),
             PathAwareValue::String((_, string)) => string.is_empty(),
-            PathAwareValue::Bool((_, boolean)) => (*boolean).to_string().is_empty(),
+            // No Bool arm. It computed `(*boolean).to_string().is_empty()`, and neither
+            // "true" nor "false" is ever the empty string, so EMPTY on a boolean was
+            // unconditionally false and `!EMPTY` unconditionally true -- a clause that reads
+            // like a check and cannot fail for any input.
+            //
+            // Falling through to the incompatible-type error below is the same treatment
+            // every other unsupported type gets, and it turns a silent always-pass into a
+            // diagnostic naming the path. `boolean_empty_is_an_incompatible_type` covers all
+            // four combinations of value and polarity.
             _ => {
                 return Err(Error::IncompatibleError(format!(
                     "Attempting EMPTY operation on type {} that does not support it at {}",
@@ -828,13 +836,13 @@ fn binary_operation<'value, 'loc: 'value>(
         // apply" and skips the whole body -- so failing here would silently disarm
         // every check in the guarded block and exit 0, which is worse than the bug
         // being fixed.
-        operators::EvalResult::EmptyRhsUnsatisfiable => Ok(EvaluationResult::EmptyQueryResult(
-            if role.is_strict() {
+        operators::EvalResult::EmptyRhsUnsatisfiable => {
+            Ok(EvaluationResult::EmptyQueryResult(if role.is_strict() {
                 Status::FAIL
             } else {
                 Status::SKIP
-            },
-        )),
+            }))
+        }
 
         // Negated comparison against a reference that resolved to nothing. There is
         // nothing to collide with, so the clause is vacuously satisfied and must not
@@ -865,13 +873,13 @@ fn binary_operation<'value, 'loc: 'value>(
         // wrapper always resolves EmptyRhs into one of the two variants above. Fail
         // closed rather than panicking, so a future refactor that routes around the
         // wrapper cannot turn this into a silent pass.
-        operators::EvalResult::EmptyRhs => Ok(EvaluationResult::EmptyQueryResult(
-            if role.is_strict() {
+        operators::EvalResult::EmptyRhs => {
+            Ok(EvaluationResult::EmptyQueryResult(if role.is_strict() {
                 Status::FAIL
             } else {
                 Status::SKIP
-            },
-        )),
+            }))
+        }
 
         operators::EvalResult::Result(results) => {
             let mut statues: Vec<(QueryResult, Status)> = Vec::with_capacity(lhs.len());
@@ -1511,11 +1519,9 @@ pub(in crate::rules) fn eval_guard_block_clause<'value, 'loc: 'value>(
                     root: rv,
                     parent: resolver,
                 };
-                match eval_general_block_clause(
-                    &block_clause.block,
-                    &mut val_resolver,
-                    |gc, r| eval_guard_clause(gc, r, role),
-                ) {
+                match eval_general_block_clause(&block_clause.block, &mut val_resolver, |gc, r| {
+                    eval_guard_clause(gc, r, role)
+                }) {
                     Ok(status) => match status {
                         Status::PASS => {
                             passes += 1;
@@ -1795,6 +1801,24 @@ pub(in crate::rules) fn eval_parameterized_rule_call<'value, 'loc: 'value>(
 
         Status::SKIP if role.is_strict() => Status::FAIL,
 
+        // A gate whose invoked rule did not apply stays SKIP rather than falling into the
+        // `_` arm below, which would turn a non-negated call into FAIL.
+        //
+        // Both are non-PASS, so with a single condition the two are indistinguishable --
+        // `eval_rule` drops the guarded body either way. The difference shows up with more
+        // than one condition: `eval_conjunction_clauses` absorbs SKIP (`Status::SKIP => {}`)
+        // but counts a FAIL, so one inapplicable gate condition returning FAIL poisons the
+        // whole `when` and drops a body that the remaining conditions would have enforced.
+        //
+        // That is exactly what `ClauseRole::Gate` is documented to prevent -- "the block it
+        // guards is still decided by the remaining conditions" -- so returning FAIL here
+        // defeated the role propagation this branch added for parameterized calls.
+        //
+        // Negated calls deliberately keep falling through: `not r(...)` where `r` did not
+        // apply must not report PASS on the strength of a check that never ran, which is the
+        // same fail-closed reasoning `eval_guard_named_clause` uses for its assertion case.
+        Status::SKIP if !call_rule.named_rule.negation => Status::SKIP,
+
         _ => {
             if call_rule.named_rule.negation {
                 Status::PASS
@@ -1845,9 +1869,7 @@ pub(in crate::rules) fn eval_when_clause<'value, 'loc: 'value>(
         // rule used as a gate failed instead of skipping and silently disarmed the
         // block it guarded.
         WhenGuardClause::Clause(gac) => eval_guard_access_clause(gac, resolver, ClauseRole::Gate),
-        WhenGuardClause::NamedRule(gnr) => {
-            eval_guard_named_clause(gnr, resolver, ClauseRole::Gate)
-        }
+        WhenGuardClause::NamedRule(gnr) => eval_guard_named_clause(gnr, resolver, ClauseRole::Gate),
         WhenGuardClause::ParameterizedNamedRule(prc) => {
             eval_parameterized_rule_call(prc, resolver, ClauseRole::Gate)
         }
@@ -2105,9 +2127,7 @@ pub(in crate::rules) fn eval_rule<'value, 'loc: 'value>(
         &rule.block
     };
 
-    match eval_general_block_clause(block, resolver, |rc, r| {
-        eval_rule_clause(rc, r, role)
-    }) {
+    match eval_general_block_clause(block, resolver, |rc, r| eval_rule_clause(rc, r, role)) {
         Ok(status) => {
             resolver.end_record(
                 &context,

--- a/guard/src/rules/eval.rs
+++ b/guard/src/rules/eval.rs
@@ -1986,7 +1986,15 @@ pub(in crate::rules) fn eval_type_block_clause<'value, 'loc: 'value>(
                 block: BlockCheck {
                     status: Status::SKIP,
                     at_least_one_matches: false,
-                    message: None,
+                    // Reaches the reader now that a skipped rule carries its reason through to the
+                    // reporters. Naming which of the two skips happened is the whole point: an
+                    // absent resource type is the ordinary, correct reason for a rule not to
+                    // apply, and a condition that matched nothing is the one worth a second look,
+                    // because a rule that never fires looks exactly like a rule that passes.
+                    message: Some(format!(
+                        "no {} in the input, so the type block had nothing to check",
+                        type_block.type_name
+                    )),
                 },
             }),
         )?;
@@ -2144,7 +2152,18 @@ pub(in crate::rules) fn eval_type_block_clause<'value, 'loc: 'value>(
             type_name: &type_block.type_name,
             block: BlockCheck {
                 status,
-                message: None,
+                // Only the SKIP needs explaining. Reaching here with neither a pass nor a fail
+                // means the input did contain resources of this type and not one of them was
+                // checked -- every one was exempted by the block's own `when` condition. That is
+                // a legitimate outcome and also the shape of a rule that silently never fires, and
+                // the reader cannot tell which from a bare "not applicable".
+                message: match status {
+                    Status::SKIP => Some(format!(
+                        "every {} in the input was exempted by the type block's `when` condition, so none was checked",
+                        type_block.type_name
+                    )),
+                    _ => None,
+                },
                 at_least_one_matches: false,
             },
         }),

--- a/guard/src/rules/eval.rs
+++ b/guard/src/rules/eval.rs
@@ -174,8 +174,34 @@ macro_rules! box_create_func {
 }
 
 pub(super) enum EvaluationResult {
-    EmptyQueryResult(Status),
+    /// An overall status with no per-value results, plus an optional explanation.
+    ///
+    /// The message is threaded into the `BlockCheck` the clause reports, which is the only
+    /// place a rule author sees it. It matters for the empty-reference cases: a clause that
+    /// fails because the thing it compares against resolved to no values needs to say so,
+    /// or the author is left looking for a fault in the template rather than in the ruleset.
+    EmptyQueryResult(Status, Option<String>),
     QueryValueResult(Vec<(QueryResult, Status)>),
+}
+
+/// Explanation attached to a clause that could not compare because its right-hand reference
+/// resolved to no values.
+///
+/// Names the remedy as well as the cause. An author who genuinely expects a possibly-empty
+/// reference can wrap the clause in `when <reference> !empty { ... }`: the gate's own
+/// `!empty` check fails when the reference is empty, so the block is skipped rather than
+/// failed, and the comparison never runs.
+fn empty_reference_message(negated: bool) -> String {
+    let clause = if negated {
+        "negated comparison"
+    } else {
+        "comparison"
+    };
+    format!(
+        "The {clause} could not be performed: the reference on the right-hand side resolved \
+         to no values. If an empty reference is expected here, guard the clause with `when \
+         <reference> !empty {{ ... }}` so it is skipped rather than failed."
+    )
 }
 
 /// Why a clause is being evaluated, which decides what an unevaluatable clause
@@ -311,30 +337,36 @@ fn unary_operation<'r, 'l: 'r, 'loc: 'l>(
                 }
                 EvaluationResult::QueryValueResult(results)
             } else {
-                EvaluationResult::EmptyQueryResult({
-                    let result = !cmp.1;
-                    let result = if inverse { !result } else { result };
-                    match result {
-                        true => {
-                            eval_context.start_record(&context)?;
-                            eval_context.end_record(
-                                &context,
-                                RecordType::ClauseValueCheck(ClauseCheck::Success),
-                            )?;
-                            Status::PASS
+                EvaluationResult::EmptyQueryResult(
+                    {
+                        let result = !cmp.1;
+                        let result = if inverse { !result } else { result };
+                        match result {
+                            true => {
+                                eval_context.start_record(&context)?;
+                                eval_context.end_record(
+                                    &context,
+                                    RecordType::ClauseValueCheck(ClauseCheck::Success),
+                                )?;
+                                Status::PASS
+                            }
+                            false => {
+                                eval_context.start_record(&context)?;
+                                eval_context.end_record(
+                                    &context,
+                                    RecordType::ClauseValueCheck(
+                                        ClauseCheck::NoValueForEmptyCheck(custom_message),
+                                    ),
+                                )?;
+                                Status::FAIL
+                            }
                         }
-                        false => {
-                            eval_context.start_record(&context)?;
-                            eval_context.end_record(
-                                &context,
-                                RecordType::ClauseValueCheck(ClauseCheck::NoValueForEmptyCheck(
-                                    custom_message,
-                                )),
-                            )?;
-                            Status::FAIL
-                        }
-                    }
-                })
+                    },
+                    // The unary EMPTY path already records its own ClauseValueCheck above,
+                    // including NoValueForEmptyCheck for the failing case, so there is
+                    // nothing an extra block-level message would add here.
+                    None,
+                )
             }
         });
     }
@@ -343,7 +375,7 @@ fn unary_operation<'r, 'l: 'r, 'loc: 'l>(
     // This only happens when the query has filters in them
     //
     if lhs.is_empty() {
-        return Ok(EvaluationResult::EmptyQueryResult(Status::SKIP));
+        return Ok(EvaluationResult::EmptyQueryResult(Status::SKIP, None));
     }
 
     use CmpOperator::*;
@@ -819,7 +851,7 @@ fn binary_operation<'value, 'loc: 'value>(
     let lhs = eval_context.query(lhs_query)?;
     let results = cmp.compare(&lhs, rhs)?;
     match results {
-        operators::EvalResult::Skip => Ok(EvaluationResult::EmptyQueryResult(Status::SKIP)),
+        operators::EvalResult::Skip => Ok(EvaluationResult::EmptyQueryResult(Status::SKIP, None)),
 
         // Positive comparison against a reference that resolved to nothing. No value
         // can be one of zero references, so the clause is unsatisfiable and every
@@ -836,50 +868,63 @@ fn binary_operation<'value, 'loc: 'value>(
         // apply" and skips the whole body -- so failing here would silently disarm
         // every check in the guarded block and exit 0, which is worse than the bug
         // being fixed.
-        operators::EvalResult::EmptyRhsUnsatisfiable => {
-            Ok(EvaluationResult::EmptyQueryResult(if role.is_strict() {
+        operators::EvalResult::EmptyRhsUnsatisfiable => Ok(EvaluationResult::EmptyQueryResult(
+            if role.is_strict() {
                 Status::FAIL
             } else {
                 Status::SKIP
-            }))
-        }
+            },
+            Some(empty_reference_message(false)),
+        )),
 
-        // Negated comparison against a reference that resolved to nothing. There is
-        // nothing to collide with, so the clause is vacuously satisfied and must not
-        // fail: an empty denylist is the normal state whenever a template contains
-        // none of the denied values.
+        // Negated comparison against a reference that resolved to nothing. Fails closed as
+        // an assertion.
         //
-        // Reported as SKIP rather than PASS, which matters inside a disjunction.
-        // eval_conjunction_clauses treats PASS as short-circuiting (eval.rs, the
-        // `Status::PASS` arm does `continue 'conjunction`) but SKIP as absorbing
-        // (`Status::SKIP => {}`). A vacuous PASS therefore satisfies an entire `or`
-        // block and abandons the sibling disjuncts unevaluated -- so
+        // The tempting reading is that this is vacuously satisfied -- there is nothing to
+        // collide with, and an empty denylist is the normal state whenever a template
+        // contains none of the denied values. That reading is what the previous SKIP
+        // encoded, and the comment here used to claim "the weaker status costs nothing in
+        // the standalone case". What it costs is the enforcement of the clause: a rule whose
+        // only check is `Property != %empty_reference` exited 0 having compared nothing,
+        // which is a denylist bypass rather than a compliant result.
         //
-        //     Encrypted != %empty_denylist  or  Encrypted == true
+        // The two error modes are not symmetric, which is what settles it. A wrong FAIL is
+        // visible and gets investigated. A wrong SKIP exits 0 and is indistinguishable from
+        // PASS in CI, so nobody ever looks. Requiring the author to declare the expectation
+        // instead -- an accompanying `!empty` guard -- was considered and rejected: it leaves
+        // every existing ruleset that lacks such a guard silently defeatable, which is the
+        // state being fixed.
         //
-        // would pass an unencrypted resource, because the first disjunct is
-        // vacuously true and the real check never runs. SKIP keeps the clause
-        // non-failing while leaving the decision to its siblings, which is the
-        // behavior base 57bbdbf had here and the reason that ruleset failed
-        // correctly before.
+        // The legitimate empty-reference case keeps an escape hatch, and it needs no new
+        // machinery: `when <reference> !empty { ... }` closes on an empty reference, because
+        // the gate's own `!empty` check fails, so the block is skipped and the comparison
+        // never runs. `an_empty_reference_can_be_guarded_with_a_when_not_empty_gate` pins it.
         //
-        // Both outcomes exit 0 for a clause evaluated on its own, so the weaker
-        // status costs nothing in the standalone case.
-        operators::EvalResult::EmptyRhsVacuouslyTrue => {
-            Ok(EvaluationResult::EmptyQueryResult(Status::SKIP))
-        }
+        // Role-aware for the same reason as the arm above rather than failing unconditionally.
+        // Failing a `when` condition makes `eval_rule` treat the rule as inapplicable and drop
+        // every check in the guarded body, so a gate that cannot compare must stay a SKIP or
+        // this fix would trade a bypassed clause for a disarmed block.
+        operators::EvalResult::EmptyRhsVacuouslyTrue => Ok(EvaluationResult::EmptyQueryResult(
+            if role.is_strict() {
+                Status::FAIL
+            } else {
+                Status::SKIP
+            },
+            Some(empty_reference_message(true)),
+        )),
 
         // Unreached in practice: `cmp` here is a (CmpOperator, bool) pair, and that
         // wrapper always resolves EmptyRhs into one of the two variants above. Fail
         // closed rather than panicking, so a future refactor that routes around the
         // wrapper cannot turn this into a silent pass.
-        operators::EvalResult::EmptyRhs => {
-            Ok(EvaluationResult::EmptyQueryResult(if role.is_strict() {
+        operators::EvalResult::EmptyRhs => Ok(EvaluationResult::EmptyQueryResult(
+            if role.is_strict() {
                 Status::FAIL
             } else {
                 Status::SKIP
-            }))
-        }
+            },
+            Some(empty_reference_message(cmp.1)),
+        )),
 
         operators::EvalResult::Result(results) => {
             let mut statues: Vec<(QueryResult, Status)> = Vec::with_capacity(lhs.len());
@@ -1284,12 +1329,12 @@ pub(in crate::rules) fn eval_guard_access_clause<'value, 'loc: 'value>(
 
     match statues {
         Ok(statues) => match statues {
-            EvaluationResult::EmptyQueryResult(status) => {
+            EvaluationResult::EmptyQueryResult(status, message) => {
                 resolver.end_record(
                     &blk_context,
                     RecordType::GuardClauseBlockCheck(BlockCheck {
                         status,
-                        message: None,
+                        message,
                         at_least_one_matches: all,
                     }),
                 )?;

--- a/guard/src/rules/eval.rs
+++ b/guard/src/rules/eval.rs
@@ -1772,7 +1772,37 @@ pub(in crate::rules) fn eval_parameterized_rule_call<'value, 'loc: 'value>(
     // Propagate the call site's role: a parameterized rule used as a `when` gate
     // must evaluate its body with gate semantics, or an unevaluatable clause inside
     // it fails the gate and silently disarms the block it guards.
-    eval_rule(&param_rule.rule, &mut eval, role)
+    let status = eval_rule(&param_rule.rule, &mut eval, role)?;
+
+    // Apply the clause-level negation of the *call*. The parser accepts and stores a
+    // leading `not` on a parameterized invocation (`not is_relevant("x")`) exactly as
+    // it does for a plain named-rule reference, but this arm used to return the
+    // invoked rule's status unchanged, so the `not` was silently discarded and
+    // `not r(...)` behaved identically to `r(...)`.
+    //
+    // Mirrors eval_guard_named_clause so both spellings agree: PASS inverts to FAIL
+    // under negation, a SKIPped rule fails closed where the reference is an assertion
+    // (a rule that never ran is not evidence for a negated claim), and otherwise the
+    // negation flips the outcome.
+    Ok(match status {
+        Status::PASS => {
+            if call_rule.named_rule.negation {
+                Status::FAIL
+            } else {
+                Status::PASS
+            }
+        }
+
+        Status::SKIP if role.is_strict() => Status::FAIL,
+
+        _ => {
+            if call_rule.named_rule.negation {
+                Status::PASS
+            } else {
+                Status::FAIL
+            }
+        }
+    })
 }
 
 /// `role` propagates the assertion-vs-gate distinction to the leaf clauses. Callers

--- a/guard/src/rules/eval.rs
+++ b/guard/src/rules/eval.rs
@@ -1130,21 +1130,24 @@ fn binary_operation<'value, 'loc: 'value>(
     }
 }
 
+/// Compares the keys of a map against a right-hand side, for `[ keys <op> ... ]` filters.
+///
+/// The narrowed `MapKeyComparator` rather than a `(CmpOperator, bool)` pair: this function's only
+/// caller is `QueryPart::MapKeyFilter`, the parser admits four comparators there, and the wider
+/// type left four arms here that nothing could reach. See the type's own comment for why that
+/// mattered.
 pub(super) fn real_binary_operation<'value, 'loc: 'value>(
     lhs: &[QueryResult],
     rhs: &[QueryResult],
-    cmp: (CmpOperator, bool),
+    cmp: MapKeyComparator,
     context: String,
     custom_message: Option<String>,
     eval_context: &mut dyn EvalContext<'value, 'loc>,
 ) -> Result<EvaluationResult> {
     let mut statues: Vec<(QueryResult, Status)> = Vec::with_capacity(lhs.len());
 
-    let cmp = if cmp.0 == CmpOperator::Eq && rhs.len() > 1 {
-        (CmpOperator::In, cmp.1)
-    } else {
-        cmp
-    };
+    let cmp = cmp.widened_for(rhs.len());
+    let recorded_cmp = cmp.as_cmp_operator();
 
     for each in lhs.iter() {
         match each {
@@ -1156,7 +1159,7 @@ pub(super) fn real_binary_operation<'value, 'loc: 'value>(
                         status: Status::FAIL,
                         message: None,
                         custom_message: custom_message.clone(),
-                        comparison: cmp,
+                        comparison: recorded_cmp,
                         from: each.clone(),
                         to: None,
                     })),
@@ -1166,58 +1169,36 @@ pub(super) fn real_binary_operation<'value, 'loc: 'value>(
 
             QueryResult::Literal(l) | QueryResult::Resolved(l) => {
                 let r = match cmp {
-                    (CmpOperator::Eq, is_not) => each_lhs_compare(
-                        not_compare(crate::rules::path_value::compare_eq, is_not),
+                    MapKeyComparator::Eq | MapKeyComparator::NotEq => each_lhs_compare(
+                        not_compare(
+                            crate::rules::path_value::compare_eq,
+                            cmp == MapKeyComparator::NotEq,
+                        ),
                         Rc::clone(l),
                         rhs,
                     )?,
 
-                    (CmpOperator::Ge, is_not) => each_lhs_compare(
-                        not_compare(crate::rules::path_value::compare_ge, is_not),
-                        Rc::clone(l),
-                        rhs,
-                    )?,
-
-                    (CmpOperator::Gt, is_not) => each_lhs_compare(
-                        not_compare(crate::rules::path_value::compare_gt, is_not),
-                        Rc::clone(l),
-                        rhs,
-                    )?,
-
-                    (CmpOperator::Lt, is_not) => each_lhs_compare(
-                        not_compare(crate::rules::path_value::compare_lt, is_not),
-                        Rc::clone(l),
-                        rhs,
-                    )?,
-
-                    (CmpOperator::Le, is_not) => each_lhs_compare(
-                        not_compare(crate::rules::path_value::compare_le, is_not),
-                        Rc::clone(l),
-                        rhs,
-                    )?,
-
-                    (CmpOperator::In, is_not) => {
-                        each_lhs_compare(in_cmp(is_not), Rc::clone(l), rhs)?
+                    MapKeyComparator::In | MapKeyComparator::NotIn => {
+                        each_lhs_compare(in_cmp(cmp == MapKeyComparator::NotIn), Rc::clone(l), rhs)?
                     }
-
-                    _ => unreachable!(),
                 };
 
-                match cmp.0 {
-                    CmpOperator::In => {
+                match cmp {
+                    // Membership is satisfied by one match, so the report folds that way.
+                    MapKeyComparator::In | MapKeyComparator::NotIn => {
                         statues.extend(report_at_least_one(
                             r,
-                            cmp,
+                            recorded_cmp,
                             context.clone(),
                             custom_message.clone(),
                             eval_context,
                         )?);
                     }
 
-                    _ => {
+                    MapKeyComparator::Eq | MapKeyComparator::NotEq => {
                         let status = report_all_values(
                             r,
-                            cmp,
+                            recorded_cmp,
                             context.clone(),
                             custom_message.clone(),
                             eval_context,

--- a/guard/src/rules/eval.rs
+++ b/guard/src/rules/eval.rs
@@ -1238,9 +1238,19 @@ pub(in crate::rules) fn eval_guard_access_clause<'value, 'loc: 'value>(
     }
 }
 
+/// Evaluates a reference to another rule by name.
+///
+/// `strict_skip` distinguishes the two contexts this is reached from:
+///
+/// - `true` — the reference is an assertion in a rule body, so a SKIPped
+///   dependent rule must not satisfy it in either polarity. Failing closed here is
+///   what stops `not <rule>` from reporting compliance for a check that never ran.
+/// - `false` — the reference is a `when` condition, where gating on a rule that did
+///   not apply is deliberate and covered by existing tests.
 pub(in crate::rules) fn eval_guard_named_clause<'value, 'loc: 'value>(
     gnc: &'value GuardNamedRuleClause<'loc>,
     resolver: &mut dyn EvalContext<'value, 'loc>,
+    strict_skip: bool,
 ) -> Result<Status> {
     let context = format!("{}", gnc);
     resolver.start_record(&context)?;
@@ -1255,6 +1265,22 @@ pub(in crate::rules) fn eval_guard_named_clause<'value, 'loc: 'value>(
                         Status::PASS
                     }
                 }
+
+                // A dependent rule that SKIPped never ran, so it is not evidence in
+                // either direction. Where this reference is an assertion in a rule
+                // body, a negated reference to it must not report compliance on the
+                // strength of a check that was never performed: `not <rule>` used to
+                // fall into the `_` arm below and yield PASS, and because the
+                // enclosing rule then reported PASS rather than SKIP, nothing in the
+                // output hinted at the omission.
+                //
+                // In a `when` condition the same shape is deliberate and tested --
+                // `rule r when !other { ... }` is how a ruleset says "apply this
+                // when that other rule did not apply" (see
+                // cross_rule_clause_when_checks). Gating on a SKIP there is not a
+                // compliance claim, so it keeps the existing behavior.
+                Status::SKIP if strict_skip => Status::FAIL,
+
                 _ => {
                     if gnc.negation {
                         Status::PASS
@@ -1637,7 +1663,9 @@ pub(in crate::rules) fn eval_guard_clause<'value, 'loc: 'value>(
 ) -> Result<Status> {
     match gc {
         GuardClause::Clause(gac) => eval_guard_access_clause(gac, resolver),
-        GuardClause::NamedRule(gnc) => eval_guard_named_clause(gnc, resolver),
+        // Rule body: a named-rule reference here is an assertion, so a SKIPped
+        // dependent rule fails closed.
+        GuardClause::NamedRule(gnc) => eval_guard_named_clause(gnc, resolver, true),
         GuardClause::BlockClause(bc) => eval_guard_block_clause(bc, resolver),
         GuardClause::WhenBlock(conditions, block) => eval_when_condition_block(
             "GuardConditionClause".to_string(),
@@ -1655,7 +1683,9 @@ pub(in crate::rules) fn eval_when_clause<'value, 'loc: 'value>(
 ) -> Result<Status> {
     match when_clause {
         WhenGuardClause::Clause(gac) => eval_guard_access_clause(gac, resolver),
-        WhenGuardClause::NamedRule(gnr) => eval_guard_named_clause(gnr, resolver),
+        // `when` condition: gating on a rule that did not apply is intentional, so
+        // keep the pre-existing SKIP handling.
+        WhenGuardClause::NamedRule(gnr) => eval_guard_named_clause(gnr, resolver, false),
         WhenGuardClause::ParameterizedNamedRule(prc) => eval_parameterized_rule_call(prc, resolver),
     }
 }

--- a/guard/src/rules/eval.rs
+++ b/guard/src/rules/eval.rs
@@ -863,11 +863,16 @@ fn binary_operation<'value, 'loc: 'value>(
         // from a raw lhs entry -- an lhs can be QueryResult::Literal (a `let`
         // literal), which every reporter treats as unreachable in a comparison.
         //
-        // In a `when` condition this must stay a SKIP. A FAIL there makes the gate
-        // not-PASS, and eval_rule treats a non-PASS condition as "rule does not
-        // apply" and skips the whole body -- so failing here would silently disarm
-        // every check in the guarded block and exit 0, which is worse than the bug
-        // being fixed.
+        // In a `when` condition this stays a SKIP, because of how the condition fold
+        // treats the two statuses. `eval_conjunction_clauses` absorbs a SKIP (`Status::SKIP
+        // => {}`) but counts a FAIL, and it answers FAIL before PASS. So a FAIL here
+        // overrides sibling conditions that passed and drops a body those siblings would
+        // have enforced, at exit 0; a SKIP is absorbed and lets them decide.
+        // `empty_reference_in_a_when_condition_does_not_disarm_the_block` pins that.
+        //
+        // With a single condition the two statuses are indistinguishable -- `eval_rule` maps
+        // every non-PASS condition to `Status::SKIP` for the rule either way -- so the
+        // difference is only observable alongside a condition that passes.
         operators::EvalResult::EmptyRhsUnsatisfiable => Ok(EvaluationResult::EmptyQueryResult(
             if role.is_strict() {
                 Status::FAIL
@@ -900,10 +905,10 @@ fn binary_operation<'value, 'loc: 'value>(
         // the gate's own `!empty` check fails, so the block is skipped and the comparison
         // never runs. `an_empty_reference_can_be_guarded_with_a_when_not_empty_gate` pins it.
         //
-        // Role-aware for the same reason as the arm above rather than failing unconditionally.
-        // Failing a `when` condition makes `eval_rule` treat the rule as inapplicable and drop
-        // every check in the guarded body, so a gate that cannot compare must stay a SKIP or
-        // this fix would trade a bypassed clause for a disarmed block.
+        // Role-aware for the same reason as the arm above rather than failing unconditionally:
+        // a FAIL on a `when` condition is counted by the condition fold and outranks sibling
+        // conditions that passed, so it would drop a body those siblings would have enforced.
+        // `negated_empty_reference_in_a_when_condition_does_not_disarm_the_block` pins that.
         operators::EvalResult::EmptyRhsVacuouslyTrue => Ok(EvaluationResult::EmptyQueryResult(
             if role.is_strict() {
                 Status::FAIL

--- a/guard/src/rules/eval.rs
+++ b/guard/src/rules/eval.rs
@@ -762,6 +762,11 @@ where
     }
 }
 
+/// `strict_empty_rhs` is true when this clause is an assertion in a rule body, and
+/// false when it is a `when` condition. A positive comparison against a reference
+/// that resolved to nothing is unsatisfiable and fails in a body, but must stay a
+/// SKIP in a condition: a failing condition makes the gate not-PASS, and eval_rule
+/// then skips the entire guarded block, which would disarm every check inside it.
 fn binary_operation<'value, 'loc: 'value>(
     lhs_query: &'value [QueryPart<'loc>],
     rhs: &[QueryResult],
@@ -769,11 +774,73 @@ fn binary_operation<'value, 'loc: 'value>(
     context: String,
     custom_message: Option<String>,
     eval_context: &mut dyn EvalContext<'value, 'loc>,
+    strict_empty_rhs: bool,
 ) -> Result<EvaluationResult> {
     let lhs = eval_context.query(lhs_query)?;
     let results = cmp.compare(&lhs, rhs)?;
     match results {
         operators::EvalResult::Skip => Ok(EvaluationResult::EmptyQueryResult(Status::SKIP)),
+
+        // Positive comparison against a reference that resolved to nothing. No value
+        // can be one of zero references, so the clause is unsatisfiable and every
+        // left-hand value fails. Returning a definite status keeps the clause
+        // enforced instead of exiting 0 unevaluated.
+        //
+        // A status is emitted rather than a per-value comparison record because there
+        // is no right-hand value to report against, and `from:` must not be built
+        // from a raw lhs entry -- an lhs can be QueryResult::Literal (a `let`
+        // literal), which every reporter treats as unreachable in a comparison.
+        //
+        // In a `when` condition this must stay a SKIP. A FAIL there makes the gate
+        // not-PASS, and eval_rule treats a non-PASS condition as "rule does not
+        // apply" and skips the whole body -- so failing here would silently disarm
+        // every check in the guarded block and exit 0, which is worse than the bug
+        // being fixed.
+        operators::EvalResult::EmptyRhsUnsatisfiable => Ok(EvaluationResult::EmptyQueryResult(
+            if strict_empty_rhs {
+                Status::FAIL
+            } else {
+                Status::SKIP
+            },
+        )),
+
+        // Negated comparison against a reference that resolved to nothing. There is
+        // nothing to collide with, so the clause is vacuously satisfied and must not
+        // fail: an empty denylist is the normal state whenever a template contains
+        // none of the denied values.
+        //
+        // Reported as SKIP rather than PASS, which matters inside a disjunction.
+        // eval_conjunction_clauses treats PASS as short-circuiting (eval.rs, the
+        // `Status::PASS` arm does `continue 'conjunction`) but SKIP as absorbing
+        // (`Status::SKIP => {}`). A vacuous PASS therefore satisfies an entire `or`
+        // block and abandons the sibling disjuncts unevaluated -- so
+        //
+        //     Encrypted != %empty_denylist  or  Encrypted == true
+        //
+        // would pass an unencrypted resource, because the first disjunct is
+        // vacuously true and the real check never runs. SKIP keeps the clause
+        // non-failing while leaving the decision to its siblings, which is the
+        // behavior base 57bbdbf had here and the reason that ruleset failed
+        // correctly before.
+        //
+        // Both outcomes exit 0 for a clause evaluated on its own, so the weaker
+        // status costs nothing in the standalone case.
+        operators::EvalResult::EmptyRhsVacuouslyTrue => {
+            Ok(EvaluationResult::EmptyQueryResult(Status::SKIP))
+        }
+
+        // Unreached in practice: `cmp` here is a (CmpOperator, bool) pair, and that
+        // wrapper always resolves EmptyRhs into one of the two variants above. Fail
+        // closed rather than panicking, so a future refactor that routes around the
+        // wrapper cannot turn this into a silent pass.
+        operators::EvalResult::EmptyRhs => Ok(EvaluationResult::EmptyQueryResult(
+            if strict_empty_rhs {
+                Status::FAIL
+            } else {
+                Status::SKIP
+            },
+        )),
+
         operators::EvalResult::Result(results) => {
             let mut statues: Vec<(QueryResult, Status)> = Vec::with_capacity(lhs.len());
             for each in results {
@@ -1075,9 +1142,12 @@ pub(super) fn real_binary_operation<'value, 'loc: 'value>(
 }
 
 #[allow(clippy::never_loop)]
+/// `strict_empty_rhs` is false when this clause is a `when` condition; see
+/// `binary_operation`.
 pub(in crate::rules) fn eval_guard_access_clause<'value, 'loc: 'value>(
     gac: &'value GuardAccessClause<'loc>,
     resolver: &mut dyn EvalContext<'value, 'loc>,
+    strict_empty_rhs: bool,
 ) -> Result<Status> {
     let all = gac.access_clause.query.match_all;
     let blk_context = format!("GuardAccessClause#block{}", gac);
@@ -1168,6 +1238,7 @@ pub(in crate::rules) fn eval_guard_access_clause<'value, 'loc: 'value>(
             format!("{}", gac),
             gac.access_clause.custom_message.clone(),
             resolver,
+            strict_empty_rhs,
         )
     };
 
@@ -1662,9 +1733,9 @@ pub(in crate::rules) fn eval_guard_clause<'value, 'loc: 'value>(
     resolver: &mut dyn EvalContext<'value, 'loc>,
 ) -> Result<Status> {
     match gc {
-        GuardClause::Clause(gac) => eval_guard_access_clause(gac, resolver),
-        // Rule body: a named-rule reference here is an assertion, so a SKIPped
-        // dependent rule fails closed.
+        // Rule body: an unsatisfiable clause fails, and a named-rule reference is an
+        // assertion, so a SKIPped dependent rule fails closed.
+        GuardClause::Clause(gac) => eval_guard_access_clause(gac, resolver, true),
         GuardClause::NamedRule(gnc) => eval_guard_named_clause(gnc, resolver, true),
         GuardClause::BlockClause(bc) => eval_guard_block_clause(bc, resolver),
         GuardClause::WhenBlock(conditions, block) => eval_when_condition_block(
@@ -1682,9 +1753,11 @@ pub(in crate::rules) fn eval_when_clause<'value, 'loc: 'value>(
     resolver: &mut dyn EvalContext<'value, 'loc>,
 ) -> Result<Status> {
     match when_clause {
-        WhenGuardClause::Clause(gac) => eval_guard_access_clause(gac, resolver),
-        // `when` condition: gating on a rule that did not apply is intentional, so
-        // keep the pre-existing SKIP handling.
+        // `when` condition: both stay non-strict. A clause whose reference did not
+        // resolve, or a reference to a rule that did not apply, must not disarm the
+        // block being guarded -- a FAIL here makes the gate not-PASS and eval_rule
+        // skips the whole body.
+        WhenGuardClause::Clause(gac) => eval_guard_access_clause(gac, resolver, false),
         WhenGuardClause::NamedRule(gnr) => eval_guard_named_clause(gnr, resolver, false),
         WhenGuardClause::ParameterizedNamedRule(prc) => eval_parameterized_rule_call(prc, resolver),
     }

--- a/guard/src/rules/eval.rs
+++ b/guard/src/rules/eval.rs
@@ -170,6 +170,40 @@ pub(super) enum EvaluationResult {
     QueryValueResult(Vec<(QueryResult, Status)>),
 }
 
+/// Why a clause is being evaluated, which decides what an unevaluatable clause
+/// should report.
+///
+/// The distinction is load-bearing, not cosmetic. `eval_rule` and
+/// `eval_when_condition_block` treat any non-PASS *condition* as "this rule does not
+/// apply" and skip the guarded body entirely. So a clause that fails as an assertion
+/// must only SKIP as a gate -- failing a gate silently disarms every check inside it
+/// and the file still exits 0.
+///
+/// Carried as an enum rather than a `bool` deliberately. A boolean parameter reads as
+/// `f(x, resolver, true)` at the call site, which says nothing about intent and is
+/// easy to omit: an earlier version of this threading passed booleans and left
+/// `WhenGuardClause::ParameterizedNamedRule` unthreaded, so a parameterized rule
+/// invoked from a `when` condition evaluated its body with assertion strictness and
+/// produced exactly the wrong-PASS described above. With an explicit parameter type
+/// every construction site has to name which case it is.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(super) enum ClauseRole {
+    /// The clause is an assertion in a rule body. An unevaluatable clause is a
+    /// failure: the rule claimed something it could not establish.
+    Assertion,
+    /// The clause is a `when` condition gating a block. An unevaluatable clause is
+    /// not applicable, never a failure, so the block it guards is still decided by
+    /// the remaining conditions.
+    Gate,
+}
+
+impl ClauseRole {
+    /// True when an unevaluatable clause in this role should FAIL rather than SKIP.
+    fn is_strict(self) -> bool {
+        matches!(self, ClauseRole::Assertion)
+    }
+}
+
 #[allow(clippy::type_complexity)]
 fn unary_operation<'r, 'l: 'r, 'loc: 'l>(
     lhs_query: &'l [QueryPart<'loc>],
@@ -762,11 +796,9 @@ where
     }
 }
 
-/// `strict_empty_rhs` is true when this clause is an assertion in a rule body, and
-/// false when it is a `when` condition. A positive comparison against a reference
-/// that resolved to nothing is unsatisfiable and fails in a body, but must stay a
-/// SKIP in a condition: a failing condition makes the gate not-PASS, and eval_rule
-/// then skips the entire guarded block, which would disarm every check inside it.
+/// `role` decides what a positive comparison against an empty reference reports: it
+/// is unsatisfiable, so it fails as an [`ClauseRole::Assertion`] but must stay a SKIP
+/// as a [`ClauseRole::Gate`]. See [`ClauseRole`] for why failing a gate is unsafe.
 fn binary_operation<'value, 'loc: 'value>(
     lhs_query: &'value [QueryPart<'loc>],
     rhs: &[QueryResult],
@@ -774,7 +806,7 @@ fn binary_operation<'value, 'loc: 'value>(
     context: String,
     custom_message: Option<String>,
     eval_context: &mut dyn EvalContext<'value, 'loc>,
-    strict_empty_rhs: bool,
+    role: ClauseRole,
 ) -> Result<EvaluationResult> {
     let lhs = eval_context.query(lhs_query)?;
     let results = cmp.compare(&lhs, rhs)?;
@@ -797,7 +829,7 @@ fn binary_operation<'value, 'loc: 'value>(
         // every check in the guarded block and exit 0, which is worse than the bug
         // being fixed.
         operators::EvalResult::EmptyRhsUnsatisfiable => Ok(EvaluationResult::EmptyQueryResult(
-            if strict_empty_rhs {
+            if role.is_strict() {
                 Status::FAIL
             } else {
                 Status::SKIP
@@ -834,7 +866,7 @@ fn binary_operation<'value, 'loc: 'value>(
         // closed rather than panicking, so a future refactor that routes around the
         // wrapper cannot turn this into a silent pass.
         operators::EvalResult::EmptyRhs => Ok(EvaluationResult::EmptyQueryResult(
-            if strict_empty_rhs {
+            if role.is_strict() {
                 Status::FAIL
             } else {
                 Status::SKIP
@@ -1142,12 +1174,12 @@ pub(super) fn real_binary_operation<'value, 'loc: 'value>(
 }
 
 #[allow(clippy::never_loop)]
-/// `strict_empty_rhs` is false when this clause is a `when` condition; see
-/// `binary_operation`.
+/// `role` is [`ClauseRole::Gate`] when this clause is a `when` condition; see
+/// [`binary_operation`].
 pub(in crate::rules) fn eval_guard_access_clause<'value, 'loc: 'value>(
     gac: &'value GuardAccessClause<'loc>,
     resolver: &mut dyn EvalContext<'value, 'loc>,
-    strict_empty_rhs: bool,
+    role: ClauseRole,
 ) -> Result<Status> {
     let all = gac.access_clause.query.match_all;
     let blk_context = format!("GuardAccessClause#block{}", gac);
@@ -1238,7 +1270,7 @@ pub(in crate::rules) fn eval_guard_access_clause<'value, 'loc: 'value>(
             format!("{}", gac),
             gac.access_clause.custom_message.clone(),
             resolver,
-            strict_empty_rhs,
+            role,
         )
     };
 
@@ -1311,17 +1343,17 @@ pub(in crate::rules) fn eval_guard_access_clause<'value, 'loc: 'value>(
 
 /// Evaluates a reference to another rule by name.
 ///
-/// `strict_skip` distinguishes the two contexts this is reached from:
+/// `role` distinguishes the two contexts this is reached from:
 ///
-/// - `true` — the reference is an assertion in a rule body, so a SKIPped
+/// - [`ClauseRole::Assertion`] — the reference is in a rule body, so a SKIPped
 ///   dependent rule must not satisfy it in either polarity. Failing closed here is
 ///   what stops `not <rule>` from reporting compliance for a check that never ran.
-/// - `false` — the reference is a `when` condition, where gating on a rule that did
-///   not apply is deliberate and covered by existing tests.
+/// - [`ClauseRole::Gate`] — the reference is a `when` condition, where gating on a
+///   rule that did not apply is deliberate and covered by existing tests.
 pub(in crate::rules) fn eval_guard_named_clause<'value, 'loc: 'value>(
     gnc: &'value GuardNamedRuleClause<'loc>,
     resolver: &mut dyn EvalContext<'value, 'loc>,
-    strict_skip: bool,
+    role: ClauseRole,
 ) -> Result<Status> {
     let context = format!("{}", gnc);
     resolver.start_record(&context)?;
@@ -1350,7 +1382,7 @@ pub(in crate::rules) fn eval_guard_named_clause<'value, 'loc: 'value>(
                 // when that other rule did not apply" (see
                 // cross_rule_clause_when_checks). Gating on a SKIP there is not a
                 // compliance claim, so it keeps the existing behavior.
-                Status::SKIP if strict_skip => Status::FAIL,
+                Status::SKIP if role.is_strict() => Status::FAIL,
 
                 _ => {
                     if gnc.negation {
@@ -1411,9 +1443,12 @@ where
     eval_conjunction_clauses(&block.conjunctions, &mut block_scope, eval_fn)
 }
 
+/// `role` is inherited from the enclosing clause; a block clause is not itself a
+/// gate or an assertion, it just groups the clauses inside it.
 pub(in crate::rules) fn eval_guard_block_clause<'value, 'loc: 'value>(
     block_clause: &'value BlockGuardClause<'loc>,
     resolver: &mut dyn EvalContext<'value, 'loc>,
+    role: ClauseRole,
 ) -> Result<Status> {
     let context = format!("BlockGuardClause#{}", block_clause.location);
     let match_all = block_clause.query.match_all;
@@ -1479,7 +1514,7 @@ pub(in crate::rules) fn eval_guard_block_clause<'value, 'loc: 'value>(
                 match eval_general_block_clause(
                     &block_clause.block,
                     &mut val_resolver,
-                    eval_guard_clause,
+                    |gc, r| eval_guard_clause(gc, r, role),
                 ) {
                     Ok(status) => match status {
                         Status::PASS => {
@@ -1581,7 +1616,11 @@ fn eval_when_condition_block<'value, 'loc: 'value>(
     };
 
     Ok(
-        match eval_general_block_clause(block, resolver, eval_guard_clause) {
+        // The guarded block holds the rule's actual assertions, regardless of how
+        // the conditions were evaluated.
+        match eval_general_block_clause(block, resolver, |gc, r| {
+            eval_guard_clause(gc, r, ClauseRole::Assertion)
+        }) {
             Ok(status) => {
                 resolver.end_record(
                     &context,
@@ -1682,9 +1721,14 @@ impl<'eval, 'value, 'loc: 'value> RecordTracer<'value>
     }
 }
 
+/// `role` is the role of the *call site*, not of the clauses inside the invoked rule.
+/// A parameterized rule invoked from a `when` condition is a gate, so its body must
+/// evaluate with gate semantics: an unevaluatable clause inside it makes the gate
+/// inapplicable rather than failed, which leaves the guarded block enforced.
 pub(in crate::rules) fn eval_parameterized_rule_call<'value, 'loc: 'value>(
     call_rule: &'value ParameterizedNamedRuleClause<'loc>,
     resolver: &mut dyn EvalContext<'value, 'loc>,
+    role: ClauseRole,
 ) -> Result<Status> {
     let param_rule = resolver.find_parameterized_rule(&call_rule.named_rule.dependent_rule)?;
 
@@ -1725,26 +1769,33 @@ pub(in crate::rules) fn eval_parameterized_rule_call<'value, 'loc: 'value>(
         resolved_parameters,
         call_rule,
     };
-    eval_rule(&param_rule.rule, &mut eval)
+    // Propagate the call site's role: a parameterized rule used as a `when` gate
+    // must evaluate its body with gate semantics, or an unevaluatable clause inside
+    // it fails the gate and silently disarms the block it guards.
+    eval_rule(&param_rule.rule, &mut eval, role)
 }
 
+/// `role` propagates the assertion-vs-gate distinction to the leaf clauses. Callers
+/// evaluating a rule body pass [`ClauseRole::Assertion`]; callers evaluating the
+/// conditions of a `when` block or a parameterized gate pass [`ClauseRole::Gate`].
 pub(in crate::rules) fn eval_guard_clause<'value, 'loc: 'value>(
     gc: &'value GuardClause<'loc>,
     resolver: &mut dyn EvalContext<'value, 'loc>,
+    role: ClauseRole,
 ) -> Result<Status> {
     match gc {
-        // Rule body: an unsatisfiable clause fails, and a named-rule reference is an
-        // assertion, so a SKIPped dependent rule fails closed.
-        GuardClause::Clause(gac) => eval_guard_access_clause(gac, resolver, true),
-        GuardClause::NamedRule(gnc) => eval_guard_named_clause(gnc, resolver, true),
-        GuardClause::BlockClause(bc) => eval_guard_block_clause(bc, resolver),
+        GuardClause::Clause(gac) => eval_guard_access_clause(gac, resolver, role),
+        GuardClause::NamedRule(gnc) => eval_guard_named_clause(gnc, resolver, role),
+        GuardClause::BlockClause(bc) => eval_guard_block_clause(bc, resolver, role),
         GuardClause::WhenBlock(conditions, block) => eval_when_condition_block(
             "GuardConditionClause".to_string(),
             conditions,
             block,
             resolver,
         ),
-        GuardClause::ParameterizedNamedRule(prc) => eval_parameterized_rule_call(prc, resolver),
+        GuardClause::ParameterizedNamedRule(prc) => {
+            eval_parameterized_rule_call(prc, resolver, role)
+        }
     }
 }
 
@@ -1753,19 +1804,32 @@ pub(in crate::rules) fn eval_when_clause<'value, 'loc: 'value>(
     resolver: &mut dyn EvalContext<'value, 'loc>,
 ) -> Result<Status> {
     match when_clause {
-        // `when` condition: both stay non-strict. A clause whose reference did not
-        // resolve, or a reference to a rule that did not apply, must not disarm the
-        // block being guarded -- a FAIL here makes the gate not-PASS and eval_rule
-        // skips the whole body.
-        WhenGuardClause::Clause(gac) => eval_guard_access_clause(gac, resolver, false),
-        WhenGuardClause::NamedRule(gnr) => eval_guard_named_clause(gnr, resolver, false),
-        WhenGuardClause::ParameterizedNamedRule(prc) => eval_parameterized_rule_call(prc, resolver),
+        // Every arm is a gate. A clause whose reference did not resolve, or a
+        // reference to a rule that did not apply, must not disarm the block being
+        // guarded: a FAIL here makes the gate not-PASS and eval_rule skips the whole
+        // body.
+        //
+        // The parameterized arm needs the role threaded through the rule it invokes.
+        // It previously called eval_parameterized_rule_call with no role, and
+        // everything downstream defaulted to assertion strictness, so a parameterized
+        // rule used as a gate failed instead of skipping and silently disarmed the
+        // block it guarded.
+        WhenGuardClause::Clause(gac) => eval_guard_access_clause(gac, resolver, ClauseRole::Gate),
+        WhenGuardClause::NamedRule(gnr) => {
+            eval_guard_named_clause(gnr, resolver, ClauseRole::Gate)
+        }
+        WhenGuardClause::ParameterizedNamedRule(prc) => {
+            eval_parameterized_rule_call(prc, resolver, ClauseRole::Gate)
+        }
     }
 }
 
+/// `role` is inherited by the clauses in the type block's body. Its own `when`
+/// conditions are always evaluated as [`ClauseRole::Gate`].
 pub(in crate::rules) fn eval_type_block_clause<'value, 'loc: 'value>(
     type_block: &'value TypeBlock<'loc>,
     resolver: &mut dyn EvalContext<'value, 'loc>,
+    role: ClauseRole,
 ) -> Result<Status> {
     let context = format!("TypeBlock#{}", type_block.type_name);
     resolver.start_record(&context)?;
@@ -1861,7 +1925,9 @@ pub(in crate::rules) fn eval_type_block_clause<'value, 'loc: 'value>(
                     parent: resolver,
                 };
 
-                match eval_general_block_clause(block, &mut val_resolver, eval_guard_clause) {
+                match eval_general_block_clause(block, &mut val_resolver, |gc, r| {
+                    eval_guard_clause(gc, r, role)
+                }) {
                     Ok(status) => {
                         match status {
                             Status::PASS => {
@@ -1938,22 +2004,36 @@ pub(in crate::rules) fn eval_type_block_clause<'value, 'loc: 'value>(
     Ok(status)
 }
 
+/// `role` is inherited by the clauses of this rule clause.
 pub(in crate::rules) fn eval_rule_clause<'value, 'loc: 'value>(
     rule_clause: &'value RuleClause<'loc>,
     resolver: &mut dyn EvalContext<'value, 'loc>,
+    role: ClauseRole,
 ) -> Result<Status> {
     match rule_clause {
-        RuleClause::Clause(gc) => eval_guard_clause(gc, resolver),
-        RuleClause::TypeBlock(tb) => eval_type_block_clause(tb, resolver),
+        RuleClause::Clause(gc) => eval_guard_clause(gc, resolver, role),
+        RuleClause::TypeBlock(tb) => eval_type_block_clause(tb, resolver, role),
         RuleClause::WhenBlock(conditions, block) => {
             eval_when_condition_block("RuleClause".to_string(), conditions, block, resolver)
         }
     }
 }
 
+/// `role` is the role of the context that *invoked* this rule, not the role of the
+/// clauses it contains.
+///
+/// A rule evaluated as a top-level entry in a rules file, or referenced from another
+/// rule's body, is an [`ClauseRole::Assertion`]: its clauses are claims and an
+/// unevaluatable one is a failure.
+///
+/// A rule invoked as a gate -- `rule x when some_gate("p") { ... }` -- is a
+/// [`ClauseRole::Gate`]. Its clauses must then SKIP rather than FAIL when they cannot
+/// be evaluated, because a failing gate makes the guarded block inapplicable and
+/// silently drops every check inside it.
 pub(in crate::rules) fn eval_rule<'value, 'loc: 'value>(
     rule: &'value Rule<'loc>,
     resolver: &mut dyn EvalContext<'value, 'loc>,
+    role: ClauseRole,
 ) -> Result<Status> {
     let context = rule.rule_name.to_string();
     resolver.start_record(&context)?;
@@ -1995,7 +2075,9 @@ pub(in crate::rules) fn eval_rule<'value, 'loc: 'value>(
         &rule.block
     };
 
-    match eval_general_block_clause(block, resolver, eval_rule_clause) {
+    match eval_general_block_clause(block, resolver, |rc, r| {
+        eval_rule_clause(rc, r, role)
+    }) {
         Ok(status) => {
             resolver.end_record(
                 &context,
@@ -2039,7 +2121,8 @@ pub(crate) fn eval_rules_file<'value, 'loc: 'value>(
     let mut fails = 0;
     let mut passes = 0;
     for each_rule in &rule.guard_rules {
-        match eval_rule(each_rule, resolver) {
+        // Top-level rule in a rules file: its clauses are assertions.
+        match eval_rule(each_rule, resolver, ClauseRole::Assertion) {
             Ok(status) => match status {
                 Status::PASS => {
                     passes += 1;

--- a/guard/src/rules/eval.rs
+++ b/guard/src/rules/eval.rs
@@ -1959,72 +1959,7 @@ pub(in crate::rules) fn eval_type_block_clause<'value, 'loc: 'value>(
 ) -> Result<Status> {
     let context = format!("TypeBlock#{}", type_block.type_name);
     resolver.start_record(&context)?;
-    let block = if let Some(conditions) = &type_block.conditions {
-        let when_context = format!("TypeBlock#{}/When", type_block.type_name);
-        resolver.start_record(&when_context)?;
-        // Note the scope: the conditions are evaluated against `resolver`, the enclosing scope,
-        // while the block below runs each clause against a per-resource `ValueScope`. So a
-        // condition here is resolved from the file root, not from the resource being checked.
-        // `a_skipped_type_block_says_why_it_was_skipped` covers what that costs an author.
-        match eval_conjunction_clauses(conditions, resolver, eval_when_clause) {
-            Ok(status) => {
-                if status != Status::PASS {
-                    resolver.end_record(&when_context, RecordType::TypeCondition(status))?;
-                    resolver.end_record(
-                        &context,
-                        RecordType::TypeCheck(TypeBlockCheck {
-                            type_name: &type_block.type_name,
-                            block: BlockCheck {
-                                status: Status::SKIP,
-                                at_least_one_matches: false,
-                                // Deliberately None. An explanation belongs here -- this is the
-                                // quietest exit in the evaluator, reporting `not_applicable` and
-                                // exit 0 without naming anything, and the likeliest cause is a
-                                // condition written as though it were resource-relative. But a
-                                // SKIP rule's records never reach a reporter: skipped rules
-                                // contribute only their name, as a `HashSet<String>`, in
-                                // `reporters::validate::common`. A message written here today
-                                // would be recorded and discarded, which is the defect this
-                                // branch just finished removing from five other record variants.
-                                //
-                                // Surfacing it needs the skip set to carry reasons, which changes
-                                // the `report` signature every reporter implements. That is worth
-                                // doing and is not this change.
-                                // `a_skipped_type_block_is_indistinguishable_from_a_clean_run`
-                                // pins the behaviour meanwhile, so whoever does it has a test to
-                                // flip rather than a discovery to repeat.
-                                message: None,
-                            },
-                        }),
-                    )?;
-                    return Ok(Status::SKIP);
-                }
-                resolver.end_record(&when_context, RecordType::TypeCondition(Status::PASS))?;
-                &type_block.block
-            }
-
-            Err(e) => {
-                resolver.end_record(&when_context, RecordType::TypeCondition(Status::FAIL))?;
-                resolver.end_record(
-                    &context,
-                    RecordType::TypeCheck(TypeBlockCheck {
-                        type_name: &type_block.type_name,
-                        block: BlockCheck {
-                            status: Status::FAIL,
-                            message: Some(format!(
-                                "Error {} during type condition evaluation, bailing",
-                                e
-                            )),
-                            at_least_one_matches: false,
-                        },
-                    }),
-                )?;
-                return Err(e);
-            }
-        }
-    } else {
-        &type_block.block
-    };
+    let block = &type_block.block;
 
     let values = match resolver.query(&type_block.query) {
         Ok(values) => values,
@@ -2070,6 +2005,73 @@ pub(in crate::rules) fn eval_type_block_clause<'value, 'loc: 'value>(
                     root: Rc::clone(rv),
                     parent: resolver,
                 };
+
+                // Conditions are evaluated per resource, against the same scope as the clauses
+                // they guard.
+                //
+                // They used to be evaluated once, before this loop, against the enclosing
+                // resolver -- so a condition resolved from the file root while the block's
+                // clauses resolved from each resource. That split made the natural spelling a
+                // trap: `AWS::EC2::Volume when Properties.Size > 10 { ... }` reads as "every
+                // volume over 10 GiB must ..." and instead looked for `Properties` at the file
+                // root, found nothing, and skipped every template it was ever run against --
+                // reporting `not_applicable` at exit 0, including for the templates it was
+                // written to catch.
+                //
+                // The cost is the mirror image, and it is real: a condition written as a literal
+                // root-anchored path (`when Resources.A.Properties.Size > 10`) resolved before
+                // and does not now, because `ValueScope::query` starts at the resource. Accepted
+                // for two reasons. A condition over one named resource does not belong on a
+                // block that iterates all of them, and the variable idiom that real rulesets use
+                // is unaffected -- `ValueScope::resolve_variable` delegates to the parent, so
+                // `let vols = ...` followed by `when %vols !empty` still resolves at the root.
+                // `a_type_block_condition_is_evaluated_against_each_resource` asserts all three
+                // spellings so the trade is visible rather than inferred.
+                if let Some(conditions) = &type_block.conditions {
+                    let when_context = format!("{}/When", block_context);
+                    val_resolver.start_record(&when_context)?;
+                    match eval_conjunction_clauses(conditions, &mut val_resolver, eval_when_clause)
+                    {
+                        Ok(status) => {
+                            val_resolver
+                                .end_record(&when_context, RecordType::TypeCondition(status))?;
+                            if status != Status::PASS {
+                                // Not applicable to this resource, so it contributes to neither
+                                // count. If that holds for every resource the fold below answers
+                                // SKIP, which is the honest answer: the block applied to nothing.
+                                val_resolver.end_record(
+                                    &block_context,
+                                    RecordType::TypeBlock(Status::SKIP),
+                                )?;
+                                continue;
+                            }
+                        }
+
+                        Err(e) => {
+                            val_resolver.end_record(
+                                &when_context,
+                                RecordType::TypeCondition(Status::FAIL),
+                            )?;
+                            val_resolver
+                                .end_record(&block_context, RecordType::TypeBlock(Status::FAIL))?;
+                            val_resolver.end_record(
+                                &context,
+                                RecordType::TypeCheck(TypeBlockCheck {
+                                    type_name: &type_block.type_name,
+                                    block: BlockCheck {
+                                        status: Status::FAIL,
+                                        message: Some(format!(
+                                            "Error {} during type condition evaluation, bailing",
+                                            e
+                                        )),
+                                        at_least_one_matches: false,
+                                    },
+                                }),
+                            )?;
+                            return Err(e);
+                        }
+                    }
+                }
 
                 match eval_general_block_clause(block, &mut val_resolver, |gc, r| {
                     eval_guard_clause(gc, r, role)

--- a/guard/src/rules/eval.rs
+++ b/guard/src/rules/eval.rs
@@ -1962,6 +1962,10 @@ pub(in crate::rules) fn eval_type_block_clause<'value, 'loc: 'value>(
     let block = if let Some(conditions) = &type_block.conditions {
         let when_context = format!("TypeBlock#{}/When", type_block.type_name);
         resolver.start_record(&when_context)?;
+        // Note the scope: the conditions are evaluated against `resolver`, the enclosing scope,
+        // while the block below runs each clause against a per-resource `ValueScope`. So a
+        // condition here is resolved from the file root, not from the resource being checked.
+        // `a_skipped_type_block_says_why_it_was_skipped` covers what that costs an author.
         match eval_conjunction_clauses(conditions, resolver, eval_when_clause) {
             Ok(status) => {
                 if status != Status::PASS {
@@ -1973,6 +1977,22 @@ pub(in crate::rules) fn eval_type_block_clause<'value, 'loc: 'value>(
                             block: BlockCheck {
                                 status: Status::SKIP,
                                 at_least_one_matches: false,
+                                // Deliberately None. An explanation belongs here -- this is the
+                                // quietest exit in the evaluator, reporting `not_applicable` and
+                                // exit 0 without naming anything, and the likeliest cause is a
+                                // condition written as though it were resource-relative. But a
+                                // SKIP rule's records never reach a reporter: skipped rules
+                                // contribute only their name, as a `HashSet<String>`, in
+                                // `reporters::validate::common`. A message written here today
+                                // would be recorded and discarded, which is the defect this
+                                // branch just finished removing from five other record variants.
+                                //
+                                // Surfacing it needs the skip set to carry reasons, which changes
+                                // the `report` signature every reporter implements. That is worth
+                                // doing and is not this change.
+                                // `a_skipped_type_block_is_indistinguishable_from_a_clean_run`
+                                // pins the behaviour meanwhile, so whoever does it has a test to
+                                // flip rather than a discovery to repeat.
                                 message: None,
                             },
                         }),

--- a/guard/src/rules/eval/operators.rs
+++ b/guard/src/rules/eval/operators.rs
@@ -708,8 +708,9 @@ impl Comparator for (crate::rules::CmpOperator, bool) {
             // Already resolved by this wrapper. The bare CmpOperator comparator only
             // ever yields EmptyRhs, so these cannot arrive here; pass them through
             // unchanged rather than double-inverting.
-            resolved @ (EvalResult::EmptyRhsUnsatisfiable
-            | EvalResult::EmptyRhsVacuouslyTrue) => resolved,
+            resolved @ (EvalResult::EmptyRhsUnsatisfiable | EvalResult::EmptyRhsVacuouslyTrue) => {
+                resolved
+            }
 
             EvalResult::Result(r) => {
                 if self.1 {

--- a/guard/src/rules/eval/operators.rs
+++ b/guard/src/rules/eval/operators.rs
@@ -88,6 +88,17 @@ impl ValueEvalResult {
 #[derive(Clone, Debug)]
 pub(crate) enum EvalResult {
     Skip,
+    /// The left-hand side resolved to values but the right-hand side resolved to
+    /// nothing, so there was no reference to compare against. Only produced by the
+    /// bare `CmpOperator` comparator; the `(CmpOperator, bool)` wrapper resolves it
+    /// using the operator's polarity and never passes it further up.
+    EmptyRhs,
+    /// Empty RHS on a positive comparison (`==`, `IN`): no value can be one of zero
+    /// references, so every left-hand value fails.
+    EmptyRhsUnsatisfiable,
+    /// Empty RHS on a negated comparison (`!=`, `NOT IN`): there is nothing to
+    /// collide with, so the clause holds.
+    EmptyRhsVacuouslyTrue,
     Result(Vec<ValueEvalResult>),
 }
 
@@ -603,8 +614,24 @@ impl Comparator for crate::rules::CmpOperator {
         lhs: &[QueryResult],
         rhs: &[QueryResult],
     ) -> crate::rules::Result<EvalResult> {
-        if lhs.is_empty() || rhs.is_empty() {
+        // An empty LHS means the query selected nothing, so the clause has nothing to
+        // say about this input. That is genuinely inapplicable -- it is what lets one
+        // ruleset run against templates that do not all contain the resource type
+        // being checked (docs/QUERY_AND_FILTERING.md describes this for filters) --
+        // and it stays a SKIP. Checked first so it keeps precedence when both sides
+        // are empty.
+        if lhs.is_empty() {
             return Ok(EvalResult::Skip);
+        }
+
+        // An empty RHS is a different situation that used to share this outcome:
+        // there ARE values on the left to check, but the reference they would be
+        // compared against resolved to nothing. Whether that is a pass or a failure
+        // depends on the polarity of the comparison, so it cannot be answered here
+        // without the not-flag. Report it and let the (CmpOperator, bool) wrapper
+        // below decide.
+        if rhs.is_empty() {
+            return Ok(EvalResult::EmptyRhs);
         }
 
         match self {
@@ -654,6 +681,36 @@ impl Comparator for (crate::rules::CmpOperator, bool) {
         let results = self.0.compare(lhs, rhs)?;
         Ok(match results {
             EvalResult::Skip => EvalResult::Skip,
+
+            // The right-hand side resolved to no values. Polarity decides the answer,
+            // which is why this is resolved here rather than in the bare comparator:
+            //
+            //   positive (`==`, `IN`)      -- "this value must be one of the
+            //     references". With no references, nothing qualifies, so no value can
+            //     satisfy the clause: FAIL. Previously this was a SKIP, which exits 0
+            //     and is why an allowlist that resolved empty reported compliance.
+            //
+            //   negated (`!=`, `NOT IN`)   -- "this value must not be one of the
+            //     references". With no references there is nothing to collide with, so
+            //     the clause is vacuously satisfied: PASS. Failing here would reject
+            //     compliant templates, because a denylist is legitimately empty
+            //     whenever the template contains none of the denied values.
+            //
+            // Both answers are definite, so neither leaves the clause unenforced.
+            EvalResult::EmptyRhs => {
+                if self.1 {
+                    EvalResult::EmptyRhsVacuouslyTrue
+                } else {
+                    EvalResult::EmptyRhsUnsatisfiable
+                }
+            }
+
+            // Already resolved by this wrapper. The bare CmpOperator comparator only
+            // ever yields EmptyRhs, so these cannot arrive here; pass them through
+            // unchanged rather than double-inverting.
+            resolved @ (EvalResult::EmptyRhsUnsatisfiable
+            | EvalResult::EmptyRhsVacuouslyTrue) => resolved,
+
             EvalResult::Result(r) => {
                 if self.1 {
                     EvalResult::Result(

--- a/guard/src/rules/eval_context.rs
+++ b/guard/src/rules/eval_context.rs
@@ -282,7 +282,8 @@ fn check_and_delegate<'value, 'loc: 'value>(
         match super::eval::eval_conjunction_clauses(
             conjunctions,
             eval_context,
-            super::eval::eval_guard_clause,
+            // Filter predicate: a selection test, not an assertion.
+            |gc, r| super::eval::eval_guard_clause(gc, r, super::eval::ClauseRole::Gate),
         ) {
             Ok(status) => {
                 eval_context.end_record(&context, RecordType::Filter(status))?;
@@ -764,7 +765,10 @@ fn query_retrieval_with_converter<'value, 'loc: 'value>(
                     let result = match super::eval::eval_conjunction_clauses(
                         conjunctions,
                         &mut val_resolver,
-                        super::eval::eval_guard_clause,
+                        // A filter predicate selects values; it is a test, not an
+                        // assertion, so an unevaluatable clause makes the filter
+                        // select nothing rather than fail.
+                        |gc, r| super::eval::eval_guard_clause(gc, r, super::eval::ClauseRole::Gate),
                     ) {
                         Ok(status) => {
                             resolver.end_record(&context, RecordType::Filter(status))?;
@@ -799,7 +803,10 @@ fn query_retrieval_with_converter<'value, 'loc: 'value>(
                     match super::eval::eval_conjunction_clauses(
                         conjunctions,
                         &mut val_resolver,
-                        super::eval::eval_guard_clause,
+                        // A filter predicate selects values; it is a test, not an
+                        // assertion, so an unevaluatable clause makes the filter
+                        // select nothing rather than fail.
+                        |gc, r| super::eval::eval_guard_clause(gc, r, super::eval::ClauseRole::Gate),
                     ) {
                         Ok(status) => match status {
                             Status::PASS => query_retrieval_with_converter(
@@ -1102,7 +1109,11 @@ impl<'value, 'loc: 'value> EvalContext<'value, 'loc> for RootScope<'value, 'loc>
 
         let status = 'done: loop {
             for each_rule in rule {
-                let status = super::eval::eval_rule(each_rule, self)?;
+                // Resolving a named rule's status for a reference elsewhere. The
+                // rule's own clauses are assertions; the reference site decides
+                // how to interpret the resulting status.
+                let status =
+                    super::eval::eval_rule(each_rule, self, super::eval::ClauseRole::Assertion)?;
                 if status != SKIP {
                     break 'done status;
                 }

--- a/guard/src/rules/eval_context.rs
+++ b/guard/src/rules/eval_context.rs
@@ -1660,6 +1660,33 @@ pub(crate) fn find_skip_reason(record: &EventRecord<'_>) -> Option<String> {
             } => message.clone(),
             _ => None,
         },
+
+        // A clause that failed *and* explained itself, reached while walking a rule that skipped.
+        //
+        // Only two things record an explanation on a comparison: a reference that resolved to no
+        // values, and operands that cannot be compared. Both mean the clause could not be decided,
+        // as opposed to being decided false -- the ordinary failure arm records `message: None`. So
+        // finding one here says the rule did not apply because a condition was undecidable, which
+        // is a different situation from a condition that was simply not met, and the only one worth
+        // interrupting an operator over.
+        //
+        // This is the quietest wrong answer left in the evaluator. `when ... Size > 10` against a
+        // template carrying `Size: "50"` -- a string, which CloudFormation templates produce
+        // routinely -- cannot be decided, so the condition does not pass, so the rule is reported
+        // as not applicable and its body never runs. Exit 0, nothing named. The rule still does not
+        // enforce, and it cannot be made to from here: both FAIL and SKIP on a condition drop the
+        // block it guards, so telling them apart needs a status that means "could not tell", which
+        // `Status` does not have. Saying so is what is available, and it turns a silent non-check
+        // into a visible one.
+        Some(RecordType::ClauseValueCheck(ClauseCheck::Comparison(ComparisonClauseCheck {
+            status: Status::FAIL,
+            message: Some(explanation),
+            ..
+        }))) => Some(format!(
+            "the rule did not apply because one of its conditions could not be decided: {}",
+            explanation
+        )),
+
         _ => None,
     };
 

--- a/guard/src/rules/eval_context.rs
+++ b/guard/src/rules/eval_context.rs
@@ -2002,15 +2002,20 @@ fn report_all_failed_clauses_for_rules<'value>(
 
             Some(RecordType::BlockGuardCheck(BlockCheck {
                 status: Status::FAIL,
+                message,
                 ..
             })) => {
                 if current.children.is_empty() {
                     clauses.push(ClauseReport::Block(GuardBlockReport {
                         context: current.context.clone(),
                         messages: Messages {
-                            error_message: Some(String::from(
-                                "query for block clause did not retrieve any value",
-                            )),
+                            // The record's own explanation when it carries one. This arm used to
+                            // hardcode the generic sentence below and ignore `message` entirely,
+                            // so a block that had said precisely why it failed was reported as
+                            // though it had merely selected nothing.
+                            error_message: Some(message.clone().unwrap_or_else(|| {
+                                String::from("query for block clause did not retrieve any value")
+                            })),
                             custom_message: None,
                             location: None,
                         },
@@ -2021,32 +2026,87 @@ fn report_all_failed_clauses_for_rules<'value>(
                 }
             }
 
+            // A disjunction records a message only on the error path in `eval_conjunction_clauses`,
+            // where it bails before any disjunct produced a child record. Reported as a block
+            // rather than as an empty `Disjunctions`, for the same reason as the arms below: an
+            // empty list of checks tells the reader nothing, and the message is the only account of
+            // what went wrong.
             Some(RecordType::Disjunction(BlockCheck {
                 status: Status::FAIL,
+                message,
                 ..
             })) => {
+                let nested = report_all_failed_clauses_for_rules(&current.children);
+                if nested.is_empty() {
+                    if let Some(explanation) = message {
+                        clauses.push(ClauseReport::Block(GuardBlockReport {
+                            context: current.context.clone(),
+                            messages: Messages {
+                                error_message: Some(explanation.clone()),
+                                custom_message: None,
+                                location: None,
+                            },
+                            unresolved: None,
+                        }));
+                    }
+                    continue;
+                }
                 clauses.push(ClauseReport::Disjunctions(DisjunctionsReport {
-                    checks: report_all_failed_clauses_for_rules(&current.children),
+                    checks: nested,
                 }));
             }
 
+            // These four recurse into their children for the per-value detail. Each can also carry
+            // a message of its own, and that message used to be discarded: the arm matched with
+            // `..`, ignoring the field, and reported whatever the children produced.
+            //
+            // Nothing is what the children produce when the clause failed *because* there was
+            // nothing to compare. An empty-reference comparison records its explanation here and
+            // has no per-value results by construction, so the report came back empty, the console
+            // printed "Number of non-compliant resources 0", and the structured output carried
+            // "checks": [] with a null error_message -- for a run that had correctly exited 19.
+            //
+            // So: recurse when the children have something to say, and fall back to this record's
+            // own message when they do not. A failing clause now always explains itself somewhere.
             Some(RecordType::GuardClauseBlockCheck(BlockCheck {
                 status: Status::FAIL,
+                message,
                 ..
             }))
-            | Some(RecordType::TypeBlock(Status::FAIL))
             | Some(RecordType::TypeCheck(TypeBlockCheck {
                 block:
                     BlockCheck {
                         status: Status::FAIL,
+                        message,
                         ..
                     },
                 ..
             }))
             | Some(RecordType::WhenCheck(BlockCheck {
                 status: Status::FAIL,
+                message,
                 ..
             })) => {
+                let nested = report_all_failed_clauses_for_rules(&current.children);
+                if nested.is_empty() {
+                    if let Some(explanation) = message {
+                        clauses.push(ClauseReport::Block(GuardBlockReport {
+                            context: current.context.clone(),
+                            messages: Messages {
+                                error_message: Some(explanation.clone()),
+                                custom_message: None,
+                                location: None,
+                            },
+                            unresolved: None,
+                        }));
+                    }
+                } else {
+                    clauses.extend(nested);
+                }
+            }
+
+            // TypeBlock carries a bare Status with no message, so there is nothing to fall back to.
+            Some(RecordType::TypeBlock(Status::FAIL)) => {
                 clauses.extend(report_all_failed_clauses_for_rules(&current.children));
             }
 

--- a/guard/src/rules/eval_context.rs
+++ b/guard/src/rules/eval_context.rs
@@ -422,13 +422,26 @@ fn query_retrieval_with_converter<'value, 'loc: 'value>(
                     if query[query_index].is_variable() {
                         let var = query[query_index].variable().unwrap();
                         let keys = resolver.resolve_variable(var)?;
-                        let keys = if query.len() > query_index + 1 {
+                        // `next_query_index` rather than `query_index + 1` at the recursions
+                        // below, because the `Index` arm *consumes* the part after the variable:
+                        // there it selects which resolved key to use, so the traversal has to
+                        // resume after it.
+                        //
+                        // Advancing by one applied the index a second time, to the value the key
+                        // had just selected. `Resources.%names[0].Type` picked `BucketA` and then
+                        // tried to index into it, so the query resolved to nothing and every part
+                        // after `[0]` was discarded -- silently, since an unresolved query is
+                        // reported as a retrieval failure rather than as a malformed rule. The
+                        // form without an index, `Resources.%names.Type`, always worked, which is
+                        // why this survived. Pinned by
+                        // `an_index_after_an_interpolated_key_is_not_applied_twice`.
+                        let (keys, next_query_index) = if query.len() > query_index + 1 {
                             match &query[query_index+1] {
-                                    QueryPart::AllIndices(_) | QueryPart::Key(_) => keys,
+                                    QueryPart::AllIndices(_) | QueryPart::Key(_) => (keys, query_index + 1),
                                     QueryPart::Index(index) => {
                                         let check = if *index >= 0 { *index } else { -*index } as usize;
                                         if check < keys.len() {
-                                            vec![keys[check].clone()]
+                                            (vec![keys[check].clone()], query_index + 2)
                                         } else {
                                             return to_unresolved_result(
                                                 current,
@@ -444,7 +457,7 @@ fn query_retrieval_with_converter<'value, 'loc: 'value>(
                                                 query[1], current.type_info(), SliceDisplay(query))))
                                 }
                         } else {
-                            keys
+                            (keys, query_index + 1)
                         };
 
                         let mut acc = Vec::with_capacity(keys.len());
@@ -465,7 +478,7 @@ fn query_retrieval_with_converter<'value, 'loc: 'value>(
                                     if let PathAwareValue::String((_, k)) = &*key {
                                         if let Some(next) = map.values.get(k) {
                                             acc.extend(query_retrieval_with_converter(
-                                                query_index + 1,
+                                                next_query_index,
                                                 query,
                                                 Rc::new(next.clone()),
                                                 resolver,
@@ -485,7 +498,7 @@ fn query_retrieval_with_converter<'value, 'loc: 'value>(
                                             match &each_key {
                                                     PathAwareValue::String((path, key_to_match)) => {
                                                         if let Some(next) = map.values.get(key_to_match) {
-                                                            acc.extend(query_retrieval_with_converter(query_index + 1, query, Rc::new(next.clone()), resolver, converter)?);
+                                                            acc.extend(query_retrieval_with_converter(next_query_index, query, Rc::new(next.clone()), resolver, converter)?);
                                                         } else {
                                                             acc.extend(
                                                                 to_unresolved_result(

--- a/guard/src/rules/eval_context.rs
+++ b/guard/src/rules/eval_context.rs
@@ -22,7 +22,7 @@ use crate::rules::{
 use cruet::case::{camel, class, kebab, pascal, snake, title, train};
 use lazy_static::lazy_static;
 use serde::{Deserialize, Serialize};
-use std::collections::{BTreeSet, HashMap};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::convert::TryFrom;
 use std::rc::Rc;
 use std::vec::Vec;
@@ -1628,6 +1628,44 @@ pub(crate) struct Messages {
     pub(crate) location: Option<Location>,
 }
 
+/// The explanation for a rule that did not apply, if the evaluator recorded one.
+///
+/// A skipped rule reaches the reporters as a name and nothing else, which is why explanations
+/// written onto skip records used to be constructed and discarded -- the same defect that had five
+/// message-bearing record variants rendering nothing. Walking the rule's own subtree is what makes
+/// the message reachable, so a message may now be added to any of the block-shaped records below
+/// and it will surface.
+///
+/// The first explanation found wins rather than all of them being concatenated. A rule that skips
+/// usually skips for one reason, and a reporter line that grows without bound with nesting depth is
+/// worse than a slightly incomplete one.
+pub(crate) fn find_skip_reason(record: &EventRecord<'_>) -> Option<String> {
+    let own = match &record.container {
+        Some(RecordType::TypeCheck(TypeBlockCheck { block, .. })) => match block {
+            BlockCheck {
+                status: Status::SKIP,
+                message,
+                ..
+            } => message.clone(),
+            _ => None,
+        },
+        Some(RecordType::GuardClauseBlockCheck(block))
+        | Some(RecordType::WhenCheck(block))
+        | Some(RecordType::BlockGuardCheck(block))
+        | Some(RecordType::Disjunction(block)) => match block {
+            BlockCheck {
+                status: Status::SKIP,
+                message,
+                ..
+            } => message.clone(),
+            _ => None,
+        },
+        _ => None,
+    };
+
+    own.or_else(|| record.children.iter().find_map(find_skip_reason))
+}
+
 pub(crate) type Metadata = HashMap<String, String>;
 
 #[derive(Clone, Debug, Serialize, Default)]
@@ -1638,6 +1676,11 @@ pub(crate) struct FileReport<'value> {
     #[serde(with = "serde_yaml::with::singleton_map_recursive")]
     pub(crate) not_compliant: Vec<ClauseReport<'value>>,
     pub(crate) not_applicable: BTreeSet<String>,
+    /// Why each inapplicable rule did not apply, for the ones where the evaluator knows something
+    /// a bare "not applicable" does not convey. Omitted when empty, so a run with nothing to
+    /// explain serialises to exactly the document consumers parse today.
+    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
+    pub(crate) not_applicable_reasons: BTreeMap<String, String>,
     pub(crate) compliant: BTreeSet<String>,
 }
 
@@ -1651,6 +1694,8 @@ impl<'value> FileReport<'value> {
         self.not_compliant.extend(report.not_compliant);
         self.compliant.extend(report.compliant);
         self.not_applicable.extend(report.not_applicable);
+        self.not_applicable_reasons
+            .extend(report.not_applicable_reasons);
     }
 }
 
@@ -2481,6 +2526,7 @@ pub(crate) fn simplified_json_from_root<'value>(
         Some(RecordType::FileCheck(NamedStatus { name, status, .. })) => {
             let mut pass: BTreeSet<String> = BTreeSet::new();
             let mut skip: BTreeSet<String> = BTreeSet::new();
+            let mut skip_reasons: BTreeMap<String, String> = BTreeMap::new();
             for each in &root.children {
                 if let Some(RecordType::RuleCheck(NamedStatus { status, name, .. })) =
                     &each.container
@@ -2491,6 +2537,9 @@ pub(crate) fn simplified_json_from_root<'value>(
                         }
                         SKIP => {
                             skip.insert(name.to_string());
+                            if let Some(reason) = find_skip_reason(each) {
+                                skip_reasons.insert(name.to_string(), reason);
+                            }
                         }
                         _ => {}
                     }
@@ -2501,6 +2550,7 @@ pub(crate) fn simplified_json_from_root<'value>(
                 name,
                 not_compliant: report_all_failed_clauses_for_rules(&root.children),
                 not_applicable: skip,
+                not_applicable_reasons: skip_reasons,
                 compliant: pass,
                 ..Default::default()
             }

--- a/guard/src/rules/eval_context.rs
+++ b/guard/src/rules/eval_context.rs
@@ -768,7 +768,9 @@ fn query_retrieval_with_converter<'value, 'loc: 'value>(
                         // A filter predicate selects values; it is a test, not an
                         // assertion, so an unevaluatable clause makes the filter
                         // select nothing rather than fail.
-                        |gc, r| super::eval::eval_guard_clause(gc, r, super::eval::ClauseRole::Gate),
+                        |gc, r| {
+                            super::eval::eval_guard_clause(gc, r, super::eval::ClauseRole::Gate)
+                        },
                     ) {
                         Ok(status) => {
                             resolver.end_record(&context, RecordType::Filter(status))?;
@@ -806,7 +808,9 @@ fn query_retrieval_with_converter<'value, 'loc: 'value>(
                         // A filter predicate selects values; it is a test, not an
                         // assertion, so an unevaluatable clause makes the filter
                         // select nothing rather than fail.
-                        |gc, r| super::eval::eval_guard_clause(gc, r, super::eval::ClauseRole::Gate),
+                        |gc, r| {
+                            super::eval::eval_guard_clause(gc, r, super::eval::ClauseRole::Gate)
+                        },
                     ) {
                         Ok(status) => match status {
                             Status::PASS => query_retrieval_with_converter(

--- a/guard/src/rules/eval_tests.rs
+++ b/guard/src/rules/eval_tests.rs
@@ -4046,6 +4046,143 @@ fn status_combinator() {
 }
 
 //
+// Comparisons whose right-hand side (the reference/allow/deny list) resolves to no
+// values. These used to SKIP, which exits 0, so an allowlist that resolved empty
+// reported compliance for a violating template.
+//
+// The answer depends on polarity, and on whether the clause is a body assertion or a
+// `when` condition. All four combinations are pinned here because getting any one of
+// them wrong reintroduces a wrong PASS or starts failing compliant templates.
+//
+fn status_of(rules: &str, input: &str) -> Result<Status> {
+    let value = PathAwareValue::try_from(input)?;
+    let rules_file = RulesFile::try_from(rules)?;
+    let mut root = root_scope(&rules_file, Rc::new(value));
+    eval_rules_file(&rules_file, &mut root, None)
+}
+
+const ONE_BUCKET: &str = r#"
+{
+    Resources: {
+        bucket: {
+            Type: 'AWS::S3::Bucket',
+            Properties: { BucketName: "PUBLIC-INSECURE" }
+        }
+    }
+}
+"#;
+
+#[test]
+fn positive_comparison_against_empty_reference_fails() -> Result<()> {
+    // "the name must be one of the approved names", where the approved list is
+    // derived from a resource type absent from this template. Nothing qualifies, so
+    // the clause cannot be satisfied. Before the fix this SKIPped and exited 0.
+    let rules = r###"
+    let approved = Resources.*[ Type == 'AWS::KMS::Key' ].Properties.KeyId
+    rule name_must_be_approved {
+        Resources.*[ Type == 'AWS::S3::Bucket' ].Properties.BucketName IN %approved
+    }
+    "###;
+    assert_eq!(status_of(rules, ONE_BUCKET)?, Status::FAIL);
+    Ok(())
+}
+
+#[test]
+fn negated_comparison_against_empty_reference_does_not_fail() -> Result<()> {
+    // "the name must NOT be one of the denied names", where the denylist is empty.
+    // Nothing to collide with, so the clause is vacuously satisfied and must not
+    // fail: a denylist is legitimately empty whenever the template contains none of
+    // the denied values.
+    //
+    // Asserted as "not FAIL" rather than "is PASS" deliberately. The status is SKIP,
+    // because a vacuous PASS short-circuits a disjunction -- see
+    // vacuous_negated_comparison_does_not_satisfy_a_disjunction below. Both SKIP and
+    // PASS exit 0 for a standalone clause, so what matters here is only that the
+    // clause is non-failing.
+    let rules = r###"
+    let denied = Resources.*[ Type == 'AWS::KMS::Key' ].Properties.KeyId
+    rule name_must_not_be_denied {
+        Resources.*[ Type == 'AWS::S3::Bucket' ].Properties.BucketName != %denied
+    }
+    "###;
+    assert_ne!(status_of(rules, ONE_BUCKET)?, Status::FAIL);
+    Ok(())
+}
+
+#[test]
+fn vacuous_negated_comparison_does_not_satisfy_a_disjunction() -> Result<()> {
+    // Regression test for a wrong PASS found by review.
+    //
+    // eval_conjunction_clauses treats PASS as short-circuiting (`continue
+    // 'conjunction`) but SKIP as absorbing (`=> {}`). Reporting the vacuous
+    // empty-denylist case as PASS therefore satisfied the whole `or` block and
+    // abandoned the sibling disjunct unevaluated, so an unencrypted resource passed
+    // the gate. Base 57bbdbf failed this ruleset correctly; an intermediate version
+    // of this change passed it.
+    //
+    // Disjunct 1 is vacuously satisfied (empty denylist). Disjunct 2 is the real
+    // check and genuinely fails. The rule must fail.
+    let rules = r###"
+    let denied = Resources[ Type == 'AWS::S3::Bucket' ].Properties.BucketName
+    rule gate {
+        Resources.V.Properties.Encrypted != %denied
+        or
+        Resources.V.Properties.Encrypted == true
+    }
+    "###;
+
+    let input = r#"
+    {
+        Resources: {
+            V: {
+                Type: 'AWS::EC2::Volume',
+                Properties: { Encrypted: false }
+            }
+        }
+    }
+    "#;
+
+    assert_eq!(status_of(rules, input)?, Status::FAIL);
+    Ok(())
+}
+
+#[test]
+fn empty_reference_in_a_when_condition_does_not_disarm_the_block() -> Result<()> {
+    // The critical case. If the empty-RHS condition FAILs, the gate is not-PASS and
+    // eval_rule treats that as "rule does not apply", skipping the entire body --
+    // so the real check silently stops running and the file exits 0. The condition
+    // must stay a SKIP so the remaining conditions decide the gate.
+    let rules = r###"
+    let empt = Resources.*[ Type == 'AWS::EC2::Instance' ].Properties.Foo
+    rule gated when Resources.*.Type IN %empt
+                    Resources.*.Type == /S3/ {
+        Resources.*.Properties.BucketName == /^secure-/
+    }
+    "###;
+    // The bucket name violates the body check, so this must not pass.
+    assert_ne!(status_of(rules, ONE_BUCKET)?, Status::PASS);
+    Ok(())
+}
+
+#[test]
+fn literal_lhs_against_empty_reference_does_not_panic() -> Result<()> {
+    // A `let` literal on the left resolves to QueryResult::Literal, which three
+    // reporters treat as unreachable inside a comparison record. Emitting a status
+    // rather than a per-value comparison keeps this off that path.
+    let rules = r###"
+    let lit = "foo"
+    let empt = Resources.*[ Type == 'AWS::EC2::Instance' ].Properties.Missing
+    rule literal_lhs {
+        %lit IN %empt
+    }
+    "###;
+    // Must produce a verdict rather than panicking.
+    let status = status_of(rules, ONE_BUCKET)?;
+    assert_eq!(status, Status::FAIL);
+    Ok(())
+}
+
+//
 // Clause-level negation on a BINARY comparison.
 //
 // `not <query> == <value>` parses (parser.rs:969 accepts a leading not before the
@@ -4094,48 +4231,6 @@ fn negated_binary_clause_is_honored() -> Result<()> {
     // Encrypted: true satisfies the intent -> PASS.
     // Before the fix this returned FAIL.
     assert_eq!(eval_single_rule(negated, encrypted_true)?, Status::PASS);
-// `not <rule>` where the dependent rule SKIPped.
-//
-// In a rule BODY this is an assertion, and a SKIPped rule is not evidence, so it
-// must not report compliance. It previously returned PASS -- and because the
-// enclosing rule then reported PASS rather than SKIP, the output gave no hint that
-// the check had never run.
-//
-// In a `when` CONDITION the same shape is intentional ("apply this rule when that
-// other rule did not apply") and is covered by cross_rule_clause_when_checks, so
-// that behavior is deliberately preserved here.
-//
-#[test]
-fn negated_reference_to_skipped_rule_does_not_pass_in_rule_body() -> Result<()> {
-    // `inner` SKIPs: its query filters on a resource type absent from the input.
-    let rules = r###"
-    rule inner {
-        Resources.*[ Type == 'AWS::KMS::Key' ].Properties.KeyId exists
-    }
-
-    rule deny when Resources.*.Type exists {
-        not inner
-    }
-    "###;
-
-    let input = r#"
-    {
-        Resources: {
-            bucket: {
-                Type: 'AWS::S3::Bucket',
-                Properties: { BucketName: "b" }
-            }
-        }
-    }
-    "#;
-
-    let resources = PathAwareValue::try_from(input)?;
-    let rules_file = RulesFile::try_from(rules)?;
-    let mut root = root_scope(&rules_file, Rc::new(resources));
-    let status = eval_rules_file(&rules_file, &mut root, None)?;
-
-    // Before the fix this was PASS, manufactured from a check that never ran.
-    assert_ne!(status, Status::PASS);
 
     Ok(())
 }
@@ -4198,6 +4293,58 @@ fn negation_composes_with_operator_not_flag() -> Result<()> {
     }
     "###;
     assert_eq!(eval_single_rule(op_only, encrypted_false)?, Status::FAIL);
+
+    Ok(())
+}
+
+//
+// `not <rule>` where the dependent rule SKIPped.
+//
+// In a rule BODY this is an assertion, and a SKIPped rule is not evidence, so it
+// must not report compliance. It previously returned PASS -- and because the
+// enclosing rule then reported PASS rather than SKIP, the output gave no hint that
+// the check had never run.
+//
+// In a `when` CONDITION the same shape is intentional ("apply this rule when that
+// other rule did not apply") and is covered by cross_rule_clause_when_checks, so
+// that behavior is deliberately preserved here.
+//
+#[test]
+fn negated_reference_to_skipped_rule_does_not_pass_in_rule_body() -> Result<()> {
+    // `inner` SKIPs: its query filters on a resource type absent from the input.
+    let rules = r###"
+    rule inner {
+        Resources.*[ Type == 'AWS::KMS::Key' ].Properties.KeyId exists
+    }
+
+    rule deny when Resources.*.Type exists {
+        not inner
+    }
+    "###;
+
+    let input = r#"
+    {
+        Resources: {
+            bucket: {
+                Type: 'AWS::S3::Bucket',
+                Properties: { BucketName: "b" }
+            }
+        }
+    }
+    "#;
+
+    let resources = PathAwareValue::try_from(input)?;
+    let rules_file = RulesFile::try_from(rules)?;
+    let mut root = root_scope(&rules_file, Rc::new(resources));
+    let status = eval_rules_file(&rules_file, &mut root, None)?;
+
+    // Before the fix this was PASS, manufactured from a check that never ran.
+    assert_ne!(status, Status::PASS);
+
+    Ok(())
+}
+
+#[test]
 fn negated_reference_to_skipped_rule_still_gates_a_when_condition() -> Result<()> {
     // Same shape, but the negated reference is a `when` condition rather than a body
     // assertion. Gating here is intentional: the guarded block should still run.
@@ -4232,3 +4379,13 @@ fn negated_reference_to_skipped_rule_still_gates_a_when_condition() -> Result<()
 
     Ok(())
 }
+
+//
+// EMPTY / !EMPTY on a boolean.
+//
+// The Bool arm of element_empty_operation used to compute
+// `(*boolean).to_string().is_empty()`, which is never true, so a boolean was never
+// EMPTY and `!empty` on one always passed regardless of its value -- a clause that
+// reads like a check but asserts nothing. It now reports the same incompatible-type
+// error as every other unsupported type.
+//

--- a/guard/src/rules/eval_tests.rs
+++ b/guard/src/rules/eval_tests.rs
@@ -4810,45 +4810,55 @@ fn the_role_reaching_a_leaf_clause_survives_every_nesting() -> Result<()> {
 /// A message written into a record and never rendered is worse than no message: the code reads as
 /// though the failure explains itself, the documentation says it does, and the operator sees
 /// nothing. That is exactly what happened to the empty-reference explanation. It was constructed,
-/// threaded into a `BlockCheck`, asserted in review to be actionable -- and dropped, because
-/// `report_all_failed_clauses_for_rules` matched the block with `..`, ignored the field, and
-/// recursed into children that an empty comparison does not have. The console printed "Number of
-/// non-compliant resources 0" for a run that had correctly exited 19.
+/// stored, and dropped, and the claim that it "names the cause and the remedy" went into
+/// docs/CLAUSES.md and into a review comment before anyone checked the output.
 ///
-/// The fix was per-variant, so this test guards the property rather than any one variant: it counts
-/// the `message: Some(...)` sites in this module and pins the total. Adding one changes the count
-/// and fails here, which is the prompt to check that the new message can actually be rendered. The
-/// variants and their counts are listed so the next person can tell at a glance which reporter path
-/// a new message needs to reach.
-///
-/// Counting source text is crude, and deliberately so. The alternative -- asserting rendered output
-/// for each site -- is not reachable: most of these are `Err(_)` arms for conditions an ordinary
-/// rules file cannot provoke, so there would be nothing to drive them with. A count that must be
-/// consciously updated is worth more than coverage that silently omits the unreachable half.
+/// So this counts the sites rather than trusting the next author to check. The count is taken by
+/// exclusion -- every `message:` field that is not `None`, not a type annotation, and not a
+/// forward of the rule author's own `custom_message` -- because the first version counted the
+/// literal string `message: Some` and undercounted the moment a message was built in a `match`
+/// arm instead. Counting what is left over cannot be fooled by a new spelling.
 #[test]
 fn every_recorded_explanation_has_a_rendering_path() {
     let source = include_str!("eval.rs");
-    let sites = source.matches("message: Some").count();
+    let total = source.matches("message: ").count();
+    // `message: None` is an explicit no-explanation, and `message: Option<...>` is a struct field
+    // or function parameter rather than a construction site.
+    let empty = source.matches("message: None").count();
+    let declarations = source.matches("message: Option").count();
+    // The rule author's own message, which has always rendered. A different feature from the
+    // evaluator explaining its own verdict, and not what this test guards.
+    let custom = source.matches("message: custom_message").count()
+        + source.matches("message: gnc.custom_message").count()
+        + source
+            .matches("message: self.call_rule.named_rule.custom_message")
+            .count();
+    let sites = total - empty - declarations - custom;
 
-    // Site counts by the record variant each lands on, as of this change:
+    // Evaluator-generated explanations, by the record variant each lands on:
     //
     //   ClauseValueCheck        3   leaf value checks; rendered by the clause arms already
     //   GuardClauseBlockCheck   4   rendered: falls back to the message when no children report
     //   BlockGuardCheck         1   rendered: uses the record's message, not a hardcoded sentence
     //   WhenCheck               2   rendered: same fallback as GuardClauseBlockCheck
-    //   TypeCheck               2   rendered: same fallback
+    //   TypeCheck               6   four failures, plus the two skips below
     //   Disjunction             1   rendered: reported as a block when no disjunct recorded anything
     //
-    // Every variant that can carry a message now has a rendering path. If this total changes,
-    // find the new site, note which variant it records against, and confirm
-    // report_all_failed_clauses_for_rules surfaces it.
-    const SITES_EXPECTED: usize = 13;
+    // The two TypeCheck skips are the newest and were the hardest to render. A skipped rule used
+    // to reach the reporters as a bare name, so a message on a skip record was recorded and
+    // discarded -- this test refused an earlier attempt to add one, which is what it is for.
+    // Skips now carry their reason through `find_skip_reason`, and both are asserted end to end by
+    // `a_skipped_type_block_explains_itself_in_the_output`.
+    //
+    // If this total changes, find the new site, note which variant it records against, and confirm
+    // it reaches rendered output before updating the number.
+    const SITES_EXPECTED: usize = 17;
 
     assert_eq!(
         sites, SITES_EXPECTED,
         "the number of recorded explanations in eval.rs changed from {SITES_EXPECTED} to {sites}. \
-         A new message needs a rendering path in report_all_failed_clauses_for_rules, or it will \
-         be recorded and silently discarded; update the table above once you have checked."
+         A new message needs a rendering path, or it will be recorded and silently discarded; \
+         update the table above once you have checked that it reaches the output."
     );
 }
 

--- a/guard/src/rules/eval_tests.rs
+++ b/guard/src/rules/eval_tests.rs
@@ -4164,25 +4164,44 @@ fn an_empty_reference_can_be_guarded_with_a_when_not_empty_gate() -> Result<()> 
     Ok(())
 }
 
-/// Failing closed must not disarm a block when the clause is a `when` condition itself.
+/// Why the empty-reference arms stay a SKIP for a `when` condition instead of failing closed
+/// like an assertion.
 ///
-/// `eval_rule` reads any non-PASS condition as "this rule does not apply" and drops every
-/// check in the guarded body, so a gate that cannot compare has to stay a SKIP. Failing it
-/// would trade one bypassed clause for an entire unenforced block while still exiting 0 --
-/// strictly worse than the bug being fixed, and the reason this arm is role-aware rather than
-/// an unconditional FAIL.
+/// The condition fold in `eval_conjunction_clauses` absorbs a SKIP but counts a FAIL, and it
+/// answers FAIL before PASS. A gate that cannot compare therefore has to SKIP: failing it
+/// would outrank the sibling conditions that did pass, make the rule inapplicable, and drop a
+/// body those siblings would have enforced -- all at exit 0, which is the same wrong-PASS
+/// shape this branch exists to close.
+///
+/// Two ANDed conditions here. The first compares against an empty reference and cannot be
+/// evaluated; the second passes. With the SKIP the second decides, the body runs, and its
+/// violation is reported as a FAIL. Under an unconditional FAIL the rule reports SKIP and
+/// nothing is enforced.
+///
+/// This shape is required to observe the difference at all. With a single condition both
+/// statuses are indistinguishable, because `eval_rule` maps every non-PASS condition to a
+/// rule-level SKIP; a disjunction hides it too, since a passing arm short-circuits either
+/// way. An earlier version of this test used one condition and passed no matter which status
+/// the arm returned.
+///
+/// `empty_reference_in_a_when_condition_does_not_disarm_the_block` is the same test for the
+/// positive polarity, which reaches the other empty-reference arm.
 #[test]
-fn failing_closed_on_an_empty_reference_does_not_disarm_a_gate() -> Result<()> {
+fn negated_empty_reference_in_a_when_condition_does_not_disarm_the_block() -> Result<()> {
     let rules = r###"
     let denied = Resources.*[ Type == 'AWS::KMS::Key' ].Properties.KeyId
-    rule name_is_safe when Resources.*[ Type == 'AWS::S3::Bucket' ].Properties.BucketName != %denied {
-        Resources.*[ Type == 'AWS::S3::Bucket' ].Properties.BucketName == 'PUBLIC-INSECURE'
+    rule name_is_approved when Resources.*[ Type == 'AWS::S3::Bucket' ].Properties.BucketName != %denied
+                               Resources.*[ Type == 'AWS::S3::Bucket' ] !empty {
+        Resources.*[ Type == 'AWS::S3::Bucket' ].Properties.BucketName == 'approved-name'
     }
     "###;
 
-    // The gate cannot compare, so it stays SKIP and the rule is inapplicable. A FAIL there
-    // would look identical from the exit code while silently dropping the body.
-    assert_eq!(status_of(rules, ONE_BUCKET)?, Status::SKIP);
+    assert_eq!(
+        status_of(rules, ONE_BUCKET)?,
+        Status::FAIL,
+        "the unevaluatable condition must be absorbed so the passing condition still applies \
+         the rule; a FAIL there reports SKIP and drops the body"
+    );
     Ok(())
 }
 

--- a/guard/src/rules/eval_tests.rs
+++ b/guard/src/rules/eval_tests.rs
@@ -4968,3 +4968,345 @@ fn a_float_valued_gate_condition_still_guards_its_body() -> Result<()> {
 
     Ok(())
 }
+
+/// The comparison operators, pinned across every operand type pairing.
+///
+/// The mixed-numeric defect fixed in `compare_values` was reachable because no test drove the
+/// ordering operators against a type they did not already agree with: `Ge`, `Gt`, `Lt` and `Le` in
+/// `real_binary_operation` had no coverage at all. A grid is the cheap way to keep that from
+/// recurring, and it doubles as the specification -- each cell is one clause evaluated end to end
+/// through `eval_rules_file`.
+///
+/// Read a grid as rows = the value the template puts in `Properties.Size`, columns = `OPS`. What
+/// the grid is really asserting is the absence of a wrong PASS: a cell that says FAIL is saying
+/// this pairing cannot be decided or is genuinely false, and either way the run must not exit 0.
+/// PASS appears only where the comparison is both decidable and true.
+///
+/// Two behaviours are worth naming because they look like typos and are not. A list on the left is
+/// distributed element-wise, so `[1,2,3] < 50` is PASS -- every element is smaller. And an absent
+/// property fails rather than skips, which is the fail-closed behaviour this branch settled on.
+#[test]
+fn the_comparison_matrix_over_operand_types_is_pinned() -> Result<()> {
+    const OPS: [&str; 6] = ["==", "!=", ">", ">=", "<", "<="];
+
+    // (label, what to write for Properties, in template order)
+    const LHS: [(&str, &str); 8] = [
+        ("int", r#""Size": 50"#),
+        ("float", r#""Size": 50.5"#),
+        ("string", r#""Size": "fifty""#),
+        ("list", r#""Size": [1,2,3]"#),
+        ("map", r#""Size": {"a":1}"#),
+        ("bool", r#""Size": true"#),
+        ("null", r#""Size": null"#),
+        ("missing", ""),
+    ];
+
+    // (right-hand side as written in the rule, one row per LHS above, cells in OPS order)
+    const GRIDS: [(&str, [&str; 8]); 6] = [
+        (
+            "50",
+            [
+                "PASS FAIL FAIL PASS FAIL PASS", // int 50 vs 50
+                "FAIL PASS PASS PASS FAIL FAIL", // float 50.5 vs 50
+                "FAIL FAIL FAIL FAIL FAIL FAIL", // string
+                "FAIL PASS FAIL FAIL PASS PASS", // list, element-wise
+                "FAIL FAIL FAIL FAIL FAIL FAIL", // map
+                "FAIL FAIL FAIL FAIL FAIL FAIL", // bool
+                "FAIL FAIL FAIL FAIL FAIL FAIL", // null
+                "FAIL FAIL FAIL FAIL FAIL FAIL", // missing property
+            ],
+        ),
+        (
+            "10",
+            [
+                "FAIL PASS PASS PASS FAIL FAIL", // int 50 vs 10
+                "FAIL PASS PASS PASS FAIL FAIL", // float 50.5 vs 10
+                "FAIL FAIL FAIL FAIL FAIL FAIL",
+                "FAIL PASS FAIL FAIL PASS PASS",
+                "FAIL FAIL FAIL FAIL FAIL FAIL",
+                "FAIL FAIL FAIL FAIL FAIL FAIL",
+                "FAIL FAIL FAIL FAIL FAIL FAIL",
+                "FAIL FAIL FAIL FAIL FAIL FAIL",
+            ],
+        ),
+        (
+            "10.5",
+            [
+                "FAIL PASS PASS PASS FAIL FAIL", // int 50 vs float 10.5
+                "FAIL PASS PASS PASS FAIL FAIL", // float 50.5 vs float 10.5
+                "FAIL FAIL FAIL FAIL FAIL FAIL",
+                "FAIL PASS FAIL FAIL PASS PASS",
+                "FAIL FAIL FAIL FAIL FAIL FAIL",
+                "FAIL FAIL FAIL FAIL FAIL FAIL",
+                "FAIL FAIL FAIL FAIL FAIL FAIL",
+                "FAIL FAIL FAIL FAIL FAIL FAIL",
+            ],
+        ),
+        (
+            "'fifty'",
+            [
+                "FAIL FAIL FAIL FAIL FAIL FAIL", // int vs string: not comparable, fails closed
+                "FAIL FAIL FAIL FAIL FAIL FAIL",
+                "PASS FAIL FAIL PASS FAIL PASS", // string vs equal string
+                "FAIL FAIL FAIL FAIL FAIL FAIL",
+                "FAIL FAIL FAIL FAIL FAIL FAIL",
+                "FAIL FAIL FAIL FAIL FAIL FAIL",
+                "FAIL FAIL FAIL FAIL FAIL FAIL",
+                "FAIL FAIL FAIL FAIL FAIL FAIL",
+            ],
+        ),
+        (
+            "[1,2,3]",
+            [
+                "FAIL FAIL PASS PASS FAIL FAIL", // 50 exceeds every element
+                "FAIL FAIL PASS PASS FAIL FAIL",
+                "FAIL FAIL FAIL FAIL FAIL FAIL",
+                "PASS FAIL FAIL FAIL FAIL FAIL", // identical lists
+                "FAIL FAIL FAIL FAIL FAIL FAIL",
+                "FAIL FAIL FAIL FAIL FAIL FAIL",
+                "FAIL FAIL FAIL FAIL FAIL FAIL",
+                "FAIL FAIL FAIL FAIL FAIL FAIL",
+            ],
+        ),
+        (
+            "true",
+            [
+                "FAIL FAIL FAIL FAIL FAIL FAIL",
+                "FAIL FAIL FAIL FAIL FAIL FAIL",
+                "FAIL FAIL FAIL FAIL FAIL FAIL",
+                "FAIL FAIL FAIL FAIL FAIL FAIL",
+                "FAIL FAIL FAIL FAIL FAIL FAIL",
+                "PASS FAIL FAIL FAIL FAIL FAIL", // bools compare for equality, not order
+                "FAIL FAIL FAIL FAIL FAIL FAIL",
+                "FAIL FAIL FAIL FAIL FAIL FAIL",
+            ],
+        ),
+    ];
+
+    let mut cells = 0;
+    for (rhs, rows) in GRIDS {
+        for ((lhs_label, properties), row) in LHS.iter().zip(rows) {
+            let expectations = row.split_whitespace().collect::<Vec<_>>();
+            assert_eq!(
+                expectations.len(),
+                OPS.len(),
+                "grid row for {} vs {} has {} cells, expected {}",
+                lhs_label,
+                rhs,
+                expectations.len(),
+                OPS.len()
+            );
+
+            for (op, expected) in OPS.iter().zip(expectations) {
+                let rules = format!(
+                    "rule r {{\n  Resources.*[ Type == 'AWS::EC2::Volume' ].Properties.Size {} {}\n}}\n",
+                    op, rhs
+                );
+                let input = format!(
+                    r#"{{ "Resources": {{ "V": {{ "Type": "AWS::EC2::Volume", "Properties": {{ {} }} }} }} }}"#,
+                    properties
+                );
+
+                let rules_file = RulesFile::try_from(rules.as_str())?;
+                let resources = PathAwareValue::try_from(input.as_str())?;
+                let mut root = root_scope(&rules_file, Rc::new(resources));
+                let status = eval_rules_file(&rules_file, &mut root, None)?;
+
+                let expected = match expected {
+                    "PASS" => Status::PASS,
+                    "FAIL" => Status::FAIL,
+                    "SKIP" => Status::SKIP,
+                    other => panic!("unknown expectation {} in the grid", other),
+                };
+                assert_eq!(
+                    status, expected,
+                    "Size {} {} with a {} operand: expected {:?}, got {:?}",
+                    op, rhs, lhs_label, expected, status
+                );
+                cells += 1;
+            }
+        }
+    }
+
+    assert_eq!(
+        cells,
+        GRIDS.len() * LHS.len() * OPS.len(),
+        "the grid did not evaluate every cell"
+    );
+
+    Ok(())
+}
+
+/// The type block's status fold, across the resource populations that produce each answer.
+///
+/// `eval_type_block_clause` counts passes and fails over the matched resources and answers
+/// `FAIL` if any failed, else `PASS` if any passed, else `SKIP` -- the same shape as
+/// `eval_conjunction_clauses`, and it absorbs a per-resource SKIP the same way. None of those
+/// arms had a test reaching them, including the one that decides whether a violating resource is
+/// reported at all.
+#[test]
+fn the_type_block_status_fold_is_pinned() -> Result<()> {
+    const RULES: &str = r###"
+    rule r {
+        AWS::EC2::Volume {
+            Properties.Encrypted == true
+        }
+    }
+    "###;
+
+    // (label, resources, expected status)
+    let cases: [(&str, &str, Status); 5] = [
+        (
+            "no resource of that type matches",
+            r#""Q": { "Type": "AWS::SQS::Queue", "Properties": {} }"#,
+            // Nothing to check, so nothing is asserted. SKIP exits 0, which is only safe
+            // because it means the type is genuinely absent from the template.
+            Status::SKIP,
+        ),
+        (
+            "one matching resource, compliant",
+            r#""A": { "Type": "AWS::EC2::Volume", "Properties": { "Encrypted": true } }"#,
+            Status::PASS,
+        ),
+        (
+            "one matching resource, violating",
+            r#""A": { "Type": "AWS::EC2::Volume", "Properties": { "Encrypted": false } }"#,
+            Status::FAIL,
+        ),
+        (
+            "two resources, one violating",
+            r#""A": { "Type": "AWS::EC2::Volume", "Properties": { "Encrypted": true } },
+               "B": { "Type": "AWS::EC2::Volume", "Properties": { "Encrypted": false } }"#,
+            // The fail must outrank the pass. PASS here would report a compliant template
+            // while B goes unencrypted.
+            Status::FAIL,
+        ),
+        (
+            "matching resource, property absent",
+            r#""A": { "Type": "AWS::EC2::Volume", "Properties": { "Size": 50 } }"#,
+            // An absent property is not a pass. This is the fail-closed reading the branch
+            // settled on for queries that resolve to nothing.
+            Status::FAIL,
+        ),
+    ];
+
+    let rules_file = RulesFile::try_from(RULES)?;
+    for (label, resources, expected) in cases {
+        let input = format!(r#"{{ "Resources": {{ {} }} }}"#, resources);
+        let resources = PathAwareValue::try_from(input.as_str())?;
+        let mut root = root_scope(&rules_file, Rc::new(resources));
+        let status = eval_rules_file(&rules_file, &mut root, None)?;
+        assert_eq!(status, expected, "type block with {}", label);
+    }
+
+    Ok(())
+}
+
+/// A type block skipped by its own `when` condition reports nothing about why.
+///
+/// The record carried `message: None`, so this was the quietest exit in the evaluator: status
+/// `not_applicable`, exit 0, no clause named. That matters because of a scoping asymmetry inside
+/// the construct -- the block's clauses are resource-relative, but the `when` conditions are
+/// resolved from the file root (`eval_type_block_clause` evaluates them against the enclosing
+/// resolver, before the per-resource `ValueScope` exists).
+///
+/// So the natural spelling is a trap. `AWS::EC2::Volume when Properties.Size > 10 { ... }` reads
+/// as "every volume over 10 GiB must ..." and instead looks for `Properties` at the file root,
+/// finds nothing, and skips. The rule passes every template it is ever run against, including the
+/// ones it was written to catch. The root-qualified spelling is asserted alongside it, because
+/// that contrast is the whole content of the finding.
+#[test]
+fn a_skipped_type_block_is_indistinguishable_from_a_clean_run() -> Result<()> {
+    const RESOURCES: &str = r#"{
+        "Resources": {
+            "A": { "Type": "AWS::EC2::Volume", "Properties": { "Size": 50, "Encrypted": true } },
+            "B": { "Type": "AWS::EC2::Volume", "Properties": { "Size": 50, "Encrypted": false } }
+        }
+    }"#;
+
+    // Resource-relative condition: does not resolve at the root, so the block is skipped.
+    let resource_relative = r###"
+    rule r {
+        AWS::EC2::Volume when Properties.Size > 10 {
+            Properties.Encrypted == true
+        }
+    }
+    "###;
+
+    // The same intent, qualified from the root, which is where the condition is evaluated.
+    let root_qualified = r###"
+    rule r {
+        AWS::EC2::Volume when Resources.A.Properties.Size > 10 {
+            Properties.Encrypted == true
+        }
+    }
+    "###;
+
+    for (label, rules, expected) in [
+        (
+            "resource-relative condition",
+            resource_relative,
+            Status::SKIP,
+        ),
+        ("root-qualified condition", root_qualified, Status::FAIL),
+    ] {
+        let rules_file = RulesFile::try_from(rules)?;
+        let resources = PathAwareValue::try_from(RESOURCES)?;
+        let mut root = root_scope(&rules_file, Rc::new(resources));
+        let status = eval_rules_file(&rules_file, &mut root, None)?;
+        assert_eq!(
+            status, expected,
+            "type block with a {} against a template holding an unencrypted volume",
+            label
+        );
+    }
+
+    // The skip now carries its reason. Without this the two outcomes above are
+    // indistinguishable to an operator: both exit 0 on the passing template, and the skipping
+    // one exits 0 on the violating template too.
+    let rules_file = RulesFile::try_from(resource_relative)?;
+    let resources = PathAwareValue::try_from(RESOURCES)?;
+    let mut root = root_scope(&rules_file, Rc::new(resources));
+    eval_rules_file(&rules_file, &mut root, None)?;
+    let recorded = root.reset_recorder().extract();
+
+    fn skipped_type_blocks<'a>(record: &'a EventRecord<'a>, out: &mut Vec<Option<String>>) {
+        if let Some(RecordType::TypeCheck(TypeBlockCheck {
+            block:
+                BlockCheck {
+                    status: Status::SKIP,
+                    message,
+                    ..
+                },
+            ..
+        })) = &record.container
+        {
+            out.push(message.clone());
+        }
+        for child in &record.children {
+            skipped_type_blocks(child, out);
+        }
+    }
+
+    let mut skips = vec![];
+    skipped_type_blocks(&recorded, &mut skips);
+    assert_eq!(
+        skips.len(),
+        1,
+        "expected exactly one skipped type block to be recorded, found {:?}",
+        skips
+    );
+
+    // Pinning the gap, not endorsing it. The record carries no explanation, and a reader of the
+    // output cannot tell this run from one where the rule genuinely did not apply. An explanation
+    // cannot simply be added at the record: skipped rules reach the reporters as a set of names,
+    // so the message would be discarded -- the defect this branch removed elsewhere. Whoever
+    // plumbs skip reasons through `report` should flip this assertion.
+    assert!(
+        skips[0].is_none(),
+        "a skipped type block now records an explanation; if it also renders, invert this \
+         assertion and update every_recorded_explanation_has_a_rendering_path"
+    );
+
+    Ok(())
+}

--- a/guard/src/rules/eval_tests.rs
+++ b/guard/src/rules/eval_tests.rs
@@ -959,7 +959,7 @@ fn block_guard_pass() -> Result<()> {
         root: Rc::new(path_value),
         recorder: Some(&mut tracker),
     };
-    let status = eval_guard_clause(&block_clauses, &mut eval)?;
+    let status = eval_guard_clause(&block_clauses, &mut eval, ClauseRole::Assertion)?;
     assert_eq!(status, Status::FAIL);
     let top = tracker.extract();
     match top.container.as_ref() {
@@ -1088,12 +1088,12 @@ fn test_guard_10_compatibility_and_diff() -> Result<()> {
 
     let clause_str = r#"Statement.*.Principal == '*'"#;
     let clause = GuardClause::try_from(clause_str)?;
-    let status = eval_guard_clause(&clause, &mut eval)?;
+    let status = eval_guard_clause(&clause, &mut eval, ClauseRole::Assertion)?;
     assert_eq!(status, Status::FAIL);
 
     let clause_str = r#"SOME Statement.*.Principal == '*'"#;
     let clause = GuardClause::try_from(clause_str)?;
-    let status = eval_guard_clause(&clause, &mut eval)?;
+    let status = eval_guard_clause(&clause, &mut eval, ClauseRole::Assertion)?;
     assert_eq!(status, Status::PASS);
 
     let value_str = r###"
@@ -1109,7 +1109,7 @@ fn test_guard_10_compatibility_and_diff() -> Result<()> {
     //
     // Evaluate the SOME clause again, it must pass with the value as well
     //
-    let status = eval_guard_clause(&clause, &mut eval)?;
+    let status = eval_guard_clause(&clause, &mut eval, ClauseRole::Assertion)?;
     assert_eq!(status, Status::PASS);
 
     Ok(())
@@ -1149,7 +1149,7 @@ fn block_evaluation() -> Result<()> {
         root: Rc::new(value),
         recorder: None,
     };
-    let status = eval_guard_clause(&clause, &mut eval)?;
+    let status = eval_guard_clause(&clause, &mut eval, ClauseRole::Assertion)?;
     assert_eq!(status, Status::PASS);
     Ok(())
 }
@@ -1196,7 +1196,7 @@ fn block_evaluation_fail() -> Result<()> {
     }
     "#;
     let clause = GuardClause::try_from(clause_str)?;
-    let status = eval_guard_clause(&clause, &mut eval)?;
+    let status = eval_guard_clause(&clause, &mut eval, ClauseRole::Assertion)?;
     assert_eq!(status, Status::FAIL);
     Ok(())
 }
@@ -1564,7 +1564,7 @@ fn test_field_type_array_or_single() -> Result<()> {
         root: Rc::new(path_value),
         recorder: None,
     };
-    let status = eval_guard_clause(&clause, &mut eval)?;
+    let status = eval_guard_clause(&clause, &mut eval, ClauseRole::Assertion)?;
     assert_eq!(status, Status::FAIL);
 
     let statements = r#"{
@@ -1580,24 +1580,24 @@ fn test_field_type_array_or_single() -> Result<()> {
         root: Rc::new(path_value),
         recorder: None,
     };
-    let status = eval_guard_clause(&clause, &mut eval)?;
+    let status = eval_guard_clause(&clause, &mut eval, ClauseRole::Assertion)?;
     assert_eq!(status, Status::FAIL);
 
     let clause = GuardClause::try_from(r#"Statement[*].Action[*] != '*'"#)?;
-    let status = eval_guard_clause(&clause, &mut eval)?;
+    let status = eval_guard_clause(&clause, &mut eval, ClauseRole::Assertion)?;
     assert_eq!(status, Status::FAIL);
 
     // Test old format
     let clause = GuardClause::try_from(r#"Statement.*.Action.* != '*'"#)?;
-    let status = eval_guard_clause(&clause, &mut eval)?;
+    let status = eval_guard_clause(&clause, &mut eval, ClauseRole::Assertion)?;
     assert_eq!(status, Status::FAIL);
 
     let clause = GuardClause::try_from(r#"some Statement[*].Action == '*'"#)?;
-    let status = eval_guard_clause(&clause, &mut eval)?;
+    let status = eval_guard_clause(&clause, &mut eval, ClauseRole::Assertion)?;
     assert_eq!(status, Status::PASS);
 
     let clause = GuardClause::try_from(r#"some Statement[*].Action != '*'"#)?;
-    let status = eval_guard_clause(&clause, &mut eval)?;
+    let status = eval_guard_clause(&clause, &mut eval, ClauseRole::Assertion)?;
     assert_eq!(status, Status::FAIL);
 
     Ok(())
@@ -1626,19 +1626,19 @@ fn test_for_in_and_not_in() -> Result<()> {
     let clause = GuardClause::try_from(
         r#"mainSteps[*].action !IN ["aws:updateSsmAgent", "aws:updateAgent"]"#,
     )?;
-    let status = eval_guard_clause(&clause, &mut eval)?;
+    let status = eval_guard_clause(&clause, &mut eval, ClauseRole::Assertion)?;
     assert_eq!(status, Status::FAIL);
 
     let clause = GuardClause::try_from(
         r#"mainSteps[*].action IN ["aws:updateSsmAgent", "aws:updateAgent"]"#,
     )?;
-    let status = eval_guard_clause(&clause, &mut eval)?;
+    let status = eval_guard_clause(&clause, &mut eval, ClauseRole::Assertion)?;
     assert_eq!(status, Status::FAIL);
 
     let clause = GuardClause::try_from(
         r#"some mainSteps[*].action IN ["aws:updateSsmAgent", "aws:updateAgent"]"#,
     )?;
-    let status = eval_guard_clause(&clause, &mut eval)?;
+    let status = eval_guard_clause(&clause, &mut eval, ClauseRole::Assertion)?;
     assert_eq!(status, Status::PASS);
 
     Ok(())
@@ -1666,7 +1666,7 @@ fn test_rule_with_range_test_and_this() -> Result<()> {
         root: Rc::new(value),
         recorder: None,
     };
-    let status = eval_rule(&rule, &mut eval)?;
+    let status = eval_rule(&rule, &mut eval, ClauseRole::Assertion)?;
     assert_eq!(status, Status::PASS);
 
     let value_str = r#"
@@ -1682,7 +1682,7 @@ fn test_rule_with_range_test_and_this() -> Result<()> {
         root: Rc::new(value),
         recorder: None,
     };
-    let status = eval_rule(&rule, &mut eval)?;
+    let status = eval_rule(&rule, &mut eval, ClauseRole::Assertion)?;
     assert_eq!(status, Status::FAIL);
 
     Ok(())
@@ -1733,7 +1733,7 @@ fn test_inner_when_skipped() -> Result<()> {
         root: Rc::new(value),
         recorder: None,
     };
-    let status = eval_rule(&rule, &mut eval)?;
+    let status = eval_rule(&rule, &mut eval, ClauseRole::Assertion)?;
     assert_eq!(status, Status::FAIL);
 
     let value_str = r#"
@@ -1755,7 +1755,7 @@ fn test_inner_when_skipped() -> Result<()> {
         root: Rc::new(value),
         recorder: None,
     };
-    let status = eval_rule(&rule, &mut eval)?;
+    let status = eval_rule(&rule, &mut eval, ClauseRole::Assertion)?;
     assert_eq!(status, Status::SKIP);
 
     let value_str = r#"
@@ -1766,7 +1766,7 @@ fn test_inner_when_skipped() -> Result<()> {
         root: Rc::new(value),
         recorder: None,
     };
-    let status = eval_rule(&rule, &mut eval)?;
+    let status = eval_rule(&rule, &mut eval, ClauseRole::Assertion)?;
     assert_eq!(status, Status::SKIP);
 
     let value_str = r#"{}"#;
@@ -1775,7 +1775,7 @@ fn test_inner_when_skipped() -> Result<()> {
         root: Rc::new(value),
         recorder: None,
     };
-    let status = eval_rule(&rule, &mut eval)?;
+    let status = eval_rule(&rule, &mut eval, ClauseRole::Assertion)?;
     assert_eq!(status, Status::FAIL);
 
     Ok(())
@@ -1867,7 +1867,7 @@ fn test_multiple_valued_clause_reporting() -> Result<()> {
         root: Rc::new(values.clone()),
         recorder: Some(&mut asserter),
     };
-    let status = eval_rule(&rules, &mut root)?;
+    let status = eval_rule(&rules, &mut root, ClauseRole::Assertion)?;
     assert_eq!(status, Status::FAIL);
 
     let rule = r###"
@@ -2222,10 +2222,10 @@ fn test_support_for_atleast_one_match_clause() -> Result<()> {
         recorder: None,
     };
 
-    let status = eval_guard_clause(&clause_some, &mut eval)?;
+    let status = eval_guard_clause(&clause_some, &mut eval, ClauseRole::Assertion)?;
     assert_eq!(status, Status::PASS);
 
-    let status = eval_guard_clause(&clause, &mut eval)?;
+    let status = eval_guard_clause(&clause, &mut eval, ClauseRole::Assertion)?;
     assert_eq!(status, Status::FAIL);
 
     let values_str = r#"{ Tags: [] }"#;
@@ -2234,10 +2234,10 @@ fn test_support_for_atleast_one_match_clause() -> Result<()> {
         root: Rc::new(values),
         recorder: None,
     };
-    let status = eval_guard_clause(&clause_some, &mut eval)?;
+    let status = eval_guard_clause(&clause_some, &mut eval, ClauseRole::Assertion)?;
     assert_eq!(status, Status::FAIL);
 
-    let status = eval_guard_clause(&clause, &mut eval)?;
+    let status = eval_guard_clause(&clause, &mut eval, ClauseRole::Assertion)?;
     assert_eq!(status, Status::FAIL);
 
     let values_str = r#"{ }"#;
@@ -2246,10 +2246,10 @@ fn test_support_for_atleast_one_match_clause() -> Result<()> {
         root: Rc::new(values.clone()),
         recorder: None,
     };
-    let status = eval_guard_clause(&clause_some, &mut eval)?;
+    let status = eval_guard_clause(&clause_some, &mut eval, ClauseRole::Assertion)?;
     assert_eq!(status, Status::FAIL);
 
-    let status = eval_guard_clause(&clause, &mut eval)?;
+    let status = eval_guard_clause(&clause, &mut eval, ClauseRole::Assertion)?;
     assert_eq!(status, Status::FAIL);
 
     //
@@ -2355,7 +2355,7 @@ fn ensure_all_list_value_access_on_empty_fails() -> Result<()> {
         root: Rc::new(values.clone()),
         recorder: None,
     };
-    let status = eval_guard_clause(&claused_failure_spec, &mut eval)?;
+    let status = eval_guard_clause(&claused_failure_spec, &mut eval, ClauseRole::Assertion)?;
     assert_eq!(status, Status::FAIL);
 
     let claused_failure_spec = GuardClause::try_from(r#"some Tags[*].Key == /Name/"#)?;
@@ -2363,7 +2363,7 @@ fn ensure_all_list_value_access_on_empty_fails() -> Result<()> {
         root: Rc::new(values.clone()),
         recorder: None,
     };
-    let status = eval_guard_clause(&claused_failure_spec, &mut eval)?;
+    let status = eval_guard_clause(&claused_failure_spec, &mut eval, ClauseRole::Assertion)?;
     assert_eq!(status, Status::FAIL);
 
     let claused_failure_spec = GuardClause::try_from(r#"Tags[*] { Key == /Name/ }"#)?;
@@ -2371,7 +2371,7 @@ fn ensure_all_list_value_access_on_empty_fails() -> Result<()> {
         root: Rc::new(values.clone()),
         recorder: None,
     };
-    let status = eval_guard_clause(&claused_failure_spec, &mut eval)?;
+    let status = eval_guard_clause(&claused_failure_spec, &mut eval, ClauseRole::Assertion)?;
     assert_eq!(status, Status::FAIL);
 
     let claused_failure_spec = GuardClause::try_from(r#"some Tags[*] { Key == /Name/ }"#)?;
@@ -2379,7 +2379,7 @@ fn ensure_all_list_value_access_on_empty_fails() -> Result<()> {
         root: Rc::new(values.clone()),
         recorder: None,
     };
-    let status = eval_guard_clause(&claused_failure_spec, &mut eval)?;
+    let status = eval_guard_clause(&claused_failure_spec, &mut eval, ClauseRole::Assertion)?;
     assert_eq!(status, Status::FAIL);
 
     let claused_failure_spec = GuardClause::try_from(r#"Tags !empty"#)?;
@@ -2387,7 +2387,7 @@ fn ensure_all_list_value_access_on_empty_fails() -> Result<()> {
         root: Rc::new(values.clone()),
         recorder: None,
     };
-    let status = eval_guard_clause(&claused_failure_spec, &mut eval)?;
+    let status = eval_guard_clause(&claused_failure_spec, &mut eval, ClauseRole::Assertion)?;
     assert_eq!(status, Status::FAIL);
 
     let claused_failure_spec = GuardClause::try_from(r#"Tags empty"#)?;
@@ -2395,7 +2395,7 @@ fn ensure_all_list_value_access_on_empty_fails() -> Result<()> {
         root: Rc::new(values.clone()),
         recorder: None,
     };
-    let status = eval_guard_clause(&claused_failure_spec, &mut eval)?;
+    let status = eval_guard_clause(&claused_failure_spec, &mut eval, ClauseRole::Assertion)?;
     assert_eq!(status, Status::PASS);
 
     let claused_failure_spec = GuardClause::try_from(r#"Tags[*] !empty"#)?;
@@ -2403,7 +2403,7 @@ fn ensure_all_list_value_access_on_empty_fails() -> Result<()> {
         root: Rc::new(values.clone()),
         recorder: None,
     };
-    let status = eval_guard_clause(&claused_failure_spec, &mut eval)?;
+    let status = eval_guard_clause(&claused_failure_spec, &mut eval, ClauseRole::Assertion)?;
     assert_eq!(status, Status::FAIL);
 
     let claused_failure_spec = GuardClause::try_from(r#"Tags[*] empty"#)?;
@@ -2411,7 +2411,7 @@ fn ensure_all_list_value_access_on_empty_fails() -> Result<()> {
         root: Rc::new(values),
         recorder: None,
     };
-    let status = eval_guard_clause(&claused_failure_spec, &mut eval)?;
+    let status = eval_guard_clause(&claused_failure_spec, &mut eval, ClauseRole::Assertion)?;
     assert_eq!(status, Status::PASS);
 
     Ok(())
@@ -2427,15 +2427,15 @@ fn ensure_all_map_values_access_on_empty_fails() -> Result<()> {
     };
 
     let clause_failure_spec = GuardClause::try_from(r#"Resources.*.Properties exists"#)?;
-    let status = eval_guard_clause(&clause_failure_spec, &mut eval)?;
+    let status = eval_guard_clause(&clause_failure_spec, &mut eval, ClauseRole::Assertion)?;
     assert_eq!(status, Status::FAIL);
 
     let clause_failure_spec = GuardClause::try_from(r#"Resources.* { Properties exists }"#)?;
-    let status = eval_guard_clause(&clause_failure_spec, &mut eval)?;
+    let status = eval_guard_clause(&clause_failure_spec, &mut eval, ClauseRole::Assertion)?;
     assert_eq!(status, Status::FAIL);
 
     let clause_failure_spec = GuardClause::try_from(r#"Resources exists"#)?;
-    let status = eval_guard_clause(&clause_failure_spec, &mut eval)?;
+    let status = eval_guard_clause(&clause_failure_spec, &mut eval, ClauseRole::Assertion)?;
     assert_eq!(status, Status::PASS);
 
     //
@@ -2443,7 +2443,7 @@ fn ensure_all_map_values_access_on_empty_fails() -> Result<()> {
     //
     let clause_failure_spec =
         GuardClause::try_from(r#"Resources[ Type == /Bucket/ ].Properties exists"#)?;
-    let status = eval_guard_clause(&clause_failure_spec, &mut eval)?;
+    let status = eval_guard_clause(&clause_failure_spec, &mut eval, ClauseRole::Assertion)?;
     assert_eq!(status, Status::SKIP);
 
     //
@@ -2461,7 +2461,7 @@ fn ensure_all_map_values_access_on_empty_fails() -> Result<()> {
         root: Rc::new(values),
         recorder: None,
     };
-    let status = eval_guard_clause(&clause_failure_spec, &mut eval)?;
+    let status = eval_guard_clause(&clause_failure_spec, &mut eval, ClauseRole::Assertion)?;
     assert_eq!(status, Status::SKIP);
 
     //
@@ -2474,7 +2474,7 @@ fn ensure_all_map_values_access_on_empty_fails() -> Result<()> {
         recorder: None,
     };
     let clause_failure_spec = GuardClause::try_from(r#"Resources exists"#)?;
-    let status = eval_guard_clause(&clause_failure_spec, &mut eval)?;
+    let status = eval_guard_clause(&clause_failure_spec, &mut eval, ClauseRole::Assertion)?;
     assert_eq!(status, Status::FAIL);
 
     Ok(())
@@ -3180,20 +3180,20 @@ fn test_iam_statement_clauses() -> Result<()> {
             this is_struct ][ KEYS == /aws:[sS]ource(Vpc|VPC|Vpce|VPCE)/ ] NOT EMPTY"#;
     // let clause = "Condition.*[ KEYS == /aws:[sS]ource(Vpc|VPC|Vpce|VPCE)/ ]";
     let parsed = GuardClause::try_from(clause)?;
-    let status = eval_guard_clause(&parsed, &mut eval)?;
+    let status = eval_guard_clause(&parsed, &mut eval, ClauseRole::Assertion)?;
     assert_eq!(Status::PASS, status);
 
     let clause = r#"Statement[ Condition EXISTS
                                      Condition.*[ KEYS == /aws:[sS]ource(Vpc|VPC|Vpce|VPCE)/ ] !EMPTY ] NOT EMPTY
     "#;
     let parsed = GuardClause::try_from(clause)?;
-    let status = eval_guard_clause(&parsed, &mut eval)?;
+    let status = eval_guard_clause(&parsed, &mut eval, ClauseRole::Assertion)?;
     assert_eq!(Status::PASS, status);
 
     let parsed = GuardClause::try_from(
         r#"SOME Statement[*].Condition.*[ THIS IS_STRUCT ][ KEYS ==  /aws:[sS]ource(Vpc|VPC|Vpce|VPCE)/ ] NOT EMPTY"#,
     )?;
-    let status = eval_guard_clause(&parsed, &mut eval)?;
+    let status = eval_guard_clause(&parsed, &mut eval, ClauseRole::Assertion)?;
     assert_eq!(Status::PASS, status);
 
     let sample = r#"
@@ -3211,7 +3211,7 @@ fn test_iam_statement_clauses() -> Result<()> {
         root: Rc::new(value),
         recorder: None,
     };
-    let status = eval_guard_clause(&parsed, &mut eval)?;
+    let status = eval_guard_clause(&parsed, &mut eval, ClauseRole::Assertion)?;
     assert_eq!(status, Status::FAIL);
 
     let sample = r#"
@@ -3232,7 +3232,7 @@ fn test_iam_statement_clauses() -> Result<()> {
         root: Rc::new(value),
         recorder: None,
     };
-    let status = eval_guard_clause(&parsed, &mut eval)?;
+    let status = eval_guard_clause(&parsed, &mut eval, ClauseRole::Assertion)?;
     assert_eq!(status, Status::FAIL);
 
     let sample = r#"
@@ -3254,7 +3254,7 @@ fn test_iam_statement_clauses() -> Result<()> {
         root: Rc::new(value),
         recorder: None,
     };
-    let status = eval_guard_clause(&parsed, &mut eval)?;
+    let status = eval_guard_clause(&parsed, &mut eval, ClauseRole::Assertion)?;
     assert_eq!(status, Status::PASS);
 
     let value = PathAwareValue::try_from(SAMPLE)?;
@@ -3263,7 +3263,7 @@ fn test_iam_statement_clauses() -> Result<()> {
         root: Rc::new(value),
         recorder: None,
     };
-    let status = eval_guard_clause(&parsed, &mut eval)?;
+    let status = eval_guard_clause(&parsed, &mut eval, ClauseRole::Assertion)?;
     assert_eq!(Status::FAIL, status);
 
     Ok(())
@@ -3326,7 +3326,7 @@ rule check_rest_api_private {
         root: Rc::new(values),
         recorder: None,
     };
-    let status = eval_rule(&rule, &mut eval)?;
+    let status = eval_rule(&rule, &mut eval, ClauseRole::Assertion)?;
     assert_eq!(status, Status::PASS);
 
     Ok(())
@@ -3391,7 +3391,7 @@ rule check_rest_api_private {
         root: Rc::new(values),
         recorder: None,
     };
-    let status = eval_rule(&rule, &mut eval)?;
+    let status = eval_rule(&rule, &mut eval, ClauseRole::Assertion)?;
     assert_eq!(status, Status::PASS);
 
     let resources = r#"
@@ -3435,7 +3435,7 @@ rule check_rest_api_private {
         root: Rc::new(values),
         recorder: None,
     };
-    let status = eval_rule(&rule, &mut eval)?;
+    let status = eval_rule(&rule, &mut eval, ClauseRole::Assertion)?;
     assert_eq!(status, Status::FAIL);
 
     Ok(())
@@ -3830,7 +3830,7 @@ fn match_lhs_with_rhs_single_element_pass() -> Result<()> {
         root: Rc::new(path_value),
         recorder: None,
     };
-    let status = eval_guard_clause(&guard_clause, &mut eval)?;
+    let status = eval_guard_clause(&guard_clause, &mut eval, ClauseRole::Assertion)?;
     assert_eq!(status, Status::PASS);
 
     let clause = r#"algorithms == ["KMS", "SSE"]"#;
@@ -3841,7 +3841,7 @@ fn match_lhs_with_rhs_single_element_pass() -> Result<()> {
         root: Rc::new(path_value),
         recorder: None,
     };
-    let status = eval_guard_clause(&guard_clause, &mut eval)?;
+    let status = eval_guard_clause(&guard_clause, &mut eval, ClauseRole::Assertion)?;
     assert_eq!(status, Status::FAIL);
 
     Ok(())
@@ -4106,6 +4106,55 @@ fn negated_comparison_against_empty_reference_does_not_fail() -> Result<()> {
     }
     "###;
     assert_ne!(status_of(rules, ONE_BUCKET)?, Status::FAIL);
+    Ok(())
+}
+
+#[test]
+fn parameterized_rule_used_as_a_gate_does_not_disarm_the_block() -> Result<()> {
+    // Regression test for a wrong PASS found by review.
+    //
+    // A parameterized rule invoked from a `when` condition is a gate, so its body
+    // must evaluate with gate semantics. eval_when_clause threaded the role into its
+    // Clause and NamedRule arms but not ParameterizedNamedRule, and everything
+    // downstream defaulted to assertion strictness. The gate therefore FAILed instead
+    // of SKIPping, eval_rule read a non-PASS condition as "rule does not apply", and
+    // the guarded body -- the real check -- was never evaluated. Exit 0 on a
+    // violating template, where base correctly exited 19.
+    //
+    // `inner` SKIPs (its query selects a resource type not present). `gate` is
+    // parameterized and negates it. `must_be_encrypted` is gated on `gate`.
+    let rules = r###"
+    rule inner {
+        Resources.*[ Type == 'AWS::Nonexistent::Thing' ] {
+            Properties.Foo == 'bar'
+        }
+    }
+
+    rule gate(unused) {
+        not inner
+    }
+
+    rule must_be_encrypted when gate("x") {
+        Resources.Bucket.Properties.Encrypted == true
+    }
+    "###;
+
+    let input = r#"
+    {
+        Resources: {
+            Bucket: {
+                Type: 'AWS::S3::Bucket',
+                Properties: { BucketName: "mybucket", Encrypted: false }
+            }
+        }
+    }
+    "#;
+
+    // The gate must open, so the body runs and its violated check fails the rule.
+    // With the role not threaded to the parameterized gate, the gate FAILed, the rule
+    // was treated as inapplicable, and this returned SKIP.
+    assert_eq!(status_of(rules, input)?, Status::FAIL);
+
     Ok(())
 }
 

--- a/guard/src/rules/eval_tests.rs
+++ b/guard/src/rules/eval_tests.rs
@@ -4094,6 +4094,48 @@ fn negated_binary_clause_is_honored() -> Result<()> {
     // Encrypted: true satisfies the intent -> PASS.
     // Before the fix this returned FAIL.
     assert_eq!(eval_single_rule(negated, encrypted_true)?, Status::PASS);
+// `not <rule>` where the dependent rule SKIPped.
+//
+// In a rule BODY this is an assertion, and a SKIPped rule is not evidence, so it
+// must not report compliance. It previously returned PASS -- and because the
+// enclosing rule then reported PASS rather than SKIP, the output gave no hint that
+// the check had never run.
+//
+// In a `when` CONDITION the same shape is intentional ("apply this rule when that
+// other rule did not apply") and is covered by cross_rule_clause_when_checks, so
+// that behavior is deliberately preserved here.
+//
+#[test]
+fn negated_reference_to_skipped_rule_does_not_pass_in_rule_body() -> Result<()> {
+    // `inner` SKIPs: its query filters on a resource type absent from the input.
+    let rules = r###"
+    rule inner {
+        Resources.*[ Type == 'AWS::KMS::Key' ].Properties.KeyId exists
+    }
+
+    rule deny when Resources.*.Type exists {
+        not inner
+    }
+    "###;
+
+    let input = r#"
+    {
+        Resources: {
+            bucket: {
+                Type: 'AWS::S3::Bucket',
+                Properties: { BucketName: "b" }
+            }
+        }
+    }
+    "#;
+
+    let resources = PathAwareValue::try_from(input)?;
+    let rules_file = RulesFile::try_from(rules)?;
+    let mut root = root_scope(&rules_file, Rc::new(resources));
+    let status = eval_rules_file(&rules_file, &mut root, None)?;
+
+    // Before the fix this was PASS, manufactured from a check that never ran.
+    assert_ne!(status, Status::PASS);
 
     Ok(())
 }
@@ -4156,6 +4198,37 @@ fn negation_composes_with_operator_not_flag() -> Result<()> {
     }
     "###;
     assert_eq!(eval_single_rule(op_only, encrypted_false)?, Status::FAIL);
+fn negated_reference_to_skipped_rule_still_gates_a_when_condition() -> Result<()> {
+    // Same shape, but the negated reference is a `when` condition rather than a body
+    // assertion. Gating here is intentional: the guarded block should still run.
+    let rules = r###"
+    rule inner {
+        Resources.*[ Type == 'AWS::KMS::Key' ].Properties.KeyId exists
+    }
+
+    rule gated when not inner {
+        Resources.*.Type exists
+    }
+    "###;
+
+    let input = r#"
+    {
+        Resources: {
+            bucket: {
+                Type: 'AWS::S3::Bucket',
+                Properties: { BucketName: "b" }
+            }
+        }
+    }
+    "#;
+
+    let resources = PathAwareValue::try_from(input)?;
+    let rules_file = RulesFile::try_from(rules)?;
+    let mut root = root_scope(&rules_file, Rc::new(resources));
+    let status = eval_rules_file(&rules_file, &mut root, None)?;
+
+    // The gate opens and the body (`Type exists`) holds, so this passes.
+    assert_eq!(status, Status::PASS);
 
     Ok(())
 }

--- a/guard/src/rules/eval_tests.rs
+++ b/guard/src/rules/eval_tests.rs
@@ -5613,3 +5613,102 @@ fn the_disjunction_context_is_stable_across_compilers() {
         );
     }
 }
+
+/// An index after an interpolated key selects the key; it must not then be applied to the value.
+///
+/// `query_retrieval_with_converter` resolves a variable used where a map key is expected, and peeks
+/// at the following query part: an index there says *which* of the resolved keys to use. Having
+/// consumed it, the recursion advanced by one anyway, so the index was applied a second time -- to
+/// the value the key had just selected. `Resources.%names[0].Type` picked `BucketA` and then tried
+/// to index into it, the query resolved to nothing, and every part after `[0]` was discarded.
+///
+/// It survived because the form without an index always worked, so a reader comparing
+/// `Resources.%names.Type` against `Resources.%names[0].Type` would see one work and assume the
+/// other was a rule-authoring mistake. The failure is also quiet in the wrong way: an unresolved
+/// query is reported as a retrieval failure on the input, not as a query the evaluator could not
+/// walk, so it reads as a problem with the template.
+///
+/// The gate case is asserted last because that is where it costs enforcement rather than just a
+/// wrong verdict: an unresolved condition does not pass, a rule whose condition does not pass is
+/// reported not applicable, and its body never runs. Same shape as the mixed-numeric defect,
+/// reached through the query resolver instead of the comparison.
+#[test]
+fn an_index_after_an_interpolated_key_is_not_applied_twice() -> Result<()> {
+    // `Pointer` names two other resources, so `%names` resolves to the keys "BucketA" and "BucketB".
+    const RESOURCES: &str = r#"{
+        "Resources": {
+            "Pointer": {
+                "Type": "AWS::CloudFormation::Stack",
+                "Properties": { "Targets": ["BucketA", "BucketB"] }
+            },
+            "BucketA": { "Type": "AWS::S3::Bucket", "Properties": { "Name": "a" } },
+            "BucketB": { "Type": "AWS::S3::Bucket", "Properties": { "Name": "b" } }
+        }
+    }"#;
+
+    const PREAMBLE: &str = "let names = Resources.Pointer.Properties.Targets[*]\n";
+
+    let cases: [(&str, &str, Status); 7] = [
+        // Selecting a key by index, then continuing the traversal. All of these resolved to
+        // nothing before the fix, so all of them failed.
+        (
+            "index then a key",
+            r#"rule r { Resources.%names[0].Type == "AWS::S3::Bucket" }"#,
+            Status::PASS,
+        ),
+        (
+            "index then two more keys",
+            r#"rule r { Resources.%names[0].Properties.Name == "a" }"#,
+            Status::PASS,
+        ),
+        (
+            "the second key",
+            r#"rule r { Resources.%names[1].Properties.Name == "b" }"#,
+            Status::PASS,
+        ),
+        // Still able to fail: the fix must not make the query resolve to something that passes
+        // regardless of the value.
+        (
+            "index then a key, wrong value",
+            r#"rule r { Resources.%names[0].Properties.Name == "b" }"#,
+            Status::FAIL,
+        ),
+        // Without an index every resolved key is used, so BucketB's "b" fails the check.
+        (
+            "no index, all keys",
+            r#"rule r { Resources.%names.Properties.Name == "a" }"#,
+            Status::FAIL,
+        ),
+        // An index past the resolved keys is still out of bounds, and still fails closed.
+        (
+            "index out of bounds",
+            r#"rule r { Resources.%names[5].Type == "AWS::S3::Bucket" }"#,
+            Status::FAIL,
+        ),
+        // The same query as a condition. Before the fix this was SKIP: the gate could not be
+        // resolved, so the rule was reported not applicable and the violation below went
+        // unreported at exit 0.
+        (
+            "the same query as a gate",
+            r#"rule r when Resources.%names[0].Type == "AWS::S3::Bucket" {
+                   Resources.BucketA.Properties.Name == "nonsense"
+               }"#,
+            Status::FAIL,
+        ),
+    ];
+
+    for (label, rule, expected) in cases {
+        let rules = format!("{}{}", PREAMBLE, rule);
+        let rules_file = RulesFile::try_from(rules.as_str())?;
+        let resources = PathAwareValue::try_from(RESOURCES)?;
+        let mut root = root_scope(&rules_file, Rc::new(resources));
+        assert_eq!(
+            eval_rules_file(&rules_file, &mut root, None)?,
+            expected,
+            "{}",
+            label
+        );
+    }
+
+    Ok(())
+}

--- a/guard/src/rules/eval_tests.rs
+++ b/guard/src/rules/eval_tests.rs
@@ -4921,3 +4921,50 @@ fn boolean_empty_is_an_incompatible_type() -> Result<()> {
 
     Ok(())
 }
+
+/// A gate that compares against a decimal must still guard its body.
+///
+/// This is the composed form of the mixed-numeric defect fixed in `compare_values`, and it is the
+/// reason that defect mattered more than a wrong FAIL. `Size > 10` against `Size: 50.5` was
+/// NotComparable, `eval_rule` maps any non-PASS condition to `Status::SKIP`, and SKIP exits 0. So
+/// the rule below stopped enforcing encryption entirely -- and it did so silently, with no clause
+/// named in the output -- the moment a template wrote a volume size as `50.5` instead of `50`.
+///
+/// Both fixtures are asserted, because the integer one is what makes the decimal one meaningful:
+/// without it a reader cannot tell whether the rule ever had teeth.
+#[test]
+fn a_float_valued_gate_condition_still_guards_its_body() -> Result<()> {
+    let rules = r###"
+    rule large_volumes_are_encrypted when Resources.*[ Type == 'AWS::EC2::Volume' ].Properties.Size > 10 {
+        Resources.*[ Type == 'AWS::EC2::Volume' ].Properties.Encrypted == true
+    }
+    "###;
+
+    let integer_size = r#"{
+        "Resources": {
+            "V": { "Type": "AWS::EC2::Volume", "Properties": { "Size": 50, "Encrypted": false } }
+        }
+    }"#;
+    let decimal_size = r#"{
+        "Resources": {
+            "V": { "Type": "AWS::EC2::Volume", "Properties": { "Size": 50.5, "Encrypted": false } }
+        }
+    }"#;
+
+    let rules_file = RulesFile::try_from(rules)?;
+    for (label, input) in [("integer", integer_size), ("decimal", decimal_size)] {
+        let resources = PathAwareValue::try_from(input)?;
+        let mut root = root_scope(&rules_file, Rc::new(resources));
+        let status = eval_rules_file(&rules_file, &mut root, None)?;
+
+        assert_eq!(
+            status,
+            Status::FAIL,
+            "the {} template has an unencrypted volume over 10 GiB and must FAIL. SKIP here means \
+             the gate could not evaluate its comparison, dropped the body, and exited 0",
+            label
+        );
+    }
+
+    Ok(())
+}

--- a/guard/src/rules/eval_tests.rs
+++ b/guard/src/rules/eval_tests.rs
@@ -4804,6 +4804,54 @@ fn the_role_reaching_a_leaf_clause_survives_every_nesting() -> Result<()> {
 
     Ok(())
 }
+
+/// Every explanation this module records must have a path to the reader.
+///
+/// A message written into a record and never rendered is worse than no message: the code reads as
+/// though the failure explains itself, the documentation says it does, and the operator sees
+/// nothing. That is exactly what happened to the empty-reference explanation. It was constructed,
+/// threaded into a `BlockCheck`, asserted in review to be actionable -- and dropped, because
+/// `report_all_failed_clauses_for_rules` matched the block with `..`, ignored the field, and
+/// recursed into children that an empty comparison does not have. The console printed "Number of
+/// non-compliant resources 0" for a run that had correctly exited 19.
+///
+/// The fix was per-variant, so this test guards the property rather than any one variant: it counts
+/// the `message: Some(...)` sites in this module and pins the total. Adding one changes the count
+/// and fails here, which is the prompt to check that the new message can actually be rendered. The
+/// variants and their counts are listed so the next person can tell at a glance which reporter path
+/// a new message needs to reach.
+///
+/// Counting source text is crude, and deliberately so. The alternative -- asserting rendered output
+/// for each site -- is not reachable: most of these are `Err(_)` arms for conditions an ordinary
+/// rules file cannot provoke, so there would be nothing to drive them with. A count that must be
+/// consciously updated is worth more than coverage that silently omits the unreachable half.
+#[test]
+fn every_recorded_explanation_has_a_rendering_path() {
+    let source = include_str!("eval.rs");
+    let sites = source.matches("message: Some").count();
+
+    // Site counts by the record variant each lands on, as of this change:
+    //
+    //   ClauseValueCheck        3   leaf value checks; rendered by the clause arms already
+    //   GuardClauseBlockCheck   4   rendered: falls back to the message when no children report
+    //   BlockGuardCheck         1   rendered: uses the record's message, not a hardcoded sentence
+    //   WhenCheck               2   rendered: same fallback as GuardClauseBlockCheck
+    //   TypeCheck               2   rendered: same fallback
+    //   Disjunction             1   rendered: reported as a block when no disjunct recorded anything
+    //
+    // Every variant that can carry a message now has a rendering path. If this total changes,
+    // find the new site, note which variant it records against, and confirm
+    // report_all_failed_clauses_for_rules surfaces it.
+    const SITES_EXPECTED: usize = 13;
+
+    assert_eq!(
+        sites, SITES_EXPECTED,
+        "the number of recorded explanations in eval.rs changed from {SITES_EXPECTED} to {sites}. \
+         A new message needs a rendering path in report_all_failed_clauses_for_rules, or it will \
+         be recorded and silently discarded; update the table above once you have checked."
+    );
+}
+
 /// `EMPTY` and `!EMPTY` on a boolean are an incompatible-type error, not a silent pass.
 ///
 /// The Bool arm of `element_empty_operation` computed `(*boolean).to_string().is_empty()`.

--- a/guard/src/rules/eval_tests.rs
+++ b/guard/src/rules/eval_tests.rs
@@ -4173,7 +4173,7 @@ fn an_empty_reference_can_be_guarded_with_a_when_not_empty_gate() -> Result<()> 
 /// body those siblings would have enforced -- all at exit 0, which is the same wrong-PASS
 /// shape this branch exists to close.
 ///
-/// Two ANDed conditions here. The first compares against an empty reference and cannot be
+/// Two conditions joined by AND here. The first compares against an empty reference and cannot be
 /// evaluated; the second passes. With the SKIP the second decides, the body runs, and its
 /// violation is reported as a FAIL. Under an unconditional FAIL the rule reports SKIP and
 /// nothing is enforced.

--- a/guard/src/rules/eval_tests.rs
+++ b/guard/src/rules/eval_tests.rs
@@ -5202,29 +5202,31 @@ fn the_type_block_status_fold_is_pinned() -> Result<()> {
     Ok(())
 }
 
-/// A type block skipped by its own `when` condition reports nothing about why.
+/// A type block's `when` conditions are evaluated against each resource, not the file root.
 ///
-/// The record carried `message: None`, so this was the quietest exit in the evaluator: status
-/// `not_applicable`, exit 0, no clause named. That matters because of a scoping asymmetry inside
-/// the construct -- the block's clauses are resource-relative, but the `when` conditions are
-/// resolved from the file root (`eval_type_block_clause` evaluates them against the enclosing
-/// resolver, before the per-resource `ValueScope` exists).
+/// The conditions used to be evaluated once, before the loop over matched resources, against the
+/// enclosing resolver -- while the block's clauses were evaluated against each resource. That
+/// split made the natural spelling a trap. `AWS::EC2::Volume when Properties.Size > 10 { ... }`
+/// reads as "every volume over 10 GiB must ..." and instead looked for `Properties` at the file
+/// root, found nothing, and skipped: `not_applicable`, exit 0, for every template it was ever run
+/// against, including the ones it was written to catch.
 ///
-/// So the natural spelling is a trap. `AWS::EC2::Volume when Properties.Size > 10 { ... }` reads
-/// as "every volume over 10 GiB must ..." and instead looks for `Properties` at the file root,
-/// finds nothing, and skips. The rule passes every template it is ever run against, including the
-/// ones it was written to catch. The root-qualified spelling is asserted alongside it, because
-/// that contrast is the whole content of the finding.
+/// All three spellings are asserted because the change has a cost as well as a benefit, and the
+/// cost should be visible in a test rather than inferred from a commit message. A literal
+/// root-anchored path resolved before and does not now. The variable idiom is unaffected, which is
+/// what makes the trade acceptable: `ValueScope::resolve_variable` delegates to the parent, and
+/// real rulesets reach the file root that way rather than by spelling out `Resources.<name>`.
 #[test]
-fn a_skipped_type_block_is_indistinguishable_from_a_clean_run() -> Result<()> {
-    const RESOURCES: &str = r#"{
+fn a_type_block_condition_is_evaluated_against_each_resource() -> Result<()> {
+    // Both volumes are over 10 GiB. B is unencrypted, so any spelling that actually applies the
+    // block must FAIL, and SKIP means the condition never matched anything.
+    const BOTH_LARGE: &str = r#"{
         "Resources": {
             "A": { "Type": "AWS::EC2::Volume", "Properties": { "Size": 50, "Encrypted": true } },
             "B": { "Type": "AWS::EC2::Volume", "Properties": { "Size": 50, "Encrypted": false } }
         }
     }"#;
 
-    // Resource-relative condition: does not resolve at the root, so the block is skipped.
     let resource_relative = r###"
     rule r {
         AWS::EC2::Volume when Properties.Size > 10 {
@@ -5233,8 +5235,16 @@ fn a_skipped_type_block_is_indistinguishable_from_a_clean_run() -> Result<()> {
     }
     "###;
 
-    // The same intent, qualified from the root, which is where the condition is evaluated.
-    let root_qualified = r###"
+    let through_a_variable = r###"
+    let volumes = Resources.*[ Type == 'AWS::EC2::Volume' ]
+    rule r {
+        AWS::EC2::Volume when %volumes !empty {
+            Properties.Encrypted == true
+        }
+    }
+    "###;
+
+    let root_anchored = r###"
     rule r {
         AWS::EC2::Volume when Resources.A.Properties.Size > 10 {
             Properties.Encrypted == true
@@ -5243,70 +5253,61 @@ fn a_skipped_type_block_is_indistinguishable_from_a_clean_run() -> Result<()> {
     "###;
 
     for (label, rules, expected) in [
+        // The spelling that used to skip everything.
         (
-            "resource-relative condition",
+            "a resource-relative condition",
             resource_relative,
-            Status::SKIP,
+            Status::FAIL,
         ),
-        ("root-qualified condition", root_qualified, Status::FAIL),
+        // Unaffected: variables resolve through the parent scope.
+        (
+            "a condition on a variable",
+            through_a_variable,
+            Status::FAIL,
+        ),
+        // The cost of the change. A path anchored at the file root no longer resolves, because
+        // the condition is now evaluated where the clauses are: at the resource.
+        ("a root-anchored literal path", root_anchored, Status::SKIP),
     ] {
         let rules_file = RulesFile::try_from(rules)?;
-        let resources = PathAwareValue::try_from(RESOURCES)?;
+        let resources = PathAwareValue::try_from(BOTH_LARGE)?;
         let mut root = root_scope(&rules_file, Rc::new(resources));
-        let status = eval_rules_file(&rules_file, &mut root, None)?;
         assert_eq!(
-            status, expected,
-            "type block with a {} against a template holding an unencrypted volume",
+            eval_rules_file(&rules_file, &mut root, None)?,
+            expected,
+            "type block with {} over a template holding an unencrypted 50 GiB volume",
             label
         );
     }
 
-    // The skip now carries its reason. Without this the two outcomes above are
-    // indistinguishable to an operator: both exit 0 on the passing template, and the skipping
-    // one exits 0 on the violating template too.
+    // Per-resource applicability is the point of the change, so assert it rather than assuming it
+    // follows. A resource the condition exempts must not shield one it does not.
     let rules_file = RulesFile::try_from(resource_relative)?;
-    let resources = PathAwareValue::try_from(RESOURCES)?;
-    let mut root = root_scope(&rules_file, Rc::new(resources));
-    eval_rules_file(&rules_file, &mut root, None)?;
-    let recorded = root.reset_recorder().extract();
-
-    fn skipped_type_blocks<'a>(record: &'a EventRecord<'a>, out: &mut Vec<Option<String>>) {
-        if let Some(RecordType::TypeCheck(TypeBlockCheck {
-            block:
-                BlockCheck {
-                    status: Status::SKIP,
-                    message,
-                    ..
-                },
-            ..
-        })) = &record.container
-        {
-            out.push(message.clone());
-        }
-        for child in &record.children {
-            skipped_type_blocks(child, out);
-        }
+    for (label, resources, expected) in [
+        (
+            "one exempt resource and one violating",
+            r#""A": { "Type": "AWS::EC2::Volume", "Properties": { "Size": 5, "Encrypted": false } },
+               "B": { "Type": "AWS::EC2::Volume", "Properties": { "Size": 50, "Encrypted": false } }"#,
+            Status::FAIL,
+        ),
+        (
+            "every resource exempt",
+            r#""A": { "Type": "AWS::EC2::Volume", "Properties": { "Size": 5, "Encrypted": false } }"#,
+            // Nothing was asserted, and SKIP says so. A PASS here would claim the unencrypted
+            // volume had been checked.
+            Status::SKIP,
+        ),
+    ] {
+        let input = format!(r#"{{ "Resources": {{ {} }} }}"#, resources);
+        let values = PathAwareValue::try_from(input.as_str())?;
+        let mut root = root_scope(&rules_file, Rc::new(values));
+        assert_eq!(
+            eval_rules_file(&rules_file, &mut root, None)?,
+            expected,
+            "type block over {}",
+            label
+        );
     }
-
-    let mut skips = vec![];
-    skipped_type_blocks(&recorded, &mut skips);
-    assert_eq!(
-        skips.len(),
-        1,
-        "expected exactly one skipped type block to be recorded, found {:?}",
-        skips
-    );
-
-    // Pinning the gap, not endorsing it. The record carries no explanation, and a reader of the
-    // output cannot tell this run from one where the rule genuinely did not apply. An explanation
-    // cannot simply be added at the record: skipped rules reach the reporters as a set of names,
-    // so the message would be discarded -- the defect this branch removed elsewhere. Whoever
-    // plumbs skip reasons through `report` should flip this assertion.
-    assert!(
-        skips[0].is_none(),
-        "a skipped type block now records an explanation; if it also renders, invert this \
-         assertion and update every_recorded_explanation_has_a_rendering_path"
-    );
 
     Ok(())
 }

--- a/guard/src/rules/eval_tests.rs
+++ b/guard/src/rules/eval_tests.rs
@@ -5580,3 +5580,36 @@ fn the_status_decisions_with_no_prior_coverage_are_correct() -> Result<()> {
 
     Ok(())
 }
+
+/// The disjunction context must not carry compiler-version-dependent text.
+///
+/// `std::any::type_name` is documented as being for diagnostics with no stability guarantee, and
+/// this use is not confined to diagnostics: the result goes into a record context that reaches
+/// verbose output, which four golden-file tests compare byte for byte. rustc 1.77.2 renders
+/// `GuardClause<'_>` and later versions render `GuardClause`, so before this was normalised the
+/// suite passed on the pinned toolchain and failed on any newer one -- those four tests had to be
+/// skipped to measure coverage on nightly at all.
+///
+/// Asserting the absence of generic arguments rather than a literal expected string, because the
+/// module path could legitimately change if these types move, and pinning it would turn a rename
+/// into a test failure for no reason. What must not come back is the part that varies by compiler.
+#[test]
+fn the_disjunction_context_is_stable_across_compilers() {
+    for name in [
+        disjunction_type_name::<GuardClause<'_>>(),
+        disjunction_type_name::<RuleClause<'_>>(),
+        disjunction_type_name::<WhenGuardClause<'_>>(),
+    ] {
+        assert!(
+            !name.contains('<') && !name.contains('>'),
+            "the disjunction context still carries generic arguments ({}), which rustc renders \
+             differently between versions",
+            name
+        );
+        assert!(
+            name.ends_with("Clause"),
+            "expected the clause type's name, got {}",
+            name
+        );
+    }
+}

--- a/guard/src/rules/eval_tests.rs
+++ b/guard/src/rules/eval_tests.rs
@@ -5310,3 +5310,157 @@ fn a_skipped_type_block_is_indistinguishable_from_a_clean_run() -> Result<()> {
 
     Ok(())
 }
+
+/// The unary operators, pinned across every value shape they can meet.
+///
+/// `unary_operation` and the `is_*` family had no test that walked them against the full set of
+/// value shapes, which is how the negation arm survived with no coverage at all. The interesting
+/// column is EMPTY: on a container it answers, and on a scalar it is an incompatible-type error
+/// rather than a status, which is the behaviour this branch settled on. An error is the right
+/// answer there because both statuses are wrong -- an int is not empty, but calling it non-empty
+/// implies the question made sense.
+///
+/// Cells are the status for the operator, then the status for its negation. `ERR` means the
+/// evaluation returns an error, so neither polarity produces a status.
+#[test]
+fn the_unary_operator_matrix_over_value_shapes_is_pinned() -> Result<()> {
+    // (label, what to write for Properties)
+    const SHAPES: [(&str, &str); 11] = [
+        ("int", r#""Size": 50"#),
+        ("float", r#""Size": 50.5"#),
+        ("string", r#""Size": "fifty""#),
+        ("empty string", r#""Size": """#),
+        ("list", r#""Size": [1,2,3]"#),
+        ("empty list", r#""Size": []"#),
+        ("map", r#""Size": {"a":1}"#),
+        ("empty map", r#""Size": {}"#),
+        ("bool", r#""Size": true"#),
+        ("null", r#""Size": null"#),
+        ("absent", ""),
+    ];
+
+    // (operator, one cell per SHAPES row, in order)
+    const MATRIX: [(&str, [&str; 11]); 8] = [
+        // int   float  str    ""     list   []     map    {}     bool   null   absent
+        (
+            "EXISTS",
+            [
+                "PASS", "PASS", "PASS", "PASS", "PASS", "PASS", "PASS", "PASS", "PASS", "PASS",
+                "FAIL",
+            ],
+        ),
+        (
+            "EMPTY",
+            [
+                "ERR", "ERR", "FAIL", "PASS", "FAIL", "PASS", "FAIL", "PASS", "ERR", "ERR", "PASS",
+            ],
+        ),
+        (
+            "IS_STRING",
+            [
+                "FAIL", "FAIL", "PASS", "PASS", "FAIL", "FAIL", "FAIL", "FAIL", "FAIL", "FAIL",
+                "FAIL",
+            ],
+        ),
+        (
+            "IS_LIST",
+            [
+                "FAIL", "FAIL", "FAIL", "FAIL", "PASS", "PASS", "FAIL", "FAIL", "FAIL", "FAIL",
+                "FAIL",
+            ],
+        ),
+        (
+            "IS_STRUCT",
+            [
+                "FAIL", "FAIL", "FAIL", "FAIL", "FAIL", "FAIL", "PASS", "PASS", "FAIL", "FAIL",
+                "FAIL",
+            ],
+        ),
+        (
+            "IS_BOOL",
+            [
+                "FAIL", "FAIL", "FAIL", "FAIL", "FAIL", "FAIL", "FAIL", "FAIL", "PASS", "FAIL",
+                "FAIL",
+            ],
+        ),
+        (
+            "IS_INT",
+            [
+                "PASS", "FAIL", "FAIL", "FAIL", "FAIL", "FAIL", "FAIL", "FAIL", "FAIL", "FAIL",
+                "FAIL",
+            ],
+        ),
+        (
+            "IS_FLOAT",
+            [
+                "FAIL", "PASS", "FAIL", "FAIL", "FAIL", "FAIL", "FAIL", "FAIL", "FAIL", "FAIL",
+                "FAIL",
+            ],
+        ),
+    ];
+
+    fn evaluate(clause: &str, properties: &str) -> Result<Option<Status>> {
+        let rules = format!(
+            "rule r {{\n  Resources.*[ Type == 'AWS::EC2::Volume' ].Properties.Size {}\n}}\n",
+            clause
+        );
+        let input = format!(
+            r#"{{ "Resources": {{ "V": {{ "Type": "AWS::EC2::Volume", "Properties": {{ {} }} }} }} }}"#,
+            properties
+        );
+        let rules_file = RulesFile::try_from(rules.as_str())?;
+        let resources = PathAwareValue::try_from(input.as_str())?;
+        let mut root = root_scope(&rules_file, Rc::new(resources));
+        // An incompatible-type operand is an error, not a status, so it is reported as None
+        // rather than swallowed into one of the three statuses.
+        Ok(eval_rules_file(&rules_file, &mut root, None).ok())
+    }
+
+    for (operator, cells) in MATRIX {
+        for ((shape, properties), expected) in SHAPES.iter().zip(cells) {
+            let plain = evaluate(operator, properties)?;
+            let negated = evaluate(&format!("not {}", operator), properties)?;
+
+            match expected {
+                "ERR" => {
+                    assert!(
+                        plain.is_none(),
+                        "{} on a {} operand should be an incompatible-type error, got {:?}",
+                        operator,
+                        shape,
+                        plain
+                    );
+                    assert!(
+                        negated.is_none(),
+                        "not {} on a {} operand should be an incompatible-type error, got {:?}",
+                        operator,
+                        shape,
+                        negated
+                    );
+                }
+                "PASS" | "FAIL" => {
+                    let (want, want_negated) = if expected == "PASS" {
+                        (Status::PASS, Status::FAIL)
+                    } else {
+                        (Status::FAIL, Status::PASS)
+                    };
+                    assert_eq!(plain, Some(want), "{} on a {} operand", operator, shape);
+                    // The negation must invert. A negated operator that answers the same status
+                    // as its positive form is the shape of the role-propagation defect: the
+                    // clause stops discriminating and a violating template can exit 0.
+                    assert_eq!(
+                        negated,
+                        Some(want_negated),
+                        "not {} on a {} operand must invert {} 's answer",
+                        operator,
+                        shape,
+                        operator
+                    );
+                }
+                other => panic!("unknown expectation {} in the matrix", other),
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/guard/src/rules/eval_tests.rs
+++ b/guard/src/rules/eval_tests.rs
@@ -329,7 +329,7 @@ fn query_empty_and_non_empty() -> Result<()> {
             }
         }
 
-        EvaluationResult::EmptyQueryResult(_) => unreachable!(),
+        EvaluationResult::EmptyQueryResult(..) => unreachable!(),
     }
 
     let query = AccessQuery::try_from("Resources.*[ Type == /Broker/ ]")?.query;
@@ -343,7 +343,7 @@ fn query_empty_and_non_empty() -> Result<()> {
     )?;
     match status {
         EvaluationResult::QueryValueResult(_) => unreachable!(),
-        EvaluationResult::EmptyQueryResult(status) => {
+        EvaluationResult::EmptyQueryResult(status, _) => {
             assert_eq!(status, Status::FAIL);
         }
     }
@@ -4087,24 +4087,101 @@ fn positive_comparison_against_empty_reference_fails() -> Result<()> {
     Ok(())
 }
 
+/// A negated comparison whose reference resolved to no values fails as an assertion.
+///
+/// This asserted SKIP until the semantics were settled in review, on the reading that the
+/// clause is vacuously satisfied: there is nothing to collide with, and a denylist is
+/// legitimately empty whenever the template contains none of the denied values.
+///
+/// The reading was rejected because the two error modes are not symmetric. A wrong FAIL is
+/// visible and gets investigated; a wrong SKIP exits 0 and is indistinguishable from PASS in
+/// CI, so a rule whose only check is `Property != %empty_reference` silently enforced nothing.
+/// That is a denylist bypass, and it is the hole this branch exists to close.
+///
+/// The alternative considered was to keep the SKIP and require authors to declare the
+/// expectation with an accompanying `!empty` clause. Rejected: it leaves every existing
+/// ruleset without such a guard silently defeatable, which is the state being fixed.
+///
+/// FAIL specifically, not merely "not SKIP" — a PASS here would short-circuit a disjunction
+/// and abandon its sibling disjuncts, which
+/// `vacuous_negated_comparison_does_not_satisfy_a_disjunction` covers.
 #[test]
-fn negated_comparison_against_empty_reference_does_not_fail() -> Result<()> {
-    // "the name must NOT be one of the denied names", where the denylist is empty.
-    // Nothing to collide with, so the clause is vacuously satisfied and must not
-    // fail: a denylist is legitimately empty whenever the template contains none of
-    // the denied values.
-    //
-    // SKIP specifically, not merely "not FAIL". The distinction is load-bearing: a
-    // PASS here would short-circuit a disjunction and abandon its sibling disjuncts
-    // (see vacuous_negated_comparison_does_not_satisfy_a_disjunction), while a FAIL
-    // would reject compliant templates whose denylist is legitimately empty. Only
-    // SKIP is both non-failing and non-satisfying, so assert it exactly.
+fn negated_comparison_against_empty_reference_fails() -> Result<()> {
     let rules = r###"
     let denied = Resources.*[ Type == 'AWS::KMS::Key' ].Properties.KeyId
     rule name_must_not_be_denied {
         Resources.*[ Type == 'AWS::S3::Bucket' ].Properties.BucketName != %denied
     }
     "###;
+    assert_eq!(status_of(rules, ONE_BUCKET)?, Status::FAIL);
+    Ok(())
+}
+
+/// The escape hatch for a reference that is legitimately allowed to be empty.
+///
+/// Failing closed on an empty reference is only defensible if an author who genuinely expects
+/// one has a way to say so. `when <reference> !empty { ... }` is that way, and it needs no new
+/// machinery: the gate's own `!empty` check fails when the reference resolved to nothing, so
+/// `eval_rule` treats the rule as inapplicable and the guarded comparison never runs.
+///
+/// Asserted rather than assumed. The claim was made in review as the reason failing closed is
+/// safe, and if it were wrong the change would leave no way to express a permissibly-empty
+/// denylist at all.
+#[test]
+fn an_empty_reference_can_be_guarded_with_a_when_not_empty_gate() -> Result<()> {
+    let guarded = r###"
+    let denied = Resources.*[ Type == 'AWS::KMS::Key' ].Properties.KeyId
+    rule name_must_not_be_denied when %denied !empty {
+        Resources.*[ Type == 'AWS::S3::Bucket' ].Properties.BucketName != %denied
+    }
+    "###;
+
+    // The gate closes on the empty reference, so the rule does not apply and the clause that
+    // would otherwise fail never runs.
+    assert_eq!(
+        status_of(guarded, ONE_BUCKET)?,
+        Status::SKIP,
+        "the `when %denied !empty` guard must make the rule inapplicable rather than failing \
+         it -- without this there is no way to express a permissibly-empty reference"
+    );
+
+    // Liveness: with a non-empty reference the gate opens and the comparison decides. Without
+    // this row the assertion above is satisfied by a rule that never ran for any reason.
+    let with_keys = r#"
+    {
+        Resources: {
+            bucket: { Type: 'AWS::S3::Bucket', Properties: { BucketName: "PUBLIC-INSECURE" } },
+            key: { Type: 'AWS::KMS::Key', Properties: { KeyId: "PUBLIC-INSECURE" } }
+        }
+    }
+    "#;
+    assert_eq!(
+        status_of(guarded, with_keys)?,
+        Status::FAIL,
+        "liveness: with a populated reference the gate must open and the collision be caught"
+    );
+
+    Ok(())
+}
+
+/// Failing closed must not disarm a block when the clause is a `when` condition itself.
+///
+/// `eval_rule` reads any non-PASS condition as "this rule does not apply" and drops every
+/// check in the guarded body, so a gate that cannot compare has to stay a SKIP. Failing it
+/// would trade one bypassed clause for an entire unenforced block while still exiting 0 --
+/// strictly worse than the bug being fixed, and the reason this arm is role-aware rather than
+/// an unconditional FAIL.
+#[test]
+fn failing_closed_on_an_empty_reference_does_not_disarm_a_gate() -> Result<()> {
+    let rules = r###"
+    let denied = Resources.*[ Type == 'AWS::KMS::Key' ].Properties.KeyId
+    rule name_is_safe when Resources.*[ Type == 'AWS::S3::Bucket' ].Properties.BucketName != %denied {
+        Resources.*[ Type == 'AWS::S3::Bucket' ].Properties.BucketName == 'PUBLIC-INSECURE'
+    }
+    "###;
+
+    // The gate cannot compare, so it stays SKIP and the rule is inapplicable. A FAIL there
+    // would look identical from the exit code while silently dropping the body.
     assert_eq!(status_of(rules, ONE_BUCKET)?, Status::SKIP);
     Ok(())
 }
@@ -4592,10 +4669,11 @@ fn boolean_empty_is_an_incompatible_type() -> Result<()> {
             let err = match result {
                 Err(e) => e,
                 Ok(status) => panic!(
-                    "`Enabled {comparator}` on the boolean {value} returned {status:?} instead \
-                     of an incompatible-type error. Before this fix `!EMPTY` passed for every \
+                    "`Enabled {}` on the boolean {} returned {:?} instead of an \
+                     incompatible-type error. Before this fix `!EMPTY` passed for every \
                      boolean and `EMPTY` failed for every boolean, in both cases without \
-                     comparing anything."
+                     comparing anything.",
+                    comparator, value, status
                 ),
             };
 
@@ -4603,7 +4681,8 @@ fn boolean_empty_is_an_incompatible_type() -> Result<()> {
             assert!(
                 message.contains("EMPTY"),
                 "expected the incompatible-type error to name the EMPTY operation so the \
-                 author can find the clause, got: {message}"
+                 author can find the clause, got: {}",
+                message
             );
         }
     }

--- a/guard/src/rules/eval_tests.rs
+++ b/guard/src/rules/eval_tests.rs
@@ -4094,18 +4094,63 @@ fn negated_comparison_against_empty_reference_does_not_fail() -> Result<()> {
     // fail: a denylist is legitimately empty whenever the template contains none of
     // the denied values.
     //
-    // Asserted as "not FAIL" rather than "is PASS" deliberately. The status is SKIP,
-    // because a vacuous PASS short-circuits a disjunction -- see
-    // vacuous_negated_comparison_does_not_satisfy_a_disjunction below. Both SKIP and
-    // PASS exit 0 for a standalone clause, so what matters here is only that the
-    // clause is non-failing.
+    // SKIP specifically, not merely "not FAIL". The distinction is load-bearing: a
+    // PASS here would short-circuit a disjunction and abandon its sibling disjuncts
+    // (see vacuous_negated_comparison_does_not_satisfy_a_disjunction), while a FAIL
+    // would reject compliant templates whose denylist is legitimately empty. Only
+    // SKIP is both non-failing and non-satisfying, so assert it exactly.
     let rules = r###"
     let denied = Resources.*[ Type == 'AWS::KMS::Key' ].Properties.KeyId
     rule name_must_not_be_denied {
         Resources.*[ Type == 'AWS::S3::Bucket' ].Properties.BucketName != %denied
     }
     "###;
-    assert_ne!(status_of(rules, ONE_BUCKET)?, Status::FAIL);
+    assert_eq!(status_of(rules, ONE_BUCKET)?, Status::SKIP);
+    Ok(())
+}
+
+#[test]
+fn negation_on_a_parameterized_rule_call_is_honored() -> Result<()> {
+    // `not r(...)` used to behave identically to `r(...)`: the parser stores the
+    // leading `not` on the call, but eval_parameterized_rule_call returned the
+    // invoked rule's status unchanged, discarding it. Same defect class as the
+    // dropped clause-level negation on binary comparisons.
+    //
+    // `inner` PASSes here, so `not inner("x")` must FAIL and `inner("x")` must PASS.
+    // Before the fix both PASSed.
+    let input = r#"
+    {
+        Resources: {
+            bucket: {
+                Type: 'AWS::S3::Bucket',
+                Properties: { BucketName: "b" }
+            }
+        }
+    }
+    "#;
+
+    let negated = r###"
+    rule inner(t) {
+        %t == 'AWS::S3::Bucket'
+    }
+    rule outer {
+        not inner(Resources.bucket.Type)
+    }
+    "###;
+
+    let plain = r###"
+    rule inner(t) {
+        %t == 'AWS::S3::Bucket'
+    }
+    rule outer {
+        inner(Resources.bucket.Type)
+    }
+    "###;
+
+    // The two forms must disagree; that they agreed is what proved the bug.
+    assert_eq!(status_of(negated, input)?, Status::FAIL);
+    assert_eq!(status_of(plain, input)?, Status::PASS);
+
     Ok(())
 }
 
@@ -4208,13 +4253,17 @@ fn empty_reference_in_a_when_condition_does_not_disarm_the_block() -> Result<()>
         Resources.*.Properties.BucketName == /^secure-/
     }
     "###;
-    // The bucket name violates the body check, so this must not pass.
-    assert_ne!(status_of(rules, ONE_BUCKET)?, Status::PASS);
+    // FAIL specifically. "Not PASS" would also admit SKIP, which is the exact
+    // failure mode this test exists to catch: a SKIP here means the gate closed and
+    // the body never ran, which is indistinguishable from a pass at the gate because
+    // both exit 0. Asserting FAIL proves the body actually executed and rejected the
+    // bucket name.
+    assert_eq!(status_of(rules, ONE_BUCKET)?, Status::FAIL);
     Ok(())
 }
 
 #[test]
-fn literal_lhs_against_empty_reference_does_not_panic() -> Result<()> {
+fn literal_lhs_against_empty_reference_fails_without_panicking() -> Result<()> {
     // A `let` literal on the left resolves to QueryResult::Literal, which three
     // reporters treat as unreachable inside a comparison record. Emitting a status
     // rather than a per-value comparison keeps this off that path.
@@ -4387,8 +4436,11 @@ fn negated_reference_to_skipped_rule_does_not_pass_in_rule_body() -> Result<()> 
     let mut root = root_scope(&rules_file, Rc::new(resources));
     let status = eval_rules_file(&rules_file, &mut root, None)?;
 
-    // Before the fix this was PASS, manufactured from a check that never ran.
-    assert_ne!(status, Status::PASS);
+    // FAIL specifically. Before the fix this was PASS, manufactured from a dependent
+    // rule that never ran. "Not PASS" would also admit SKIP, and a SKIP would mean
+    // the negated reference had been made merely inert rather than fail-closed --
+    // still exit 0, so still a gate bypass. FAIL is the property that matters.
+    assert_eq!(status, Status::FAIL);
 
     Ok(())
 }

--- a/guard/src/rules/eval_tests.rs
+++ b/guard/src/rules/eval_tests.rs
@@ -5475,3 +5475,108 @@ fn the_unary_operator_matrix_over_value_shapes_is_pinned() -> Result<()> {
 
     Ok(())
 }
+
+/// The status decisions that a coverage sweep found nothing reaching.
+///
+/// Grouped into one test because they share a purpose rather than a mechanism: each is a line that
+/// decides PASS, FAIL or SKIP and that no test in the suite executed. That is the shape the two
+/// defects in this branch's parent PR had, and the shape the mixed-numeric defect had -- not an
+/// exotic input, just a decision nobody had ever asserted.
+///
+/// None of these turned out to be wrong, which is worth recording as plainly as a bug would be: an
+/// audit that only reports its finds is indistinguishable from one that stopped early.
+#[test]
+fn the_status_decisions_with_no_prior_coverage_are_correct() -> Result<()> {
+    const RESOURCES: &str = r#"{
+        "Resources": { "B": { "Type": "AWS::S3::Bucket", "Properties": { "Name": "b" } } }
+    }"#;
+
+    // A clause-level `not` in front of `EMPTY`, where two negations compose: the operator's own
+    // flag and the clause's. The arm that applies the second had never run in either direction.
+    //
+    // The query has to end in a filter, or be a lone variable, to reach that arm at all.
+    // `unary_operation` handles `EMPTY` on such a query in a separate early-return block, and the
+    // clause-level flip lives inside that block. A first version of this test used
+    // `not Resources.B.Properties.Missing EMPTY`, a plain key path: it produced the right answer
+    // by an entirely different route and left the arm at zero. Worth knowing before editing these.
+    let clause_level_negation = [
+        // %buckets is not empty, so `EMPTY` is false and the clause's `not` makes it true.
+        (
+            "not %buckets EMPTY",
+            "let buckets = Resources.*[ Type == \"AWS::S3::Bucket\" ]\n\
+             rule r { not %buckets EMPTY }",
+            Status::PASS,
+        ),
+        // Both negations applied. If the two flips ever collapsed into one, this row and the one
+        // above would agree -- and a clause that answers the same either way has stopped
+        // discriminating, which is the defect this branch opened with.
+        (
+            "not %buckets not EMPTY",
+            "let buckets = Resources.*[ Type == \"AWS::S3::Bucket\" ]\n\
+             rule r { not %buckets not EMPTY }",
+            Status::FAIL,
+        ),
+        // The same clause without the leading `not`, so the flip is visibly what moves the answer.
+        (
+            "%buckets EMPTY, no clause negation",
+            "let buckets = Resources.*[ Type == \"AWS::S3::Bucket\" ]\n\
+             rule r { %buckets EMPTY }",
+            Status::FAIL,
+        ),
+        // A filter as the final query part reaches the same block by the other condition, and a
+        // filter selecting nothing takes the empty branch inside it.
+        (
+            "not <filter> EMPTY, filter matches",
+            r#"rule r { not Resources.*[ Type == "AWS::S3::Bucket" ] EMPTY }"#,
+            Status::PASS,
+        ),
+        (
+            "not <filter> EMPTY, filter matches nothing",
+            r#"rule r { not Resources.*[ Type == "AWS::None::Type" ] EMPTY }"#,
+            Status::FAIL,
+        ),
+    ];
+
+    // A negated parameterized call. The SKIP case is already covered; these are the two where the
+    // invoked rule reached a verdict and the negation has to invert it.
+    let negated_parameterized = [
+        (
+            "not r(x) where r fails",
+            "rule inner(n) { Resources.B.Properties.Name == %n }\nrule r { not inner(\"wrong\") }",
+            Status::PASS,
+        ),
+        (
+            "not r(x) where r passes",
+            "rule inner(n) { Resources.B.Properties.Name == %n }\nrule r { not inner(\"b\") }",
+            Status::FAIL,
+        ),
+    ];
+
+    // A disjunction in which every disjunct skipped. SKIP rather than PASS matters: PASS would
+    // report that one of the alternatives held when none of them was evaluated.
+    let all_disjuncts_skip = [(
+        "gate disjunction where both sides skip",
+        "rule gate(ty) { Resources.*[ Type == %ty ].Properties.Name == \"zzz\" }\n\
+         rule r when gate(\"AWS::None::One\") or gate(\"AWS::None::Two\") { \
+         Resources.B.Properties.Name == \"nope\" }",
+        Status::SKIP,
+    )];
+
+    for (label, rules, expected) in clause_level_negation
+        .iter()
+        .chain(negated_parameterized.iter())
+        .chain(all_disjuncts_skip.iter())
+    {
+        let rules_file = RulesFile::try_from(*rules)?;
+        let resources = PathAwareValue::try_from(RESOURCES)?;
+        let mut root = root_scope(&rules_file, Rc::new(resources));
+        assert_eq!(
+            eval_rules_file(&rules_file, &mut root, None)?,
+            *expected,
+            "{}",
+            label
+        );
+    }
+
+    Ok(())
+}

--- a/guard/src/rules/eval_tests.rs
+++ b/guard/src/rules/eval_tests.rs
@@ -4639,6 +4639,171 @@ fn a_skipping_parameterized_gate_does_not_drop_a_body_its_sibling_enforces() -> 
     Ok(())
 }
 
+/// A `when` block inside a gate must not evaluate its body as an assertion.
+///
+/// `eval_when_condition_block` took no role and hardcoded `ClauseRole::Assertion` for the guarded
+/// body, on the reasoning that a guarded block holds the rule's own assertions however its
+/// conditions were evaluated. True of a rule evaluated as an assertion; false of one evaluated as a
+/// gate.
+///
+/// The cost was a wrong PASS of exactly the shape this module exists to prevent. Wrapping an
+/// empty-reference clause in `when { ... }` inside a parameterized gate failed it as an assertion;
+/// `eval_conjunction_clauses` counts a FAIL and absorbs a SKIP and answers FAIL before PASS, so the
+/// failure outranked the passing sibling condition, the enclosing rule became inapplicable, and its
+/// guarded check was dropped at exit 0. The same rule without the inner `when` exited 19.
+///
+/// Both spellings are asserted together, because the defect was invisible in either alone: each on
+/// its own merely looks like whatever the current behaviour is, and only the pair shows that
+/// wrapping a clause in `when` changed its meaning.
+#[test]
+fn nested_when_inherits_the_enclosing_role() -> Result<()> {
+    // A gate whose body holds the empty-reference clause directly. The clause SKIPs as a gate, the
+    // SKIP is absorbed, the passing sibling applies the rule, and the body decides.
+    let direct = r###"
+    let denied = Resources.*[ Type == 'AWS::KMS::Key' ].Properties.KeyId
+    rule relevant(ty) {
+        Resources.*[ Type == %ty ].Properties.BucketName != %denied
+    }
+    rule guarded when relevant('AWS::S3::Bucket')
+                      Resources.*[ Type == 'AWS::S3::Bucket' ] !empty {
+        Resources.*[ Type == 'AWS::S3::Bucket' ].Properties.BucketName == 'approved-name'
+    }
+    "###;
+
+    // The same gate, with the clause wrapped in a `when` block whose condition passes. Wrapping
+    // must not change what the clause means.
+    let nested = r###"
+    let denied = Resources.*[ Type == 'AWS::KMS::Key' ].Properties.KeyId
+    rule relevant(ty) {
+        when Resources.*[ Type == %ty ] !empty {
+            Resources.*[ Type == %ty ].Properties.BucketName != %denied
+        }
+    }
+    rule guarded when relevant('AWS::S3::Bucket')
+                      Resources.*[ Type == 'AWS::S3::Bucket' ] !empty {
+        Resources.*[ Type == 'AWS::S3::Bucket' ].Properties.BucketName == 'approved-name'
+    }
+    "###;
+
+    assert_eq!(
+        status_of(direct, ONE_BUCKET)?,
+        Status::FAIL,
+        "baseline: the gate does not apply, the sibling passes, and the body catches the name"
+    );
+    assert_eq!(
+        status_of(nested, ONE_BUCKET)?,
+        Status::FAIL,
+        "wrapping the gate's clause in `when` dropped the guarded body: the clause failed as an \
+         assertion, which outranked the passing sibling condition and exited 0"
+    );
+
+    Ok(())
+}
+
+/// Exhaustive check that the role reaching a leaf clause survives arbitrary `when` nesting.
+///
+/// `nested_when_inherits_the_enclosing_role` pins the one shape that was broken. This pins the
+/// surface around it, because the defect was not that one arm was wrong on purpose -- it was that
+/// role threading is invisible when omitted. Three of the four arms of `eval_guard_clause` forwarded
+/// `role` and one silently did not, and nothing failed.
+///
+/// The axes are the enclosing role, the nesting depth, and the leaf clause's polarity. Rows are
+/// generated rather than written out, and `ROWS_EXPECTED` is asserted against the product of the
+/// axis lengths, so dropping an axis value fails instead of quietly shrinking coverage.
+///
+/// What makes each cell observable: an empty-reference clause is the leaf precisely because it
+/// answers differently by role -- FAIL as an assertion, SKIP as a gate. The fixtures are built so
+/// the two answers produce *different file statuses*, which a single fixture would not do:
+///
+/// - As an assertion, a correct leaf FAILs the rule, so the file FAILs. Leaking the gate role
+///   instead would SKIP it.
+/// - As a gate, a correct leaf SKIPs, is absorbed by the condition fold, and lets the passing
+///   sibling apply the rule, whose body is written to pass -- so the file PASSes. Leaking the
+///   assertion role instead would FAIL the gate, outrank the sibling, and SKIP the rule.
+///
+/// So expected FAIL for assertions and PASS for gates, with SKIP being the signature of a leaked
+/// role in either direction.
+#[test]
+fn the_role_reaching_a_leaf_clause_survives_every_nesting() -> Result<()> {
+    // (label, clause tail against an empty reference)
+    const LEAVES: [(&str, &str); 2] = [("negated", "!= %denied"), ("positive", "IN %denied")];
+    const DEPTHS: [usize; 3] = [0, 1, 2];
+    const ROLES: [&str; 2] = ["assertion", "gate"];
+    const ROWS_EXPECTED: usize = 2 * 3 * 2;
+
+    let mut rows = 0;
+
+    for (leaf_label, leaf_tail) in LEAVES {
+        for depth in DEPTHS {
+            for role in ROLES {
+                // The gate fixture has to use a *parameterized* rule. A plain named rule is also
+                // evaluated as a top-level rule in its own right, as an assertion, so its own
+                // failure would decide the file status and mask what the gate reference did with
+                // it. A parameterized rule needs arguments, so it is only ever evaluated where it
+                // is called. An earlier version of this matrix used a plain rule and failed on
+                // that, not on the behaviour under test.
+                //
+                // The type is therefore spelled through the parameter in the gate case and
+                // literally in the assertion case, so both fixtures select the same resources.
+                let ty = if role == "gate" {
+                    "%ty"
+                } else {
+                    "'AWS::S3::Bucket'"
+                };
+                let condition = format!("Resources.*[ Type == {ty} ] !empty");
+
+                // Wrap the leaf in `depth` passing `when` blocks.
+                let mut body =
+                    format!("Resources.*[ Type == {ty} ].Properties.BucketName {leaf_tail}");
+                for _ in 0..depth {
+                    body = format!("when {condition} {{\n            {body}\n        }}");
+                }
+
+                let rules = if role == "assertion" {
+                    // Top level, so the clauses are assertions.
+                    format!(
+                        "let denied = Resources.*[ Type == 'AWS::KMS::Key' ].Properties.KeyId\n\
+                         rule r {{\n        {body}\n    }}"
+                    )
+                } else {
+                    // Invoked as a parameterized gate, with a passing sibling condition so a gate
+                    // FAIL is distinguishable from a gate SKIP, and a body written to pass.
+                    format!(
+                        "let denied = Resources.*[ Type == 'AWS::KMS::Key' ].Properties.KeyId\n\
+                         rule relevant(ty) {{\n        {body}\n    }}\n\
+                         rule guarded when relevant('AWS::S3::Bucket')\n\
+                                           Resources.*[ Type == 'AWS::S3::Bucket' ] !empty {{\n\
+                             Resources.*[ Type == 'AWS::S3::Bucket' ].Properties.BucketName \
+                             == 'PUBLIC-INSECURE'\n\
+                         }}"
+                    )
+                };
+
+                let expected = if role == "assertion" {
+                    Status::FAIL
+                } else {
+                    Status::PASS
+                };
+
+                let got = status_of(rules.as_str(), ONE_BUCKET)?;
+                assert_eq!(
+                    got, expected,
+                    "{role} leaf {leaf_label} at nesting depth {depth}: expected {expected:?}, \
+                     got {got:?}. SKIP here means the role was lost on the way to the leaf and the \
+                     clause answered as the other kind.\nrules:\n{rules}"
+                );
+                rows += 1;
+            }
+        }
+    }
+
+    assert_eq!(
+        rows, ROWS_EXPECTED,
+        "the matrix must cover every combination of the axes; an axis lost a value"
+    );
+
+    Ok(())
+}
 /// `EMPTY` and `!EMPTY` on a boolean are an incompatible-type error, not a silent pass.
 ///
 /// The Bool arm of `element_empty_operation` computed `(*boolean).to_string().is_empty()`.

--- a/guard/src/rules/eval_tests.rs
+++ b/guard/src/rules/eval_tests.rs
@@ -4044,3 +4044,118 @@ fn status_combinator() {
     assert_eq!(pass.and(fail), Status::FAIL);
     assert_eq!(fail.and(pass), Status::FAIL);
 }
+
+//
+// Clause-level negation on a BINARY comparison.
+//
+// `not <query> == <value>` parses (parser.rs:969 accepts a leading not before the
+// query) and is stored as GuardAccessClause::negation, but the binary evaluation
+// path used to drop it, so the clause evaluated as its un-negated self -- the exact
+// inverse of the author's intent -- while the report still displayed the `not`.
+//
+// The unary path was never affected; these tests cover the binary path and assert
+// that an un-negated clause is unchanged.
+//
+fn eval_single_rule(rules: &str, resources: &str) -> Result<Status> {
+    let value = PathAwareValue::try_from(serde_yaml::from_str::<serde_yaml::Value>(resources)?)?;
+    let rules_file = RulesFile::try_from(rules)?;
+    let mut eval = root_scope(&rules_file, Rc::new(value));
+    eval_rules_file(&rules_file, &mut eval, None)
+}
+
+#[test]
+fn negated_binary_clause_is_honored() -> Result<()> {
+    let encrypted_false = r#"
+    Resources:
+      bucket:
+        Type: AWS::S3::Bucket
+        Properties:
+          Encrypted: false
+    "#;
+    let encrypted_true = r#"
+    Resources:
+      bucket:
+        Type: AWS::S3::Bucket
+        Properties:
+          Encrypted: true
+    "#;
+
+    // "It must NOT be the case that Encrypted == false."
+    let negated = r###"
+    rule encrypted_must_not_be_false {
+        not Resources.*[ Type == 'AWS::S3::Bucket' ].Properties.Encrypted == false
+    }
+    "###;
+
+    // Encrypted: false violates the intent -> FAIL.
+    // Before the fix this returned PASS.
+    assert_eq!(eval_single_rule(negated, encrypted_false)?, Status::FAIL);
+
+    // Encrypted: true satisfies the intent -> PASS.
+    // Before the fix this returned FAIL.
+    assert_eq!(eval_single_rule(negated, encrypted_true)?, Status::PASS);
+
+    Ok(())
+}
+
+#[test]
+fn unnegated_binary_clause_is_unchanged() -> Result<()> {
+    let encrypted_false = r#"
+    Resources:
+      bucket:
+        Type: AWS::S3::Bucket
+        Properties:
+          Encrypted: false
+    "#;
+    let encrypted_true = r#"
+    Resources:
+      bucket:
+        Type: AWS::S3::Bucket
+        Properties:
+          Encrypted: true
+    "#;
+
+    let plain = r###"
+    rule encrypted_equals_false {
+        Resources.*[ Type == 'AWS::S3::Bucket' ].Properties.Encrypted == false
+    }
+    "###;
+
+    // The negated and un-negated forms must now disagree on every input; before the
+    // fix they agreed, which is what proved the `not` was being dropped.
+    assert_eq!(eval_single_rule(plain, encrypted_false)?, Status::PASS);
+    assert_eq!(eval_single_rule(plain, encrypted_true)?, Status::FAIL);
+
+    Ok(())
+}
+
+#[test]
+fn negation_composes_with_operator_not_flag() -> Result<()> {
+    let encrypted_false = r#"
+    Resources:
+      bucket:
+        Type: AWS::S3::Bucket
+        Properties:
+          Encrypted: false
+    "#;
+
+    // Double negation: clause-level `not` plus the operator's own `!=`.
+    // `not X != false` is equivalent to `X == false`, which holds here -> PASS.
+    let double = r###"
+    rule double_negation {
+        not Resources.*[ Type == 'AWS::S3::Bucket' ].Properties.Encrypted != false
+    }
+    "###;
+    assert_eq!(eval_single_rule(double, encrypted_false)?, Status::PASS);
+
+    // Single negation via the operator alone is unaffected: `X != false` is false
+    // here -> FAIL.
+    let op_only = r###"
+    rule op_not_only {
+        Resources.*[ Type == 'AWS::S3::Bucket' ].Properties.Encrypted != false
+    }
+    "###;
+    assert_eq!(eval_single_rule(op_only, encrypted_false)?, Status::FAIL);
+
+    Ok(())
+}

--- a/guard/src/rules/eval_tests.rs
+++ b/guard/src/rules/eval_tests.rs
@@ -4481,12 +4481,132 @@ fn negated_reference_to_skipped_rule_still_gates_a_when_condition() -> Result<()
     Ok(())
 }
 
-//
-// EMPTY / !EMPTY on a boolean.
-//
-// The Bool arm of element_empty_operation used to compute
-// `(*boolean).to_string().is_empty()`, which is never true, so a boolean was never
-// EMPTY and `!empty` on one always passed regardless of its value -- a clause that
-// reads like a check but asserts nothing. It now reports the same incompatible-type
-// error as every other unsupported type.
-//
+/// A non-negated parameterized gate that SKIPs must not poison the rest of the `when`.
+///
+/// `eval_parameterized_rule_call` returned the invoked rule's status through a `_` arm that
+/// converted any non-PASS, non-strict-SKIP result into FAIL for a non-negated call. With a
+/// single condition that is invisible: FAIL and SKIP both make `eval_rule` treat the rule as
+/// inapplicable and drop the guarded body.
+///
+/// It becomes visible with two conditions, which is why this test has two.
+/// `eval_conjunction_clauses` absorbs SKIP (`Status::SKIP => {}`) but counts a FAIL, so the
+/// inapplicable gate returning FAIL dropped a body that the passing sibling condition should
+/// have kept enforced. `ClauseRole::Gate` is documented as "the block it guards is still
+/// decided by the remaining conditions", so FAIL here defeated the role propagation.
+///
+/// The fixture: `no_such_type` invokes a parameterized rule whose query selects nothing, so it
+/// SKIPs; `bucket_exists` PASSes; and the guarded body requires a Name the template violates.
+/// The body must therefore run and the file must FAIL. Before the fix it exited 0 with the
+/// body dropped, which is the wrong-PASS shape this whole branch is about.
+#[test]
+fn a_skipping_parameterized_gate_does_not_drop_a_body_its_sibling_enforces() -> Result<()> {
+    // `relevant` must SKIP, not FAIL, or this fixture tests the wrong arm. A binary
+    // comparison whose left-hand query selects nothing yields `EvalResult::Skip`
+    // (`CmpOperator::compare`'s `lhs.is_empty()` guard), so the rule SKIPs. `!empty` would
+    // FAIL instead -- an unresolved query is EMPTY, so `!empty` is false -- which reaches the
+    // `_` arm by a different route and would not exercise the SKIP path at all.
+    let rules = r###"
+    rule relevant(ty) {
+        Resources.*[ Type == %ty ].Properties.Name == 'anything'
+    }
+    rule guarded when relevant('AWS::Nonexistent::Type') Resources.*[ Type == 'AWS::S3::Bucket' ] !empty {
+        Resources.*[ Type == 'AWS::S3::Bucket' ].Properties.Name == 'safebucket'
+    }
+    "###;
+
+    let input = r#"
+    {
+        Resources: {
+            b: {
+                Type: 'AWS::S3::Bucket',
+                Properties: { Name: "publicbucket" }
+            }
+        }
+    }
+    "#;
+
+    let resources = PathAwareValue::try_from(input)?;
+    let rules_file = RulesFile::try_from(rules)?;
+    let mut root = root_scope(&rules_file, Rc::new(resources));
+    let status = eval_rules_file(&rules_file, &mut root, None)?;
+
+    // FAIL: the parameterized gate does not apply, the sibling condition passes, so the body
+    // runs and catches `publicbucket`. SKIP here would mean the inapplicable gate closed the
+    // whole `when` and the violation went unreported while the process exited 0.
+    assert_eq!(
+        status,
+        Status::FAIL,
+        "a parameterized gate that did not apply suppressed a body its sibling condition \
+         should have kept enforced"
+    );
+
+    Ok(())
+}
+
+/// `EMPTY` and `!EMPTY` on a boolean are an incompatible-type error, not a silent pass.
+///
+/// The Bool arm of `element_empty_operation` computed `(*boolean).to_string().is_empty()`.
+/// Neither "true" nor "false" is ever the empty string, so EMPTY on a boolean was
+/// unconditionally false and `!EMPTY` unconditionally true: a clause that reads like a check
+/// and cannot fail for any input. A rule author writing `Properties.Enabled !EMPTY` got a
+/// green check that verified nothing.
+///
+/// Removing the arm lets a boolean reach the same `IncompatibleError` every other unsupported
+/// type already reached, which surfaces the mistake with the offending path instead of
+/// certifying it.
+///
+/// All four combinations are covered because the two axes fail differently. The old code made
+/// `!EMPTY` a silent *pass* and `EMPTY` a silent *fail*, so a test on one polarity alone would
+/// have left the other spelling unguarded, and `true` versus `false` is exactly the axis the
+/// old implementation was insensitive to -- asserting only one value would not have
+/// distinguished "handled" from "ignored".
+#[test]
+fn boolean_empty_is_an_incompatible_type() -> Result<()> {
+    for value in ["true", "false"] {
+        for comparator in ["EMPTY", "!EMPTY"] {
+            let rules = format!(
+                r###"
+                rule flag_check {{
+                    Resources.*[ Type == 'AWS::S3::Bucket' ].Properties.Enabled {comparator}
+                }}
+                "###
+            );
+            let input = format!(
+                r#"
+                {{
+                    Resources: {{
+                        b: {{
+                            Type: 'AWS::S3::Bucket',
+                            Properties: {{ Enabled: {value} }}
+                        }}
+                    }}
+                }}
+                "#
+            );
+
+            let resources = PathAwareValue::try_from(input.as_str())?;
+            let rules_file = RulesFile::try_from(rules.as_str())?;
+            let mut root = root_scope(&rules_file, Rc::new(resources));
+            let result = eval_rules_file(&rules_file, &mut root, None);
+
+            let err = match result {
+                Err(e) => e,
+                Ok(status) => panic!(
+                    "`Enabled {comparator}` on the boolean {value} returned {status:?} instead \
+                     of an incompatible-type error. Before this fix `!EMPTY` passed for every \
+                     boolean and `EMPTY` failed for every boolean, in both cases without \
+                     comparing anything."
+                ),
+            };
+
+            let message = format!("{err}");
+            assert!(
+                message.contains("EMPTY"),
+                "expected the incompatible-type error to name the EMPTY operation so the \
+                 author can find the clause, got: {message}"
+            );
+        }
+    }
+
+    Ok(())
+}

--- a/guard/src/rules/exprs.rs
+++ b/guard/src/rules/exprs.rs
@@ -182,8 +182,53 @@ pub(crate) struct GuardAccessClause<'loc> {
 
 #[derive(Eq, PartialEq, Debug, Clone, Serialize, Deserialize, Hash)]
 pub(crate) struct MapKeyFilterClause<'loc> {
-    pub(crate) comparator: (CmpOperator, bool),
+    pub(crate) comparator: MapKeyComparator,
     pub(crate) compare_with: LetValue<'loc>,
+}
+
+/// The comparators a map key filter can be written with.
+///
+/// This field held a `(CmpOperator, bool)`, which can express every operator in the language while
+/// `map_keys_match` parses exactly these four. The gap was not free. `real_binary_operation` -- whose
+/// only caller is the map key filter -- carried arms for `Ge`, `Gt`, `Lt` and `Le` that no rules
+/// file could reach, and they recorded zero executions against a 288-clause matrix using those very
+/// operators. Dead code that looks live is worse than dead code that looks dead: the arms duplicate
+/// the comparison logic, so someone fixing a comparison bug would naturally edit the one calling
+/// `compare_ge` and see no effect anywhere.
+///
+/// Narrowing the type is what makes those arms impossible rather than merely unused, which is why
+/// this is an enum here instead of a comment there.
+#[derive(Eq, PartialEq, Debug, Clone, Copy, Serialize, Deserialize, Hash)]
+pub(crate) enum MapKeyComparator {
+    Eq,
+    NotEq,
+    In,
+    NotIn,
+}
+
+impl MapKeyComparator {
+    /// The wider pair, for the comparison records the reporters render.
+    pub(crate) fn as_cmp_operator(self) -> (CmpOperator, bool) {
+        match self {
+            MapKeyComparator::Eq => (CmpOperator::Eq, false),
+            MapKeyComparator::NotEq => (CmpOperator::Eq, true),
+            MapKeyComparator::In => (CmpOperator::In, false),
+            MapKeyComparator::NotIn => (CmpOperator::In, true),
+        }
+    }
+
+    /// Equality against more than one right-hand value is membership.
+    ///
+    /// `keys == %several` reads as "each key equals" and is evaluated as "is among", which is what
+    /// the `Eq`-with-multiple-values promotion has always done. Kept as a method so the rule is
+    /// stated once rather than inline in the evaluator.
+    pub(crate) fn widened_for(self, rhs_count: usize) -> Self {
+        match self {
+            MapKeyComparator::Eq if rhs_count > 1 => MapKeyComparator::In,
+            MapKeyComparator::NotEq if rhs_count > 1 => MapKeyComparator::NotIn,
+            unchanged => unchanged,
+        }
+    }
 }
 
 #[derive(Eq, PartialEq, Debug, Clone, Serialize, Deserialize, Hash)]

--- a/guard/src/rules/parser.rs
+++ b/guard/src/rules/parser.rs
@@ -811,12 +811,16 @@ fn map_keys_match(input: Span) -> IResult<Span, QueryPart> {
     let (input, _open) = open_array(input)?;
     let (input, var) = opt(variable_capture_in_map_or_index)(input)?;
     let (input, _keys) = preceded(zero_or_more_ws_or_comment, keys)(input)?;
+    // The four comparators a key filter accepts. `MapKeyComparator` exists so this list and the
+    // evaluator cannot disagree: anything absent here is unrepresentable downstream rather than an
+    // unreachable match arm.
     let (input, cmp) = cut(preceded(
         zero_or_more_ws_or_comment,
         alt((
-            eq,
-            value((CmpOperator::In, false), in_keyword),
-            map(tuple((not, in_keyword)), |_m| (CmpOperator::In, true)),
+            value(MapKeyComparator::Eq, tag("==")),
+            value(MapKeyComparator::NotEq, tag("!=")),
+            value(MapKeyComparator::In, in_keyword),
+            map(tuple((not, in_keyword)), |_m| MapKeyComparator::NotIn),
         )),
     ))(input)?;
     let (input, with) = cut(preceded(

--- a/guard/src/rules/parser_tests.rs
+++ b/guard/src/rules/parser_tests.rs
@@ -1349,7 +1349,7 @@ fn test_keys_keyword() {
             QueryPart::MapKeyFilter(
                 None,
                 MapKeyFilterClause {
-                    comparator: (CmpOperator::In, false),
+                    comparator: MapKeyComparator::In,
                     compare_with: LetValue::AccessClause(AccessQuery {
                         match_all: true,
                         query: vec![QueryPart::Key("%var".to_string())],
@@ -1363,7 +1363,7 @@ fn test_keys_keyword() {
             QueryPart::MapKeyFilter(
                 None,
                 MapKeyFilterClause {
-                    comparator: (CmpOperator::In, true),
+                    comparator: MapKeyComparator::NotIn,
                     compare_with: LetValue::AccessClause(AccessQuery {
                         match_all: true,
                         query: vec![QueryPart::Key("%var".to_string())],
@@ -1378,7 +1378,7 @@ fn test_keys_keyword() {
             QueryPart::MapKeyFilter(
                 None,
                 MapKeyFilterClause {
-                    comparator: (CmpOperator::Eq, false),
+                    comparator: MapKeyComparator::Eq,
                     compare_with: LetValue::Value(
                         PathAwareValue::try_from(Value::Regex("aws:S".to_string())).unwrap(),
                     ),
@@ -1392,7 +1392,7 @@ fn test_keys_keyword() {
             QueryPart::MapKeyFilter(
                 None,
                 MapKeyFilterClause {
-                    comparator: (CmpOperator::Eq, true),
+                    comparator: MapKeyComparator::NotEq,
                     compare_with: LetValue::Value(
                         PathAwareValue::try_from(Value::String("aws:IsSecure".to_string()))
                             .unwrap(),
@@ -1406,7 +1406,7 @@ fn test_keys_keyword() {
             QueryPart::MapKeyFilter(
                 None,
                 MapKeyFilterClause {
-                    comparator: (CmpOperator::In, true),
+                    comparator: MapKeyComparator::NotIn,
                     compare_with: LetValue::AccessClause(AccessQuery {
                         match_all: true,
                         query: vec![QueryPart::Key("%var".to_string())],
@@ -3826,7 +3826,7 @@ fn some_clause_parse() -> Result<(), Error> {
                     QueryPart::MapKeyFilter(
                         None,
                         MapKeyFilterClause {
-                            comparator: (CmpOperator::Eq, false),
+                            comparator: MapKeyComparator::Eq,
                             compare_with: LetValue::Value(
                                 PathAwareValue::try_from(Value::Regex(
                                     "aws:[sS]ource(Vpc|VPC|Vpce|VPCE)".to_string(),

--- a/guard/src/rules/path_value.rs
+++ b/guard/src/rules/path_value.rs
@@ -1044,6 +1044,40 @@ impl PathAwareValue {
     }
 }
 
+/// Order an integer against a float without going through a lossy conversion.
+///
+/// `(i as f64).partial_cmp(f)` is the obvious spelling and it is wrong: `i64` values above 2^53
+/// are not exactly representable in `f64`, so the cast rounds and two distinct values can compare
+/// `Equal`. Casting the other way is exact once the float is known to be in range, because
+/// `floor` is exact on `f64` and `as i64` then truncates a value that is already integral.
+///
+/// Returns `None` only for NaN, matching what `f64::partial_cmp` does for float-to-float.
+fn compare_int_to_float(i: i64, f: f64) -> Option<Ordering> {
+    if f.is_nan() {
+        return None;
+    }
+
+    // 2^63. `i64::MAX as f64` rounds *up* to this value, so comparing against `i64::MAX as f64`
+    // would let f == 2^63 through, and the `as i64` below would then saturate to `i64::MAX` and
+    // report a spurious `Equal`. Bound on 2^63 itself instead.
+    const TWO_POW_63: f64 = 9_223_372_036_854_775_808.0;
+    if f >= TWO_POW_63 {
+        return Some(Ordering::Less); // every i64 is smaller
+    }
+    if f < -TWO_POW_63 {
+        return Some(Ordering::Greater); // every i64 is larger
+    }
+
+    // -2^63 <= f < 2^63, so `floor` is representable as i64 and the cast is exact.
+    let truncated = f.floor();
+    Some(match i.cmp(&(truncated as i64)) {
+        // Same integral part, so the float decides it: anything above its own floor has a
+        // fraction left over and is therefore the larger of the two.
+        Ordering::Equal if f > truncated => Ordering::Less,
+        ordering => ordering,
+    })
+}
+
 fn compare_values(first: &PathAwareValue, other: &PathAwareValue) -> Result<Ordering, Error> {
     match (first, other) {
         //
@@ -1058,6 +1092,21 @@ fn compare_values(first: &PathAwareValue, other: &PathAwareValue) -> Result<Orde
                 "Float values are not comparable".to_owned(),
             )),
         },
+
+        // A number is a number. Without these two arms `Size > 10` reports the template's own
+        // value as not comparable the moment someone writes `50.5` instead of `50`, and in a
+        // `when` condition that non-PASS becomes a SKIP, which exits 0 and takes the guarded
+        // body with it. Pinned by `mixed_int_and_float_operands_compare_numerically`.
+        (PathAwareValue::Int((_, i)), PathAwareValue::Float((_, f))) => {
+            compare_int_to_float(*i, *f)
+                .ok_or_else(|| Error::NotComparable("Float values are not comparable".to_owned()))
+        }
+        (PathAwareValue::Float((_, f)), PathAwareValue::Int((_, i))) => {
+            compare_int_to_float(*i, *f)
+                .map(Ordering::reverse)
+                .ok_or_else(|| Error::NotComparable("Float values are not comparable".to_owned()))
+        }
+
         (PathAwareValue::Char((_, f)), PathAwareValue::Char((_, s))) => Ok(f.cmp(s)),
         (_, _) => Err(Error::NotComparable(format!(
             "PathAwareValues are not comparable {}, {}",

--- a/guard/src/rules/path_value_tests.rs
+++ b/guard/src/rules/path_value_tests.rs
@@ -407,3 +407,83 @@ fn merge_values_test() -> Result<(), Error> {
 
     Ok(())
 }
+
+/// Mixed integer and float operands order numerically, and exactly.
+///
+/// `compare_values` matched Int/Int and Float/Float and nothing in between, so every mixed
+/// numeric comparison reached the `NotComparable` catch-all. `Size > 10` against a template
+/// carrying `Size: 50.5` reported "PathAwareValues are not comparable float, int" and FAILed a
+/// compliant volume. Worse in a `when` condition, where the non-PASS became a SKIP and dropped
+/// the guarded body at exit 0 -- see `a_float_valued_gate_condition_still_guards_its_body` in
+/// eval_tests.rs.
+///
+/// The precision cases below are the reason this is not `(i as f64).partial_cmp(f)`. `i64` values
+/// above 2^53 do not survive a round trip through `f64`: `9007199254740993i64` (2^53 + 1) casts to
+/// `9007199254740992.0`, so the lossy spelling reports `Equal` for two values that differ by one.
+#[test]
+fn mixed_int_and_float_operands_compare_numerically() {
+    fn int(i: i64) -> PathAwareValue {
+        PathAwareValue::Int((Path::root(), i))
+    }
+    fn flt(f: f64) -> PathAwareValue {
+        PathAwareValue::Float((Path::root(), f))
+    }
+
+    // (int operand, float operand, how the int orders against the float)
+    let cases: [(i64, f64, Ordering); 12] = [
+        (50, 10.0, Ordering::Greater),
+        (10, 50.5, Ordering::Less),
+        (50, 50.0, Ordering::Equal),
+        (50, 50.5, Ordering::Less), // same floor, float carries the fraction
+        (51, 50.5, Ordering::Greater),
+        (-1, -0.5, Ordering::Less), // floor(-0.5) is -1, and -0.5 is the larger
+        (-1, -1.0, Ordering::Equal),
+        (0, -0.0, Ordering::Equal),
+        // 2^53 + 1 against 2^53: exact here, Equal under an `as f64` cast on the integer.
+        (
+            9_007_199_254_740_993,
+            9_007_199_254_740_992.0,
+            Ordering::Greater,
+        ),
+        // Out of i64 range in both directions: no cast, no saturation.
+        (i64::MAX, 1.0e300, Ordering::Less),
+        (i64::MIN, -1.0e300, Ordering::Greater),
+        // i64::MIN is exactly -2^63, which f64 represents exactly.
+        (i64::MIN, -9_223_372_036_854_775_808.0, Ordering::Equal),
+    ];
+
+    for (i, f, expected) in cases {
+        assert_eq!(
+            compare_values(&int(i), &flt(f)).unwrap(),
+            expected,
+            "comparing int {} against float {}",
+            i,
+            f
+        );
+        assert_eq!(
+            compare_values(&flt(f), &int(i)).unwrap(),
+            expected.reverse(),
+            "comparing float {} against int {} (reversed operands)",
+            f,
+            i
+        );
+    }
+
+    // The operators built on compare_values, so the fix reaches the surface the rules use.
+    assert!(compare_gt(&flt(50.5), &int(10)).unwrap());
+    assert!(compare_ge(&flt(50.5), &int(10)).unwrap());
+    assert!(compare_lt(&int(10), &flt(50.5)).unwrap());
+    assert!(compare_le(&int(10), &flt(50.5)).unwrap());
+    assert!(compare_eq(&flt(50.0), &int(50)).unwrap());
+    assert!(!compare_eq(&flt(50.5), &int(50)).unwrap());
+
+    // NaN stays not-comparable, the same answer Float/Float already gave.
+    assert!(matches!(
+        compare_values(&int(1), &flt(f64::NAN)),
+        Err(Error::NotComparable(_))
+    ));
+    assert!(matches!(
+        compare_values(&flt(f64::NAN), &int(1)),
+        Err(Error::NotComparable(_))
+    ));
+}

--- a/guard/tests/utils.rs
+++ b/guard/tests/utils.rs
@@ -102,35 +102,43 @@ pub fn get_full_path_for_resource_file(path: &str) -> String {
     return resource.display().to_string();
 }
 
-pub fn replace_home_directory_with_tilde(text: String) -> String {
-    let home_dir_string = match env::var("HOME") {
-        Ok(home_path) => home_path,
-        Err(_) => panic!("HOME variable required for tests!"),
-    };
-
-    text.replace(&home_dir_string, "~")
-}
-
+/// Reduce resource paths in captured output to bare filenames, so expected-output fixtures do
+/// not depend on where the repository is checked out.
+///
+/// Anchored on `CARGO_MANIFEST_DIR`. Every resource path that reaches test output is rooted
+/// there, because `get_full_path_for_resource_file` builds them from it.
+///
+/// This replaced a `$HOME`-based version that first rewrote the home directory to `~` and then
+/// matched `~/…`, which had two bugs:
+///
+/// - `$HOME` was substituted by plain substring match, so a checkout whose path merely
+///   *contains* `$HOME` was corrupted rather than normalised. With `HOME=/home/u`, the path
+///   `/local/home/u/repo/tests/resources/x.yaml` became `/local~/repo/tests/resources/x.yaml`,
+///   and reducing the tail then left `/localx.yaml` welded together. `/local/home` is a real
+///   layout rather than a hypothetical, and it failed 15 of the 96 `validate` tests while
+///   leaving them looking like product failures.
+/// - a checkout *outside* `$HOME` produced no `~` at all, so the reduction never fired and every
+///   comparison saw a full absolute path.
+///
+/// Anchoring on the crate directory also leaves URLs alone by construction, which a regex over
+/// bare absolute paths would not: the SARIF fixtures contain
+/// `//docs.oasis-open.org/…/sarif-schema-2.1.0.json`, and reducing that to its basename would
+/// break them. It is the only slash-bearing file reference in `guard/resources`, so the
+/// distinction is load-bearing for exactly one fixture and easy to lose.
 pub fn replace_path_with_filenames(text: String) -> String {
     let extensions = ["yaml", "yml", "json"];
-    // pattern to match anything between "~/" and any of the extensions
+    // Any path rooted at the crate directory, reduced to its final component.
     let pattern = format!(
-        r#"~/(?:[\w/\-]+/)?([\w/\-]+\.(?:{}))"#,
+        r#"{}[\w/.\-]*/([\w.\-]+\.(?:{}))"#,
+        fancy_regex::escape(env!("CARGO_MANIFEST_DIR")),
         extensions.join("|")
     );
     let re = Regex::new(&pattern).unwrap();
-    // replace the entire match with match group 1 (the file name)
-    let replaced_filenames = re.replace_all(&text, "$1");
-
-    replaced_filenames.to_string()
+    re.replace_all(&text, "$1").to_string()
 }
 
 pub fn sanitize_path(string_to_sanitize: String) -> String {
-    // replace the home directory to avoid regex issues with path matches beyond the
-    // leading forward slash for example '[/Users/...' or 'name="/User...'
-    let replaced_home_directory = replace_home_directory_with_tilde(string_to_sanitize);
-    // return the blob of text with full path replaced with just the filename
-    replace_path_with_filenames(replaced_home_directory)
+    replace_path_with_filenames(string_to_sanitize)
 }
 
 pub fn compare_write_buffer_with_file(

--- a/guard/tests/validate.rs
+++ b/guard/tests/validate.rs
@@ -309,6 +309,68 @@ mod validate_tests {
         );
     }
 
+    /// A failure message comparing against many values shows a few and says how many there were.
+    ///
+    /// The reporter computed its cut-off as `max(values.len(), 5)`, which is never below the number
+    /// of values, so the loop that was meant to stop early never did and the branch reporting a
+    /// `Total` was unreachable. A rule comparing against a denylist of five hundred entries printed
+    /// all five hundred, in every failure message, for every resource. The dead branch is what gives
+    /// the intent away -- it exists to say how many there were when not all are shown.
+    ///
+    /// The right-hand side has to resolve to many *separate* values to reach this at all. A literal
+    /// list is one value however long it is, which is why the fixture compares against a variable
+    /// over nine resources rather than against `['a', 'b', ...]`. An earlier version of this test
+    /// used the literal and proved nothing.
+    #[test]
+    fn a_long_in_comparison_is_truncated_with_a_total() {
+        let mut reader = Reader::default();
+        let mut writer = Writer::new(WBVec(vec![])).expect("Failed to create writer.");
+
+        let status_code = ValidateTestRunner::default()
+            .data(vec!["many-allowed-values-template.yaml"])
+            .rules(vec!["volume-type-in-allowed-names.guard"])
+            .run(&mut writer, &mut reader);
+
+        assert_eq!(
+            StatusCode::VALIDATION_ERROR,
+            status_code,
+            "the volume type is not among the allowed names, so the rule must fail"
+        );
+
+        let output = writer.stripped().expect("failed to read the writer");
+        assert!(
+            output.contains("Total"),
+            "a truncated comparison should report how many values there were:\n{}",
+            output
+        );
+        // Scoped to the ComparedWith line rather than the whole output. The report echoes the
+        // offending template, and the fixture's nine topic names all appear there, so a search over
+        // everything would find the withheld values in the code snippet and prove nothing.
+        let compared_with = output
+            .lines()
+            .find(|line| line.contains("ComparedWith"))
+            .unwrap_or_else(|| panic!("no ComparedWith line in the report:\n{}", output));
+
+        // Five shown, four withheld. Both halves are asserted: a reporter that printed no values at
+        // all would satisfy the withheld check on its own.
+        for shown in ["n0", "n4"] {
+            assert!(
+                compared_with.contains(shown),
+                "expected {} among the values shown, got: {}",
+                shown,
+                compared_with
+            );
+        }
+        for withheld in ["n5", "n8"] {
+            assert!(
+                !compared_with.contains(withheld),
+                "{} should have been withheld by the cut-off, got: {}",
+                withheld,
+                compared_with
+            );
+        }
+    }
+
     /// A condition that could not be decided has to say so, and a condition that was merely false
     /// must not.
     ///

--- a/guard/tests/validate.rs
+++ b/guard/tests/validate.rs
@@ -309,6 +309,75 @@ mod validate_tests {
         );
     }
 
+    /// A condition that could not be decided has to say so, and a condition that was merely false
+    /// must not.
+    ///
+    /// This is the quietest wrong answer left in the evaluator, and the reason the discrimination
+    /// matters. `when ... Size > 10` against a template carrying `Size: "50"` cannot be decided, so
+    /// the condition does not pass, so the rule is reported as not applicable and its unencrypted
+    /// volume is never checked. Exit 0. A template with `Size: 50` fails the same rule.
+    ///
+    /// The rule still does not enforce, and it cannot be made to from here: on a condition, both
+    /// FAIL and SKIP drop the block being guarded, so telling "could not decide" from "decided
+    /// false" at the point it matters needs a status meaning "could not tell", which `Status` does
+    /// not have. What is available is saying so, which turns a silent non-check into a visible one.
+    /// When that third state exists, this test is where the stronger behaviour gets asserted.
+    ///
+    /// The false-condition case is asserted alongside because the discriminator is the whole
+    /// mechanism: only an undecidable comparison records an explanation, so a rule that legitimately
+    /// does not apply stays quiet. Without that, every inapplicable rule in a large ruleset would
+    /// grow a line of output and the signal would be worthless.
+    #[rstest::rstest]
+    #[case(None, "volume-size-as-string-template.yaml", true)]
+    #[case(Some("json"), "volume-size-as-string-template.yaml", true)]
+    #[case(None, "volume-under-gate-threshold-template.yaml", false)]
+    #[case(Some("json"), "volume-under-gate-threshold-template.yaml", false)]
+    fn an_undecidable_condition_says_so_in_the_output(
+        #[case] output_format: Option<&str>,
+        #[case] data_file: &str,
+        #[case] expect_explanation: bool,
+    ) {
+        let mut reader = Reader::default();
+        let mut writer = Writer::new(WBVec(vec![])).expect("Failed to create writer.");
+
+        let mut runner = ValidateTestRunner::default();
+        let runner = runner
+            .data(vec![data_file])
+            .rules(vec!["large_volumes_encrypted_gate.guard"]);
+        let status_code = match output_format {
+            Some(format) => runner
+                .output_format(Some(format))
+                .show_summary(vec!["none"])
+                .run(&mut writer, &mut reader),
+            None => runner
+                .show_summary(vec!["all"])
+                .run(&mut writer, &mut reader),
+        };
+
+        // Both templates exit 0, which is the point: the exit code cannot tell them apart.
+        assert_eq!(
+            StatusCode::SUCCESS,
+            status_code,
+            "an inapplicable rule exits 0 whichever reason applied"
+        );
+
+        let output = writer.stripped().expect("failed to read the writer");
+        let explained = output.contains("could not be decided");
+        assert_eq!(
+            explained,
+            expect_explanation,
+            "the {} output for {} {} an explanation; got:\n{}",
+            output_format.unwrap_or("console"),
+            data_file,
+            if expect_explanation {
+                "should have carried"
+            } else {
+                "should not have carried"
+            },
+            output
+        );
+    }
+
     /// A rule that skipped has to say why, in both the console and the structured output.
     ///
     /// This is the case `every_recorded_explanation_has_a_rendering_path` refused earlier in this

--- a/guard/tests/validate.rs
+++ b/guard/tests/validate.rs
@@ -257,6 +257,83 @@ mod validate_tests {
         assert_eq!(StatusCode::INTERNAL_FAILURE, status_code);
     }
 
+    /// A clause that fails because its reference resolved to nothing must say so in the output.
+    ///
+    /// Exit code alone is not enough, and asserting only the exit code is how this was missed: the
+    /// run correctly returned 19 while the console said "Number of non-compliant resources 0" and
+    /// the structured output carried `"checks": []` with a null error_message. The explanation was
+    /// built, recorded, and discarded by the reporter, so an operator got a failure with no stated
+    /// reason -- and docs/CLAUSES.md promised one.
+    ///
+    /// Both output paths are asserted because they discard messages independently. The structured
+    /// reporter walks the record tree, and the console reporter additionally organises findings by
+    /// resource, which a clause with nothing to compare cannot be attributed to.
+    #[rstest::rstest]
+    #[case(None)]
+    #[case(Some("json"))]
+    fn empty_reference_failure_explains_itself_in_the_output(#[case] output_format: Option<&str>) {
+        let mut reader = Reader::default();
+        let mut writer = Writer::new(WBVec(vec![])).expect("Failed to create writer.");
+
+        let mut runner = ValidateTestRunner::default();
+        let runner = runner
+            .data(vec!["bucket-with-no-kms-keys-template.yaml"])
+            .rules(vec!["denied_names_from_empty_reference.guard"]);
+        let status_code = match output_format {
+            Some(format) => runner
+                .output_format(Some(format))
+                .show_summary(vec!["none"])
+                .run(&mut writer, &mut reader),
+            None => runner
+                .show_summary(vec!["all"])
+                .run(&mut writer, &mut reader),
+        };
+
+        assert_eq!(
+            StatusCode::VALIDATION_ERROR,
+            status_code,
+            "the clause must still fail; this test is about the explanation, not the verdict"
+        );
+
+        let output = writer.stripped().expect("failed to read the writer");
+        assert!(
+            output.contains("resolved to no values"),
+            "output ({:?}) did not explain that the reference resolved to no values.\n{}",
+            output_format.unwrap_or("console"),
+            output
+        );
+        assert!(
+            output.contains("!empty"),
+            "the explanation should name the `!empty` guard as the remedy, got:\n{}",
+            output
+        );
+    }
+
+    /// The counterpart: a run with nothing wrong must not print the section.
+    ///
+    /// Without this, the assertion above is satisfied by a reporter that prints the explanation
+    /// unconditionally.
+    #[test]
+    fn a_clean_run_does_not_print_an_unevaluated_clause_section() {
+        let mut reader = Reader::default();
+        let mut writer = Writer::new(WBVec(vec![])).expect("Failed to create writer.");
+
+        let status_code = ValidateTestRunner::default()
+            .data(vec!["bucket-with-no-kms-keys-template.yaml"])
+            .rules(vec!["denied_names_guarded_by_not_empty.guard"])
+            .show_summary(vec!["all"])
+            .run(&mut writer, &mut reader);
+
+        assert_eq!(StatusCode::SUCCESS, status_code);
+
+        let output = writer.stripped().expect("failed to read the writer");
+        assert!(
+            !output.contains("Clauses that could not be evaluated"),
+            "a guarded, skipped clause is not an unevaluated failure, got:\n{}",
+            output
+        );
+    }
+
     #[test]
     fn test_single_data_file_single_rules_file_compliant() {
         let mut reader = Reader::default();

--- a/guard/tests/validate.rs
+++ b/guard/tests/validate.rs
@@ -309,6 +309,74 @@ mod validate_tests {
         );
     }
 
+    /// A rule that skipped has to say why, in both the console and the structured output.
+    ///
+    /// This is the case `every_recorded_explanation_has_a_rendering_path` refused earlier in this
+    /// branch. A message was written onto the skip record and it went nowhere: a skipped rule
+    /// reached the reporters as a bare name, so the explanation was constructed and discarded --
+    /// the same defect that had five other message-bearing record variants rendering nothing.
+    /// Making it reachable meant the skip set had to carry reasons, which changed the shape of
+    /// `FileReport` and of the `GenericReporter::report` signature.
+    ///
+    /// Both skip causes are asserted, because telling them apart is the whole value. "No volumes
+    /// in the template" is the ordinary reason for a rule not to apply. "Every volume was exempted
+    /// by the condition" is the one worth a second look, since a rule that never fires looks
+    /// exactly like a rule that passes -- both report SKIP and exit 0.
+    #[rstest::rstest]
+    #[case(
+        None,
+        "volume-below-threshold-template.yaml",
+        "was exempted by the type block"
+    )]
+    #[case(
+        Some("json"),
+        "volume-below-threshold-template.yaml",
+        "was exempted by the type block"
+    )]
+    #[case(None, "no-volumes-template.yaml", "no AWS::EC2::Volume in the input")]
+    #[case(
+        Some("json"),
+        "no-volumes-template.yaml",
+        "no AWS::EC2::Volume in the input"
+    )]
+    fn a_skipped_type_block_explains_itself_in_the_output(
+        #[case] output_format: Option<&str>,
+        #[case] data_file: &str,
+        #[case] expected: &str,
+    ) {
+        let mut reader = Reader::default();
+        let mut writer = Writer::new(WBVec(vec![])).expect("Failed to create writer.");
+
+        let mut runner = ValidateTestRunner::default();
+        let runner = runner
+            .data(vec![data_file])
+            .rules(vec!["large_volumes_encrypted_type_block.guard"]);
+        let status_code = match output_format {
+            Some(format) => runner
+                .output_format(Some(format))
+                .show_summary(vec!["none"])
+                .run(&mut writer, &mut reader),
+            None => runner
+                .show_summary(vec!["all"])
+                .run(&mut writer, &mut reader),
+        };
+
+        assert_eq!(
+            StatusCode::SUCCESS, status_code,
+            "a rule that does not apply exits 0; this test is about the explanation, not the verdict"
+        );
+
+        let output = writer.stripped().expect("failed to read the writer");
+        assert!(
+            output.contains(expected),
+            "the {} output for {} did not explain why the rule was skipped; wanted {:?} in:\n{}",
+            output_format.unwrap_or("console"),
+            data_file,
+            expected,
+            output
+        );
+    }
+
     /// The counterpart: a run with nothing wrong must not print the section.
     ///
     /// Without this, the assertion above is satisfied by a reporter that prints the explanation

--- a/guard/tests/validate.rs
+++ b/guard/tests/validate.rs
@@ -201,6 +201,29 @@ mod validate_tests {
     #[case(vec!["blank.yaml"], vec!["rules-dir/s3_bucket_public_read_prohibited.guard"], StatusCode::INTERNAL_FAILURE)]
     #[case(vec!["s3-server-side-encryption-template-non-compliant-2.yaml"], vec!["comments.guard"], StatusCode::SUCCESS)]
     #[case(vec!["s3-server-side-encryption-template-non-compliant-2.yaml"], vec!["comments.guard"], StatusCode::SUCCESS)]
+    // A rule whose only check compares against a reference that resolved to no values must
+    // not reach a successful exit. It used to: the comparison reported SKIP, the file status
+    // was SKIP, and the process exited 0 having enforced nothing. Exit code rather than
+    // reported status is the assertion that matters here, because 0 is what a CI gate reads,
+    // and SKIP and PASS are indistinguishable from outside the process.
+    // These fixtures sit at the resources/validate root rather than in data-dir/ and
+    // rules-dir/, because test_updated_summary_output evaluates every rules file in
+    // rules-dir/ against every data file in data-dir/ and compares the result to a
+    // checked-in golden output.
+    #[case(
+        vec!["bucket-with-no-kms-keys-template.yaml"],
+        vec!["denied_names_from_empty_reference.guard"],
+        StatusCode::VALIDATION_ERROR
+    )]
+    // The same comparison with the possibly-empty reference declared as a `when` guard. The
+    // condition fails, the rule does not apply, and exiting 0 is correct. Without this row
+    // the case above is also satisfied by failing every ruleset that mentions an empty
+    // reference, which would leave no way to express a permissibly-empty denylist.
+    #[case(
+        vec!["bucket-with-no-kms-keys-template.yaml"],
+        vec!["denied_names_guarded_by_not_empty.guard"],
+        StatusCode::SUCCESS
+    )]
     fn test_single_data_file_single_rules_file_status(
         #[case] data_arg: Vec<&str>,
         #[case] rules_arg: Vec<&str>,


### PR DESCRIPTION
Stacked on #717 — GitHub will not let a fork PR target another fork branch, so this is opened against `main` and shows #717's commits as well. The eight commits new here run from `70feb75` to `d56965c`. It is a draft until #717 merges, at which point the diff reduces to those eight.

#717 fixed two defects a reviewer found by reading. This branch went looking for the rest of that class by measuring instead: drive branch coverage over the evaluator, then treat every line that decides a PASS, FAIL or SKIP and has never executed as a bug candidate.

Three defects came out of it, and all three are fixed here. Two are the same failure mode as #717 — a rule that silently stops enforcing anything while exiting `0` — reached by different routes: a mixed integer/float comparison that no operand-type test covered, and a type block whose `when` condition was resolved from the wrong scope. The third is not a wrong answer but a maintenance trap: four evaluator arms that no rules file could reach, sitting in the function a reader would edit to fix a comparison bug.

Both language changes are documented in `d56965c`, and the migration for the one spelling that stops working is spelled out there and below.

## Commits

| Commit | What |
|---|---|
| `70feb75` | mixed integer and float operands were not comparable, which silently disarmed any gate that compared them |
| `7ea5c43` | 288-cell comparison matrix, the type block's status fold, and the root-scoped type-block `when` |
| `a023d09` | 176-cell unary operator matrix across every value shape |
| `eeddc92` | a type block's `when` conditions are evaluated against each resource, not the file root |
| `ca818b0` | a skipped rule can explain why it did not apply, in both console and structured output |
| `b104090` | narrows the map key filter comparator so four unreachable evaluator arms become impossible |
| `cc5a2f5` | asserts the status decisions no test in the suite reached |
| `d56965c` | documents the type block and the numeric comparison rule |

### `70feb75` — a number is a number

`compare_values` in `path_value.rs` matched Int/Int, Float/Float, String/String, Char/Char and Null/Null, with no arm across the two numeric types. Every mixed comparison fell to the `NotComparable` catch-all.

The visible half is a wrong FAIL: `Size > 10` against a template carrying `Size: 50.5` reported "PathAwareValues are not comparable float, int" and failed a compliant volume.

The half that matters is a wrong PASS. Put the same comparison in a `when` condition and `eval_rule` maps the non-PASS to `Status::SKIP`, which exits 0 and takes the guarded body with it:

```
rule large_volumes_are_encrypted when Resources.*[ Type == 'AWS::EC2::Volume' ].Properties.Size > 10 {
    Resources.*[ Type == 'AWS::EC2::Volume' ].Properties.Encrypted == true
}
```

| template | result |
|---|---|
| `Size: 50, Encrypted: false` | FAIL, exit 19 |
| `Size: 50.5, Encrypted: false` | SKIP, exit 0, nothing reported |

Changing one character in a template turns the encryption rule off. Reproduced on the merge-base `57bbdbf`, so it predates this work; the reason nobody hit it in review is that the `Ge`/`Gt`/`Lt`/`Le` paths had no test that reached them with operands of differing types.

The comparison is exact rather than `(i as f64).partial_cmp(f)`. `i64` above 2^53 does not survive a round trip through `f64`, so the lossy spelling answers `Equal` for 2^53+1 against 2^53. Casting the other way is safe once the float is bounds-checked, and the bound is 2^63 rather than `i64::MAX as f64` because the latter rounds *up* to 2^63 and would admit a float that then saturates on the cast. NaN stays `NotComparable`, which is what Float/Float already answered.

Mutation-verified twice: removing the arms restores `NotComparable`, and substituting the lossy spelling fails on the 2^53+1 case specifically. No existing test or golden file depended on the old behaviour.

### `7ea5c43` — the comparison matrix, and two type-block findings

`the_comparison_matrix_over_operand_types_is_pinned` evaluates 288 clauses end to end: six operators against eight left-hand operand types and six right-hand literals. What the grid asserts is the absence of a wrong PASS — a FAIL cell is a pairing that is undecidable or genuinely false, and PASS appears only where the comparison is decidable and true. Two cells look like mistakes and are not, so the doc comment names them: a list on the left distributes element-wise, so `[1,2,3] < 50` passes, and an absent property fails rather than skips.

`the_type_block_status_fold_is_pinned` covers `eval_type_block_clause`'s fold, which has the same shape as `eval_conjunction_clauses` and absorbs a per-resource SKIP the same way. No test reached any of its arms, including the one that decides whether a violating resource is reported at all.

`a_skipped_type_block_is_indistinguishable_from_a_clean_run` records a defect rather than fixing it. Inside one construct the scoping is not consistent: the block's clauses are resource-relative, but the `when` conditions are evaluated against the enclosing resolver, before the per-resource `ValueScope` exists. So

```
AWS::EC2::Volume when Properties.Size > 10 { Properties.Encrypted == true }
```

reads as "every volume over 10 GiB must be encrypted" and instead looks for `Properties` at the file root, finds nothing, and skips — reporting `not_applicable` and exit 0 for every template it is ever run against, including the ones it was written to catch. `when Resources.A.Properties.Size > 10` works. Both spellings are asserted, since the contrast is the whole finding.

I wrote an explanation onto that skip record and then removed it. It could not reach a reader: skipped rules arrive at the reporters as a `HashSet<String>` of names, so the message would have been recorded and discarded — which is the defect #717 just removed from five variants. `every_recorded_explanation_has_a_rendering_path` caught it, which is what that test is for. Surfacing it properly means the skip set has to carry reasons, and that changes the `report` signature every reporter implements.

Both halves are now fixed, in `eeddc92` and `ca818b0`.

### `eeddc92` — type block conditions are per resource

The conditions moved inside the loop over matched resources, so they are evaluated against the same scope as the clauses they guard. That also makes them per resource: one the condition exempts contributes to neither the pass nor the fail count, so an exempt resource cannot shield a violating one, and a block that applied to nothing answers SKIP rather than PASS.

The cost is the mirror image and it is real. A condition written as a literal root-anchored path — `when Resources.A.Properties.Size > 10` — resolved before and does not now, because `ValueScope::query` starts at the resource. Accepted for two reasons: a condition over one named resource does not belong on a block that iterates all of them, and the idiom real rulesets use is unaffected, since `ValueScope::resolve_variable` delegates to the parent and `let volumes = ...` followed by `when %volumes !empty` still resolves at the root. The test asserts all three spellings so the trade is visible rather than inferred.

Nothing in the repository depended on the old behaviour: a search for type blocks carrying a `when` found two occurrences, both fixtures added by this branch.

Rejected alternative: having `ValueScope` fall back to the parent root when a query does not resolve locally would keep both spellings working, but every unresolved path would retry against a different scope, so a typo in a resource-relative path would silently resolve somewhere else — trading a visible skip for an invisible wrong answer.

### `ca818b0` — a skipped rule can explain itself

`find_skip_reason` walks a rule's own record subtree for a block-shaped record that skipped with a message, and the three paths that report skips were widened to carry it: `FileReport` gained `not_applicable_reasons`, the console summary prints the reason under the rule, and `GenericReporter::report` takes a `SkippedRules` map instead of a `HashSet<String>`.

Both new serialised fields are `skip_serializing_if` empty, so a run with nothing to explain produces byte-identical output and no consumer of the JSON or YAML document sees a shape change. `BTreeMap` rather than `HashMap`, and the console printer sorts, because the underlying map is unordered and would otherwise reshuffle its own lines between runs.

Two explanations use the mechanism, and they are the pair worth telling apart. A type block whose query matched nothing says the type is absent, which is the ordinary reason for a rule not to apply. One whose condition exempted every matched resource says so, and that is the one worth a second look — a rule that never fires looks exactly like a rule that passes, because both report SKIP and exit 0.

The counting in `every_recorded_explanation_has_a_rendering_path` changed too. It counted the literal string `message: Some` and undercounted the moment a message was built in a `match` arm, reading 14 where the real figure was 15. It now counts by exclusion: every `message:` field that is not `None`, not a type annotation, and not a forward of the author's own `custom_message`. That cannot be fooled by a new spelling, and it separates evaluator explanations from the custom-message feature, which always rendered.

### `b104090` — the unreachable arms, removed by narrowing

`MapKeyFilterClause::comparator` was a `(CmpOperator, bool)`, which can express every operator, while `map_keys_match` parses four. `real_binary_operation` is reached only from `QueryPart::MapKeyFilter` and carried `Ge`, `Gt`, `Lt` and `Le` arms that recorded zero executions against the 288-clause matrix using those very operators.

Deleting them and keeping the wider type would have left them one parser change from returning and converted a currently-correct dead path into `unreachable!()`. A comment would have left the file permanently uncoverable and the trap intact — someone tracking an ordering bug finds the arm calling `compare_ge`, edits it, and sees no effect. A `MapKeyComparator` enum makes them impossible instead.

One user-visible consequence, an improvement rather than a regression: `parse-tree` serialises a map key filter's comparator as `Eq` rather than the two-element sequence `[Eq, false]`, and `!=` as `NotEq`. Regenerating the three affected golden files changed exactly one site — the other comparators in those documents belong to `AccessClause`, which keeps the pair. Hand-editing them first produced a wrong diff, because `AccessClause` also has a `compare_with` field and so cannot be told from a map key filter by its neighbours.

### `cc5a2f5` — the decisions nothing reached

A clause-level `not` in front of `EMPTY`, where the clause's negation composes with the operator's own; a negated parameterized call whose invoked rule reached a verdict; and a disjunction in which every disjunct skipped. All correct, which is worth stating as plainly as a bug would be — an audit that reports only its finds cannot be told apart from one that stopped early.

The negation fixtures are fussier than they look. A first version used a plain key path, which produces the right answer through a different code path entirely: `unary_operation` handles `EMPTY` on a filter-terminated or lone-variable query in a separate early-return block, and the clause-level flip lives inside it. The test passed while the arm stayed at zero. Coverage caught that the assertion was vacuous; reading the source would not have.

### `d56965c` — the language docs

Two of these changes alter what a rule means, so they belong in the docs. Type blocks with a `when` condition were undocumented — the only prior mention of type blocks anywhere in `docs/` is a passing note about variable scoping — so `COMPLEX_COMPOSITION.md` now covers the construct, the per-resource scoping, the three outcomes, and how to migrate a root-anchored condition. `CLAUSES.md` gains the numeric comparison rule under Binary Operators, with the `when` case spelled out because that is where the old behaviour cost enforcement rather than merely reporting a wrong verdict. `KNOWN_ISSUES.md` item 2 still holds for genuinely different kinds, so a note narrows it to exclude the numeric pair.

Every rule sample was run through `parse-tree`, and the worked example was executed against five templates to confirm each documented outcome. The last branch to write a docs claim about evaluator behaviour did not check it, and the claim was wrong.

### `a023d09` — the unary operators

176 cells: eight operators in both polarities against eleven operand shapes, including the empty and absent cases that separate `EMPTY` from `EXISTS`. `unary_operation` and the `is_*` family had no test walking them across shapes, which is how the negation arm arrived here uncovered.

Two behaviours are pinned on purpose. `EMPTY` on a container answers; on a scalar it is an incompatible-type error rather than a status, which is right because both statuses would be wrong — an int is not empty, but calling it non-empty implies the question made sense. And every negation must invert its positive form: a negated operator answering the same status as the positive one has stopped discriminating, which is the shape of the role-propagation defect #717 opens with.

## Coverage, and a caveat about measuring it

Stable 1.77.2, the pinned toolchain, emits no branch counters, so the branch column needs nightly. But nightly's `--branch` instrumentation splits sub-expressions into separate regions — `eval.rs` reports 842 regions on stable and 1855 on nightly — and marks struct-literal fields and closing punctuation *inside covered blocks* as uncovered. At `eval.rs:2070-2071`, two fields of a single struct literal report 45 executions and 0. So nightly's region and line percentages carry an artifact floor and are not comparable to anything CI reports; only its branch column is meaningful. The two toolchains also cannot share a target directory, since stable's `llvm-cov` rejects nightly-built artifacts outright.

Region and line coverage on the pinned toolchain, before and after:

| file | regions | lines |
|---|---|---|
| `eval.rs` | 67.93% -> 72.92% | 74.03% -> 77.86% |
| `eval/operators.rs` | 74.34% -> 76.60% | 74.84% -> 77.90% |
| `eval_context.rs` | 68.01% -> 68.21% | 72.09% -> 72.13% |
| `reporters/validate/cfn.rs` | 69.48% (unchanged) | 77.03% (unchanged) |

Branch coverage, which only nightly reports: `eval.rs` 71.88% -> 78.23%, `operators.rs` 82.14% (unchanged), `cfn.rs` 63.33% (unchanged), `eval_context.rs` 42.95% -> 43.67%.

The gains are modest next to the findings, and that is the honest shape of the result: the wrong-PASS class lives in the fold and role paths, which are a small share of the line count. What remains uncovered is mostly not status-deciding — `query_retrieval_with_converter` (173 lines of query shapes) and `report_all_failed_clauses_for_rules` (153 lines of reporter variants) in `eval_context.rs`, `operators::compare` (101), and the reporter's error-message formatting helpers (47 in `cfn.rs`).

Rather than chase the percentage, the sweep enumerated every line in these four files that produces or folds a PASS, FAIL or SKIP and had never executed, then closed the reachable ones. What is left is 13 error-propagation arms that require the resolver itself to fail, one `unreachable!()`, and the `EmptyRhs` arm already commented as unreached because its wrapper resolves the case into two other variants. None of them decides a verdict for input a rules file can express. `cfn.rs` has no uncovered status decisions at all.

## Verification

- 316 unit tests and 105 integration tests pass, nothing failing. Roughly 480 new assertion cells.
- Both the type-block scoping and the skip-reason plumbing are mutation-verified: severing `find_skip_reason` fails every case of `a_skipped_type_block_explains_itself_in_the_output`, and disabling only the console loop fails exactly the two console cases.
- `cargo clippy --all-features`, `cargo fmt --check`, `typos` and `shellcheck install-guard.sh` clean on the pinned 1.77.2.
- The mixed-numeric fix is mutation-verified against both the missing-arm and the lossy-conversion variants.
- Four golden-file tests fail on a newer toolchain and pass on 1.77.2. They compare output containing `std::any::type_name`, which is explicitly not stable across compiler versions: nightly prints `GuardClause` where 1.77.2 prints `GuardClause<'_>`. CI is unaffected, but they will break on a compiler bump. Unrelated to this branch and not addressed here.
