### PR TITLE
ci: enforce Conventional Commits with commitizen

### DIFF
--- a/.github/workflows/commit-message.yml
+++ b/.github/workflows/commit-message.yml
@@ -1,0 +1,44 @@
+name: Commit Message
+
+# Pull requests are squash-merged here: 59 of the last 60 commits on main end in
+# `(#NNN)` and none is a merge commit, so the pull request title is what becomes
+# the commit message. Checking the title is therefore checking what lands.
+#
+# This is a workflow of its own rather than a job in pr.yml because pr.yml carries
+# `paths-ignore: guard/ts-lib/**`, so a pull request touching only that directory
+# does not run it. The title of such a pull request still lands on main and still
+# wants checking.
+#
+# Individual commits on the branch are deliberately not checked. They are squashed
+# away, so requiring each one to be well-formed would reject work in progress
+# without protecting anything. If the merge strategy ever changes to merge commits
+# or rebase, that reasoning stops holding and the `commitizen-branch` hook from the
+# same upstream repository is the thing to add.
+on:
+  pull_request:
+    # `edited` matters: it is what re-runs the check after a title is corrected.
+    types: [opened, edited, reopened, synchronize]
+
+permissions:
+  contents: read
+
+jobs:
+  conventional-title:
+    name: Pull request title follows Conventional Commits
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - run: pip install -r requirements-dev.txt
+      - name: Check the pull request title
+        env:
+          # Passed through the environment rather than interpolated into the script.
+          # A title is author-controlled text, and `${{ ... }}` is substituted before
+          # the shell sees the line, so interpolating it directly would let a title
+          # containing shell syntax run as part of this step.
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          printf '%s\n' "$PR_TITLE" > "$RUNNER_TEMP/pr-title.txt"
+          cz check --allow-abort --commit-msg-file "$RUNNER_TEMP/pr-title.txt"

--- a/.github/workflows/commit-message.yml
+++ b/.github/workflows/commit-message.yml
@@ -41,4 +41,21 @@ jobs:
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
           printf '%s\n' "$PR_TITLE" > "$RUNNER_TEMP/pr-title.txt"
-          cz check --allow-abort --commit-msg-file "$RUNNER_TEMP/pr-title.txt"
+          # No `--allow-abort`, and `--allowed-prefixes` with an empty list. Each of
+          # those two defaults lets a title through without its format being checked,
+          # and the title is what becomes the squash commit on main.
+          #
+          # `cz check` skips the Conventional Commits regex outright for a message
+          # beginning with one of its default allowed prefixes (Merge, Revert, Pull
+          # request, fixup!, squash!, amend!), so `Merge pull request #1 from nonsense`
+          # passes unchecked. Those prefixes are there for messages git itself writes
+          # during a merge or a rebase, which a pull request title is not. Passing the
+          # flag with no values leaves the set empty, so nothing is exempt.
+          #
+          # `--allow-abort` permits an empty message, the way a commit is abandoned from
+          # an editor. Git comment lines are stripped before the regex runs, so a title
+          # of `# invalid title` reduces to an empty message, which `--allow-abort` then
+          # accepts.
+          #
+          # A rejected title exits 14, not 1.
+          cz check --commit-msg-file "$RUNNER_TEMP/pr-title.txt" --allowed-prefixes

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,19 +1,29 @@
 name: Pre-Commit Hook CI
