### PR TITLE
fix: satisfy ruff's expanded default rule set, and cap the version

### DIFF
--- a/pre_commit_hooks/cfn_guard.py
+++ b/pre_commit_hooks/cfn_guard.py
@@ -2,6 +2,9 @@
 This module contains the logic for the cfn-guard pre-commit hook
 """
 
+from __future__ import annotations
+
+import argparse
 import os
 import platform
 import shutil
@@ -9,9 +12,8 @@ import subprocess
 import sys
 import tarfile
 import tempfile
-import argparse
+from collections.abc import Sequence
 from pathlib import Path
-from typing import Sequence, Union
 from urllib.request import Request, urlopen
 
 BIN_NAME = "cfn-guard"
@@ -84,9 +86,8 @@ def install_cfn_guard():
     if current_os in supported_oses:
         url = release_urls_dict[current_os].replace("TAG", GUARD_BINARY_VERSION)
         # Download tarball of release from Github
-        with tempfile.NamedTemporaryFile(delete=False) as temp_file:
-            with urlopen(url) as response:
-                shutil.copyfileobj(response, temp_file)
+        with tempfile.NamedTemporaryFile(delete=False) as temp_file, urlopen(url) as response:
+            shutil.copyfileobj(response, temp_file)
 
         # Create the install_dir if it doesn't exist
         os.makedirs(install_dir, exist_ok=True)
@@ -100,12 +101,10 @@ def install_cfn_guard():
                 filename = os.path.basename(member.name)
                 # Join the install_dir path and the filename to get the full target path
                 file_path = os.path.join(install_dir, filename)
-                # Open the archived file
-                with tar.extractfile(member) as source:
-                    # Create a new file using the file_path with write binary mode
-                    with open(file_path, "wb") as target:
-                        # Copy the contents of the archived file(s) to the target file
-                        shutil.copyfileobj(source, target)
+                # Open the archived file, and a new file at file_path in write binary mode
+                with tar.extractfile(member) as source, open(file_path, "wb") as target:
+                    # Copy the contents of the archived file(s) to the target file
+                    shutil.copyfileobj(source, target)
 
         binary_path = os.path.join(install_dir, binary_name)
         os.chmod(binary_path, 0o755)
@@ -135,7 +134,7 @@ def run_cfn_guard(args: str) -> int:
         return run_cfn_guard(args)
 
 
-def main(argv: Union[Sequence[str], None] = None) -> int:
+def main(argv: Sequence[str] | None = None) -> int:
     """Entry point for the pre-commit hook"""
     if argv is None:
         argv = sys.argv[1:]

--- a/pre_commit_hooks_tests/test_cfn_guard.py
+++ b/pre_commit_hooks_tests/test_cfn_guard.py
@@ -5,9 +5,9 @@ cfn-guard args and returns the expected error code
 
 from __future__ import annotations
 
-from pre_commit_hooks.cfn_guard import main
-
 import os.path
+
+from pre_commit_hooks.cfn_guard import main
 
 
 def get_guard_resource_path(relative_path):

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
 pytest
 mypy
 black
-ruff
+ruff>=0.16.4,<0.17


### PR DESCRIPTION
`ruff check ./pre_commit_hooks_tests/ ./pre_commit_hooks` fails on **every** open pull request, and has since ruff 0.16 shipped. The `Pre-Commit Hook CI` workflow last passed on 2026-03-30.

## What is happening

`requirements-dev.txt` pins nothing, so CI installs whatever is current at run time. The most recent run installed `ruff-0.16.4`, and **0.16 expanded which rules are on by default**. The six findings are all pre-existing code that earlier ruff releases did not look at — nothing in the failing pull requests touches these files.

Reproduced on an unmodified `main` with ruff 0.16.4:

| rule | site | what |
|---|---|---|
| `I001` ×2 | `cfn_guard.py:5`, `test_cfn_guard.py:6` | import block unsorted |
| `UP035` | `cfn_guard.py:14` | import `Sequence` from `collections.abc` |
| `UP007` | `cfn_guard.py:138` | `X \| Y` in an annotation |
| `SIM117` ×2 | `cfn_guard.py:87`, `:104` | nested `with` |

Local ruff 0.15.5 reports `All checks passed!` on the same tree, which is how this went unnoticed.

## The part that is not cosmetic

`from __future__ import annotations` is added to `pre_commit_hooks/cfn_guard.py` **before** the other fixes, and it is what makes them safe.

`setup.cfg` declares `python_requires = >=3.8`. Without that import, `Sequence[str] | None` is a runtime `TypeError` before Python 3.10, and a subscripted `collections.abc.Sequence` before 3.9. This package is published and used as a pre-commit hook, so those interpreters are real. **Applying ruff's suggestions as-is would have made the hook fail to import on Pythons this repository says it supports.** `pre_commit_hooks_tests/test_cfn_guard.py` already carries the same import, so this follows the file next to it.

The two `SIM117` sites combine two context managers into a single `with`, kept on one line — the parenthesized multi-line form requires 3.10.

## Capping ruff, which is the part that stops this recurring

`requirements-dev.txt` now says `ruff>=0.16.4,<0.17`. Without a cap, the next minor release can expand the default set again and redden every open pull request, which is what happened here. With it, raising the version becomes a deliberate change and whatever new findings it brings appear in the same diff rather than on somebody else's pull request.

`black`, `mypy` and `pytest` are also unpinned, and CI has drifted to major versions of all three — `black-26.5.1`, `mypy-2.3.1`, `pytest-9.1.1`. They currently pass. Capping them too is a broader decision and is deliberately not made here.

## Verification

Run with CI's own four commands:

- `black --check .` — exit 0
- `ruff check ./pre_commit_hooks_tests/ ./pre_commit_hooks` — exit 0, `All checks passed!`, with ruff **0.16.4**, the version CI installed
- `mypy ./pre_commit_hooks/ ./pre_commit_hooks_tests/` — exit 0. Checked against both the original and the combined `with` form: identical result, so the change introduces no type error. `mypy.ini` sets `python_version = 3.9`.
- The module still imports on Python 3.9 and `main`'s signature resolves.

The two `pytest` failures seen locally are `assert 126 == ...` — the downloaded `cfn-guard` binary is not executable in this sandbox. They reproduce identically on an unmodified `main` and the `pytest` step passes in CI.

Local `black` and `mypy` here are 25.11.0 and 1.19.1; CI resolves newer majors. Only `ruff` was reproduced at CI's exact version, because ruff is the tool that changed behaviour.
