### PR TITLE
Fix release notes comparison range

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -246,13 +246,43 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Generate release notes
+        if: ${{ !inputs.dry_run && steps.check.outputs.exists == 'false' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PREVIOUS_TAG="$(gh release list \
+            --repo "${{ github.repository }}" \
+            --exclude-drafts \
+            --limit 1 \
+            --json tagName \
+            --jq '.[0].tagName')"
+          if [[ -z "$PREVIOUS_TAG" ]]; then
+            echo "::error::No previous published release found"
+            exit 1
+          fi
+
+          echo "Generating release notes from $PREVIOUS_TAG to $VERSION"
+          gh api --method POST \
+            "repos/${{ github.repository }}/releases/generate-notes" \
+            -f tag_name="$VERSION" \
+            -f previous_tag_name="$PREVIOUS_TAG" \
+            --jq '.body' > release-notes.md
+
       - name: Create release
-        if: ${{ !inputs.dry_run }}
+        if: ${{ !inputs.dry_run && steps.check.outputs.exists == 'false' }}
         uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ env.VERSION }}
           name: v${{ env.VERSION }}
-          generate_release_notes: ${{ steps.check.outputs.exists == 'false' }}
+          body_path: release-notes.md
+          files: artifacts/*.tar.gz
+
+      - name: Update existing release assets
+        if: ${{ !inputs.dry_run && steps.check.outputs.exists == 'true' }}
+        uses: softprops/action-gh-release@v3
+        with:
+          tag_name: ${{ env.VERSION }}
           files: artifacts/*.tar.gz
 
   # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- select the latest published release before generating notes
- pass its tag to GitHub's generate-notes API as `previous_tag_name`
- keep release reruns from regenerating or replacing existing notes

## Root cause
Release tags are created on separate `release/<version>` branches. Those tag commits are not ancestors of subsequent release tags, so GitHub's implicit ancestry-based selection skips recent versions and compares against an older reachable tag.

## Validation
- `actionlint .github/workflows/release.yml`
- parsed the workflow as YAML and checked the embedded Bash with `bash -n`
- reproduced GitHub generation for `3.2.1`: implicit generation selected `3.1.12...3.2.1`; explicit `previous_tag_name=3.2.0` selected `3.2.0...3.2.1`