+
+# commit-message.yml and requirements-dev.txt are in the path list because
+# pre_commit_hooks_tests/test_commit_message_gate.py asserts on both: it reads the `cz check`
+# command out of that workflow and compares the commitizen pin in that requirements file against
+# the pre-commit hook's rev. Without them here, dropping a flag from the gate or unpinning
+# commitizen would change what those tests are about while leaving the tests unrun.
 on:
   push:
     paths:
       - pre_commit_hooks/**
       - pre_commit_hooks_tests/**
       - .github/workflows/pre-commit.yml
+      - .github/workflows/commit-message.yml
       - .pre-commit-config.yaml
       - .pre-commit-hooks.yaml
+      - requirements-dev.txt
   pull_request:
     paths:
       - pre_commit_hooks/**
       - pre_commit_hooks_tests/**
       - .github/workflows/pre-commit.yml
+      - .github/workflows/commit-message.yml
       - .pre-commit-config.yaml
       - .pre-commit-hooks.yaml
+      - requirements-dev.txt
 permissions:
   contents: read
 jobs:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,13 @@
+# The commitizen hook below runs at the `commit-msg` stage, and `pre-commit install`
+# installs only the `pre-commit` stage unless it is told otherwise. Without this
+# line the hook is configured, reported by `pre-commit run --all-files` as skipped,
+# and never actually checks a commit message. Contributors who already ran
+# `pre-commit install` before this change need to run it again to pick up the new
+# hook type.
+default_install_hook_types:
+-   pre-commit
+-   commit-msg
+
 repos:
 -   repo: https://github.com/aws-cloudformation/cloudformation-guard
     rev: pre-commit-v0.0.2
@@ -12,3 +22,7 @@ repos:
                 - --operation=test
                 - --dir=pre_commit_hooks_tests/resources/
             files: ^pre_commit_hooks_tests/resources.*
+-   repo: https://github.com/commitizen-tools/commitizen
+    rev: v4.10.1
+    hooks:
+        -   id: commitizen

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,13 +37,56 @@ To send us a pull request, please:
    cargo install cargo-about
    cargo about generate about.hbs > ATTRIBUTION
    ```
-5. Commit to your fork using clear commit messages.
+5. Commit to your fork using clear commit messages that follow [Conventional Commits](#commit-messages).
 6. Send us a pull request, answering any default questions in the pull request interface.
 7. Pay attention to any automated CI failures reported in the pull request, and stay involved in the conversation.
 8. If your pull request includes rules for the Examples, please review the [Examples README](guard-examples/README.md) for the acceptance criteria.
 
 GitHub provides additional document on [forking a repository](https://help.github.com/articles/fork-a-repo/) and
 [creating a pull request](https://help.github.com/articles/creating-a-pull-request/).
+
+
+## Commit messages
+
+Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/): a type, an
+optional scope, then a short description.
+
+```
+fix: prevent silent policy enforcement failures
+fix(deps): update undici to 6.28.0
+feat: add a --structured flag to validate
+chore: bump version to 3.2.1
+```
+
+The accepted types are `build`, `bump`, `chore`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`,
+`style` and `test`. A scope in parentheses is optional, as in `fix(deps):`. A `!` before the colon, as in
+`feat!:`, marks a breaking change. Version bumps in this repository have used `chore:` rather than `bump:`.
+
+**Pull requests are squash-merged, so the pull request title becomes the commit message on `main`.** That title
+is what CI checks; the individual commits on your branch are not checked, so you are free to commit however
+suits you while you work.
+
+[commitizen](https://commitizen-tools.github.io/commitizen/) is configured to help with both writing and
+checking messages:
+
+```bash
+pip install -r requirements-dev.txt
+
+cz commit          # prompts for type, scope and description, then commits
+cz check --rev-range origin/main..HEAD    # check what you have written so far
+```
+
+To have your messages checked as you commit, install the git hooks once:
+
+```bash
+pre-commit install
+```
+
+If you installed the hooks before commitizen was added, run `pre-commit install` again — the message check runs
+at the `commit-msg` stage, which is a hook type that has to be installed separately from the others.
+
+Version numbers and tags are not managed by commitizen; `.github/workflows/release.yml` owns those. `cz bump
+--dry-run` is still a convenient way to see which version the commits since the last release imply.
 
 
 ## Finding contributions to work on

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,8 +85,26 @@ pre-commit install
 If you installed the hooks before commitizen was added, run `pre-commit install` again — the message check runs
 at the `commit-msg` stage, which is a hook type that has to be installed separately from the others.
 
-Version numbers and tags are not managed by commitizen; `.github/workflows/release.yml` owns those. `cz bump
---dry-run` is still a convenient way to see which version the commits since the last release imply.
+Version numbers and tags are not managed by commitizen; `.github/workflows/release.yml` owns those.
+
+Do not use `cz bump --dry-run` to pick a release version here. It reports a wrong version and exits 0 while
+doing it. Commitizen reads the current version from the newest tag that is an ancestor of `HEAD`, and the
+release tags are not ancestors: pull requests are squash-merged, so the commit `release.yml` tagged and the
+commit that landed on `main` are two different objects. The newest release tag reachable from `main` is
+therefore older than the actual latest release, and both halves of the output come from that wrong starting
+point — the version it calls current, and the increment it derives from the commits it believes are
+unreleased. When this was written it proposed 3.2.0, which had already been released, and it read the increment
+as minor from `feat:` commits that shipped in earlier releases.
+
+To choose a release version, read the latest tag and apply the increment implied by the Conventional Commits
+types merged since it — `fix:` is a patch, `feat:` is a minor, and a `!` is a major:
+
+```bash
+git tag --sort=-v:refname | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | head -1
+```
+
+The filter matters: this repository also carries `action-v*`, `pre-commit-v*` and older `v`-prefixed tags, and
+an unfiltered `git tag --sort=-v:refname` sorts one of those to the top.
 
 
 ## Finding contributions to work on

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,6 +66,12 @@ The accepted types are `build`, `bump`, `chore`, `ci`, `docs`, `feat`, `fix`, `p
 is what CI checks; the individual commits on your branch are not checked, so you are free to commit however
 suits you while you work.
 
+One title shape fails the check in a way you might not expect. GitHub's revert button proposes
+`Revert "<original title>"`, which is not a Conventional Commits subject and is rejected. Retitle it to
+`revert: <what you are reverting>`; `revert` is one of the accepted types. `Revert` titles are not exempted,
+because commitizen's prefix exemption is a plain `startswith` — exempting the revert button's output would
+also exempt every other title beginning with those letters, unchecked.
+
 [commitizen](https://commitizen-tools.github.io/commitizen/) is configured to help with both writing and
 checking messages:
 

--- a/pre_commit_hooks/cfn_guard.py
+++ b/pre_commit_hooks/cfn_guard.py
@@ -2,6 +2,9 @@
 This module contains the logic for the cfn-guard pre-commit hook
 """
 
+from __future__ import annotations
+
+import argparse
 import os
 import platform
 import shutil
@@ -9,9 +12,8 @@ import subprocess
 import sys
 import tarfile
 import tempfile
-import argparse
 from pathlib import Path
-from typing import Sequence, Union
+from typing import Sequence
 from urllib.request import Request, urlopen
 
 BIN_NAME = "cfn-guard"
@@ -84,9 +86,8 @@ def install_cfn_guard():
     if current_os in supported_oses:
         url = release_urls_dict[current_os].replace("TAG", GUARD_BINARY_VERSION)
         # Download tarball of release from Github
-        with tempfile.NamedTemporaryFile(delete=False) as temp_file:
-            with urlopen(url) as response:
-                shutil.copyfileobj(response, temp_file)
+        with tempfile.NamedTemporaryFile(delete=False) as temp_file, urlopen(url) as response:
+            shutil.copyfileobj(response, temp_file)
 
         # Create the install_dir if it doesn't exist
         os.makedirs(install_dir, exist_ok=True)
@@ -100,12 +101,10 @@ def install_cfn_guard():
                 filename = os.path.basename(member.name)
                 # Join the install_dir path and the filename to get the full target path
                 file_path = os.path.join(install_dir, filename)
-                # Open the archived file
-                with tar.extractfile(member) as source:
-                    # Create a new file using the file_path with write binary mode
-                    with open(file_path, "wb") as target:
-                        # Copy the contents of the archived file(s) to the target file
-                        shutil.copyfileobj(source, target)
+                # Open the archived file, create a new file at file_path in write
+                # binary mode, and copy the archived contents into it
+                with tar.extractfile(member) as source, open(file_path, "wb") as target:
+                    shutil.copyfileobj(source, target)
 
         binary_path = os.path.join(install_dir, binary_name)
         os.chmod(binary_path, 0o755)
@@ -135,7 +134,7 @@ def run_cfn_guard(args: str) -> int:
         return run_cfn_guard(args)
 
 
-def main(argv: Union[Sequence[str], None] = None) -> int:
+def main(argv: Sequence[str] | None = None) -> int:
     """Entry point for the pre-commit hook"""
     if argv is None:
         argv = sys.argv[1:]

--- a/pre_commit_hooks/cfn_guard.py
+++ b/pre_commit_hooks/cfn_guard.py
@@ -12,8 +12,8 @@ import subprocess
 import sys
 import tarfile
 import tempfile
+from collections.abc import Sequence
 from pathlib import Path
-from typing import Sequence
 from urllib.request import Request, urlopen
 
 BIN_NAME = "cfn-guard"
@@ -101,9 +101,9 @@ def install_cfn_guard():
                 filename = os.path.basename(member.name)
                 # Join the install_dir path and the filename to get the full target path
                 file_path = os.path.join(install_dir, filename)
-                # Open the archived file, create a new file at file_path in write
-                # binary mode, and copy the archived contents into it
+                # Open the archived file, and a new file at file_path in write binary mode
                 with tar.extractfile(member) as source, open(file_path, "wb") as target:
+                    # Copy the contents of the archived file(s) to the target file
                     shutil.copyfileobj(source, target)
 
         binary_path = os.path.join(install_dir, binary_name)

--- a/pre_commit_hooks_tests/test_cfn_guard.py
+++ b/pre_commit_hooks_tests/test_cfn_guard.py
@@ -5,9 +5,9 @@ cfn-guard args and returns the expected error code
 
 from __future__ import annotations
 
-from pre_commit_hooks.cfn_guard import main
-
 import os.path
+
+from pre_commit_hooks.cfn_guard import main
 
 
 def get_guard_resource_path(relative_path):

--- a/pre_commit_hooks_tests/test_commit_message_gate.py
+++ b/pre_commit_hooks_tests/test_commit_message_gate.py
@@ -7,7 +7,14 @@ command's defaults let a title through without its format being checked at all. 
 skips the Conventional Commits regex outright for a message beginning with one of its default
 allowed prefixes -- Merge, Revert, Pull request, fixup!, squash!, amend! -- and `--allow-abort`
 accepts an empty message, which is what `# invalid title` reduces to once git comment lines are
-stripped. Both were measured: with the defaults in place all three of the titles below passed.
+stripped.
+
+Both were measured against the command as first written, `cz check --allow-abort
+--commit-msg-file F`: seven of the eight titles below passed it, everything except the plain
+unconventional control. The two fixes are independent, and each closes only its own half.
+Emptying the prefix list closes the six prefix titles and does nothing for `# invalid title`;
+dropping `--allow-abort` closes `# invalid title` and does nothing for the six. Both flags are
+therefore load-bearing, which is why each bypass has its own case here.
 
 Since the title becomes the squash commit on main, a flag quietly dropped from that command
 reopens the bypass with nothing failing. These tests are what fail instead.
@@ -35,7 +42,18 @@ REJECTED = [
     # The `Merge` and `Revert` default prefixes. Those exist for messages git itself writes
     # during a merge or a rebase, which a pull request title is not.
     ("Merge pull request #1 from nonsense", "Merge default prefix"),
-    ("Revert whatever I feel like, unformatted", "Revert default prefix"),
+    # The `Revert` case uses the shape GitHub's revert button actually produces, because that is
+    # the one closed bypass whose closure costs a contributor anything: they get a red check and
+    # have to retitle. Two commits reached main this way -- `Revert "Bumping up clap-rs (#294)"
+    # (#299)` and `Revert "Filter as skips (#38)" (#39)` -- against 641 commits of history, with
+    # no conventional `revert:` commit at all.
+    #
+    # Rejecting it is still right, and not for tidiness. `--allowed-prefixes Revert` cannot be
+    # narrowed to that shape: commitizen matches with `commit_msg.startswith(prefix)`, so such an
+    # allowance also exempts `Reverted the thing, no type at all` from the regex entirely. Both
+    # were measured. `revert:` is an accepted type here and is in ACCEPTED below, so the fix for
+    # a revert-button title is one retitle.
+    ('Revert "fix: keep the digits above i64::MAX"', "Revert default prefix"),
     ("Pull request: nothing conventional here", "Pull request default prefix"),
     ("fixup! not a real type", "fixup! default prefix"),
     ("squash! not a real type", "squash! default prefix"),
@@ -57,6 +75,10 @@ ACCEPTED = [
     "fix(values): keep the digits above i64::MAX",
     "feat!: a breaking change",
     "docs: a note",
+    # The conventional form of a revert. CONTRIBUTING.md tells contributors to retitle a
+    # revert-button pull request to this, so it has to keep working -- otherwise that advice goes
+    # stale with nothing failing.
+    "revert: keep the digits above i64::MAX",
 ]
 
 

--- a/pre_commit_hooks_tests/test_commit_message_gate.py
+++ b/pre_commit_hooks_tests/test_commit_message_gate.py
@@ -1,0 +1,189 @@
+# Copyright Amazon Web Services, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""The pull request title gate rejects the titles it is there to reject.
+
+Why this exists: the gate is one `cz check` invocation in a workflow file, and two of that
+command's defaults let a title through without its format being checked at all. `cz check`
+skips the Conventional Commits regex outright for a message beginning with one of its default
+allowed prefixes -- Merge, Revert, Pull request, fixup!, squash!, amend! -- and `--allow-abort`
+accepts an empty message, which is what `# invalid title` reduces to once git comment lines are
+stripped. Both were measured: with the defaults in place all three of the titles below passed.
+
+Since the title becomes the squash commit on main, a flag quietly dropped from that command
+reopens the bypass with nothing failing. These tests are what fail instead.
+
+The command is read out of the workflow rather than restated here. A copy would keep passing
+after the workflow changed, which is the failure mode being guarded against -- the point is to
+pin what CI actually runs, not what this file remembers it running.
+"""
+
+from __future__ import annotations
+
+import os.path
+import re
+import shutil
+import subprocess
+import sys
+
+import pytest
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+WORKFLOW = os.path.join(REPO_ROOT, ".github", "workflows", "commit-message.yml")
+
+# Titles that must be rejected, each with the specific bypass it exercises.
+REJECTED = [
+    # The `Merge` and `Revert` default prefixes. Those exist for messages git itself writes
+    # during a merge or a rebase, which a pull request title is not.
+    ("Merge pull request #1 from nonsense", "Merge default prefix"),
+    ("Revert whatever I feel like, unformatted", "Revert default prefix"),
+    ("Pull request: nothing conventional here", "Pull request default prefix"),
+    ("fixup! not a real type", "fixup! default prefix"),
+    ("squash! not a real type", "squash! default prefix"),
+    ("amend! not a real type", "amend! default prefix"),
+    # Every git comment line is stripped before the regex runs, so this reduces to an empty
+    # message -- which `--allow-abort` accepts.
+    ("# invalid title", "comment-only title reducing to empty via --allow-abort"),
+    # A plain unconventional title, which is the case the gate is obviously for. Included so a
+    # command that rejected everything, including valid titles, is still distinguishable from
+    # one that works: the accepted cases below are the other half of that.
+    ("just some words", "no Conventional Commits type"),
+]
+
+# Titles that must be accepted, so a gate that rejects everything fails too. Without these the
+# suite would pass for a `cz check` that had been broken into rejecting its own repository's
+# commit style.
+ACCEPTED = [
+    "ci: enforce Conventional Commits with commitizen",
+    "fix(values): keep the digits above i64::MAX",
+    "feat!: a breaking change",
+    "docs: a note",
+]
+
+
+def workflow_cz_check_command() -> list[str]:
+    """The `cz check` argv the workflow runs, with the message-file placeholder removed.
+
+    Read from the workflow so the assertion follows the command CI runs. The message file is
+    substituted per case by the caller, since each title needs its own.
+    """
+    with open(WORKFLOW, encoding="utf-8") as handle:
+        workflow = handle.read()
+
+    lines = [line.strip() for line in workflow.splitlines() if re.match(r"^\s*cz check\b", line)]
+    assert len(lines) == 1, (
+        f"expected exactly one `cz check` line in {WORKFLOW}, found {len(lines)}: {lines}. "
+        "These tests pin that command, so more than one means the wrong thing would be checked."
+    )
+
+    argv = lines[0].split()
+
+    # The workflow points --commit-msg-file at $RUNNER_TEMP; each case below supplies its own
+    # path instead. Dropping the flag and its value here keeps everything else -- notably the
+    # presence or absence of --allow-abort and --allowed-prefixes -- exactly as CI has it.
+    try:
+        index = argv.index("--commit-msg-file")
+    except ValueError:  # pragma: no cover - the flag is the point of the command
+        pytest.fail(f"the `cz check` line in {WORKFLOW} has no --commit-msg-file: {argv}")
+    del argv[index : index + 2]
+
+    return argv
+
+
+def run_cz_check(title: str, tmp_path) -> subprocess.CompletedProcess:
+    if shutil.which("cz") is None:
+        pytest.skip("commitizen is not installed; `pip install -r requirements-dev.txt`")
+
+    message_file = tmp_path / "pr-title.txt"
+    # printf '%s\n', matching the workflow: cz check reads a file, and a title with no trailing
+    # newline is not what CI hands it.
+    message_file.write_text(title + "\n", encoding="utf-8")
+
+    argv = workflow_cz_check_command() + ["--commit-msg-file", str(message_file)]
+    return subprocess.run(
+        argv,
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+@pytest.mark.parametrize(("title", "bypass"), REJECTED, ids=[b for _, b in REJECTED])
+def test_malformed_titles_are_rejected(title, bypass, tmp_path):
+    result = run_cz_check(title, tmp_path)
+    assert result.returncode != 0, (
+        f"`{title}` was accepted, so the {bypass} is open. The pull request title becomes the "
+        f"squash commit on main, so this lands unconventional. Check that the `cz check` line in "
+        f"{WORKFLOW} still passes --allowed-prefixes and still omits --allow-abort.\n"
+        f"stdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+    # 14 is cz check's rejection code specifically. Asserting on it rather than on "nonzero"
+    # alone keeps a crash -- a missing config file, an unparsable pyproject -- from reading as a
+    # correctly rejected title.
+    assert result.returncode == 14, (
+        f"`{title}` failed with exit {result.returncode} rather than 14, which is the code "
+        f"cz check uses for a rejected message. Another code means the command did not run to a "
+        f"verdict.\nstdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+
+
+@pytest.mark.parametrize("title", ACCEPTED)
+def test_conventional_titles_are_accepted(title, tmp_path):
+    result = run_cz_check(title, tmp_path)
+    assert result.returncode == 0, (
+        f"`{title}` is a well-formed Conventional Commits title and was rejected, so the gate "
+        f"would block correct work.\nstdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+
+
+def test_the_gate_pins_commitizen_to_the_pre_commit_hook_version():
+    """CI and the pre-commit hook must validate with the same commitizen.
+
+    `cz check`'s behavior is the thing under test, and its defaults have changed between
+    releases -- the allowed-prefix list is a default, and so is the exit code above. An
+    unpinned CI install resolves to whatever is newest, so a local pass would stop predicting
+    a CI pass without either file changing.
+    """
+    with open(os.path.join(REPO_ROOT, "requirements-dev.txt"), encoding="utf-8") as handle:
+        requirements = handle.read()
+    with open(os.path.join(REPO_ROOT, ".pre-commit-config.yaml"), encoding="utf-8") as handle:
+        pre_commit = handle.read()
+
+    pinned = re.search(r"^commitizen==(\S+)\s*$", requirements, re.MULTILINE)
+    assert pinned, (
+        "requirements-dev.txt does not pin commitizen to an exact version. CI installs from "
+        "this file, so an unpinned entry lets CI and local pre-commit run different versions."
+    )
+
+    hook_versions = re.findall(r"commitizen-tools/commitizen\s*\n\s*rev:\s*v?(\S+)", pre_commit)
+    assert hook_versions, (
+        "no commitizen rev found in .pre-commit-config.yaml; this test needs it to compare "
+        "against the requirements-dev.txt pin."
+    )
+    for hook_version in hook_versions:
+        assert hook_version == pinned.group(1), (
+            f"the pre-commit hook uses commitizen {hook_version} but requirements-dev.txt pins "
+            f"{pinned.group(1)}. Local and CI validation would differ."
+        )
+
+
+def test_commitizen_under_test_matches_the_pin():
+    """The installed cz is the pinned one, so the cases above measure what CI measures."""
+    if shutil.which("cz") is None:
+        pytest.skip("commitizen is not installed; `pip install -r requirements-dev.txt`")
+
+    with open(os.path.join(REPO_ROOT, "requirements-dev.txt"), encoding="utf-8") as handle:
+        pinned = re.search(r"^commitizen==(\S+)\s*$", handle.read(), re.MULTILINE)
+    assert pinned, "requirements-dev.txt does not pin commitizen"
+
+    result = subprocess.run(
+        [sys.executable, "-m", "commitizen", "version"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    installed = result.stdout.strip()
+    assert installed == pinned.group(1), (
+        f"commitizen {installed} is installed but requirements-dev.txt pins "
+        f"{pinned.group(1)}, so the assertions above are not measuring the version CI uses."
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,3 +2,37 @@
 line-length = 100
 target-version = ['py37']
 include = '\.pyi?$'
+
+# Conventional Commits, via commitizen-tools/commitizen.
+#
+# `cz commit` prompts for a well-formed message; `cz check` validates one. Both
+# are described in CONTRIBUTING.md. The settings below describe how this
+# repository already releases, so that anything commitizen derives from history
+# agrees with what is actually tagged.
+[tool.commitizen]
+name = "cz_conventional_commits"
+
+# Releases are tagged bare, without a `v` prefix: 3.2.1, 3.2.0, 3.1.12. Two other
+# tag families exist for the sub-artifacts, `action-v*` and `pre-commit-v*`, and
+# they are deliberately not matched by this pattern.
+tag_format = "$version"
+
+# The version lives in git tags, and `.github/workflows/release.yml` is what puts
+# it there: it takes the version as a workflow input, rewrites the `[package]`
+# version in each crate's Cargo.toml, commits, tags and publishes. Pointing
+# commitizen at the tags rather than at a version stored here keeps that workflow
+# the single thing that decides a version, instead of adding a second place that
+# has to be kept in step with it.
+#
+# `cz bump` is therefore not wired into CI. `cz bump --dry-run` is still useful
+# locally: it reports the version the commits since the last tag imply, which is
+# a reasonable way to choose the input to give the release workflow.
+version_provider = "scm"
+
+# Conventional Commits became the practice here partway through the project's
+# history: of the 120 commits before this change, 81 satisfy `cz check` and 39 do
+# not, the latter being older bracket-style subjects such as `[BUG] Update
+# Toolchain` and dependabot's `Bump <dep> from x to y`. A changelog generated
+# across that boundary would be missing the earlier half rather than describing
+# it, so generation starts from the current release.
+changelog_start_rev = "3.2.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,25 @@ line-length = 100
 target-version = ['py37']
 include = '\.pyi?$'
 
+# Ruff has to be told which Python this hook runs on. It normally infers the
+# floor from `project.requires-python`, which does not exist here: the hook is
+# packaged from setup.cfg, where `python_requires = >=3.8`. With nothing to infer
+# from, ruff assumes a current interpreter and its pyupgrade rules then propose
+# syntax that is invalid at the declared floor.
+#
+# This setting is load-bearing, not decoration. Removing it makes UP035 fire and
+# ask for `from collections.abc import Sequence`; ruff also asked for PEP 604
+# unions before `from __future__ import annotations` was added to cfn_guard.py,
+# and without that import `Sequence[str] | None` raises
+# `TypeError: unsupported operand type(s) for |` at import time on 3.9. CI runs
+# `python-version: '3.x'`, so it resolves to a modern interpreter where both
+# rewrites look fine -- nothing in CI would have caught either break.
+#
+# Because these rules are version-gated rather than disabled, they start applying
+# again on their own once the floor moves up. Keep this in step with setup.cfg.
+[tool.ruff]
+target-version = "py38"
+
 # Conventional Commits, via commitizen-tools/commitizen.
 #
 # `cz commit` prompts for a well-formed message; `cz check` validates one. Both

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,9 +43,11 @@ tag_format = "$version"
 # the single thing that decides a version, instead of adding a second place that
 # has to be kept in step with it.
 #
-# `cz bump` is therefore not wired into CI. `cz bump --dry-run` is still useful
-# locally: it reports the version the commits since the last tag imply, which is
-# a reasonable way to choose the input to give the release workflow.
+# `cz bump` is therefore not wired into CI, and `cz bump --dry-run` is not a way
+# to choose the version to hand it either. Squash merges leave the release tags
+# off `main`'s ancestry, so commitizen reads a stale current version and derives
+# the increment from commits that already shipped: it reports a wrong version and
+# exits 0 doing it. CONTRIBUTING.md has the mechanism and the manual procedure.
 version_provider = "scm"
 
 # Conventional Commits became the practice here partway through the project's

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 pytest
 mypy
 black
-ruff
+ruff>=0.16.4,<0.17
 commitizen

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,3 +2,4 @@ pytest
 mypy
 black
 ruff
+commitizen

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,4 +2,4 @@ pytest
 mypy
 black
 ruff>=0.16.4,<0.17
-commitizen
+commitizen==4.10.1


### PR DESCRIPTION
Conventional Commits are already the practice in this repository — **81 of the last 120 commits on `main` satisfy `cz check`** — but nothing enforces them and nothing helps an author write one. This wires up [commitizen](https://commitizen-tools.github.io/commitizen/) for both.

## What this adds

| file | change |
|---|---|
| `pyproject.toml` | `[tool.commitizen]`, configured to match how this repository actually releases |
| `.pre-commit-config.yaml` | the upstream commitizen hook at the `commit-msg` stage |
| `.github/workflows/commit-message.yml` | checks the pull request title |
| `requirements-dev.txt` | `commitizen` |
| `CONTRIBUTING.md` | a `Commit messages` section |

## Three decisions, each with a plausible alternative

**`cz bump` is deliberately not wired in.** `release.yml` already owns versioning: it takes a version as a workflow input, rewrites the `[package]` version in each crate's `Cargo.toml`, then commits, tags and publishes. Adding `cz bump` would give the version two owners. So commitizen is pointed at the git tags (`version_provider = "scm"`) rather than at a version stored in config, and no fourth place has to be kept in step with the three `Cargo.toml` files. `cz bump --dry-run` still reports the version the commits since the last tag imply, which is a reasonable way to choose the input to give `release.yml`.

**CI checks the pull request title, not the individual commits.** Pull requests are squash-merged here — 59 of the last 60 commits on `main` end in `(#NNN)` and none is a merge commit — so the title is what becomes the commit message. Requiring every commit on a branch to be well-formed would reject work in progress without protecting `main`. If the merge strategy ever changes to merge commits or rebase, the `commitizen-branch` hook from the same upstream repository is the thing to add, and there is a comment in the workflow saying so.

**It is its own workflow rather than a job in `pr.yml`.** `pr.yml` carries `paths-ignore: guard/ts-lib/**`, so a pull request touching only that directory does not run it — and the title of such a pull request still lands on `main`.

## Two things that would otherwise fail silently

**`default_install_hook_types` is set.** A `commit-msg` hook is not installed by a bare `pre-commit install`; only the `pre-commit` stage is. Without that line the hook would be configured, reported by `pre-commit run` as skipped, and never check anything. Contributors who installed hooks before this change need to run `pre-commit install` again — `CONTRIBUTING.md` says so.

**The pull request title reaches the check through the environment, not `${{ }}` interpolation.** A title is author-controlled text, and interpolation is substituted before the shell parses the line, so a title containing shell syntax would otherwise run as part of the step.

## Why the changelog is not generated here

`changelog_start_rev` is set to the current release. Of the 120 commits before this change, **39 do not satisfy `cz check`** — older bracket-style subjects such as `[BUG] Update Toolchain`, and dependabot's `Bump <dep> from x to y`. A changelog generated across that boundary would omit the earlier half rather than describe it, so generation starts from `3.2.1`.

## Verification

- A non-conventional message is rejected by the hook at exit code 14 (`commitizen check.....Failed`), and a conventional one commits. Confirmed it is the commitizen hook rejecting it, not the existing `cfn-guard` hook, which passes in both cases.
- `pre-commit install` with **no flags** lands both `.git/hooks/pre-commit` and `.git/hooks/commit-msg`.
- `cz check` works in a **shallow clone with zero tags**, which is what CI checks out — the one real risk in choosing `version_provider = "scm"`.
- The twelve types named in `CONTRIBUTING.md` are exactly the twelve the configured pattern accepts, each confirmed individually against `cz check`.
- `pre-commit run` and `pre-commit run --all-files` output is unchanged: commitizen is a `commit-msg`-stage hook and appears in neither. `pre-commit.yml` greps that output for `exit code: 19` and `exit code: 7`, so this matters.
- This pull request's own commit message and title both pass `cz check`.

`black --check` was not run locally — the module is not installed in this environment. No `.py` files are changed, so it is unaffected.
