### PR TITLE
fix: authenticate the install scripts' releases-API request

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -65,6 +65,8 @@ jobs:
         with:
           path: cloudformation-guard
       - name: Test install script on ${{ matrix.os }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -e
           cd cloudformation-guard
@@ -79,6 +81,8 @@ jobs:
         with:
           path: cloudformation-guard
       - name: Test install script on windows-latest
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           cd cloudformation-guard
           ./install-guard.ps1

--- a/install-guard.ps1
+++ b/install-guard.ps1
@@ -53,12 +53,26 @@ function Get-ArchType {
 
 function Get-Versions {
   Write-Host "Getting the latest release version online"
-  $latestRelease = Invoke-RestMethod -Uri "https://api.github.com/repos/aws-cloudformation/cloudformation-guard/releases/latest"
+  $requestArgs = Get-GitHubApiAuthArgs
+  $latestRelease = Invoke-RestMethod -Uri "https://api.github.com/repos/aws-cloudformation/cloudformation-guard/releases/latest" @requestArgs
   $tag_name = $latestRelease.tag_name
   $majorVersion = $tag_name.Split('.')[0]
   $version = $tag_name
   Write-Host "Latest release is $version"
   return $majorVersion, $version
+}
+
+function Get-GitHubApiAuthArgs {
+  # The GitHub API rate limits anonymous requests per source IP. CI runners
+  # share their IPs, so that quota is often already spent, and the request
+  # fails. Authenticate when the environment offers a token. With no token
+  # this returns no arguments and the request goes out anonymously, exactly
+  # as it always has.
+  $token = if ($env:GITHUB_TOKEN) { $env:GITHUB_TOKEN } else { $env:GH_TOKEN }
+  if (-not $token) {
+      return @{}
+  }
+  return @{ Headers = @{ Authorization = "Bearer $token" } }
 }
 
 function extract_tar {

--- a/install-guard.ps1
+++ b/install-guard.ps1
@@ -70,8 +70,10 @@ function Get-GitHubApiAuthArgs {
   # as it always has.
   $token = if ($env:GITHUB_TOKEN) { $env:GITHUB_TOKEN } else { $env:GH_TOKEN }
   if (-not $token) {
+      Write-Host "No GITHUB_TOKEN or GH_TOKEN set, so the request is anonymous."
       return @{}
   }
+  Write-Host "Found a token in the environment, so the request is authenticated."
   return @{ Headers = @{ Authorization = "Bearer $token" } }
 }
 

--- a/install-guard.sh
+++ b/install-guard.sh
@@ -118,6 +118,13 @@ download() {
 # host a release asset redirects to.
 download_from_api() {
 	_token="${GITHUB_TOKEN:-${GH_TOKEN:-}}"
+	# Report which path was taken, never the token itself. stderr, because this
+	# function's stdout is the API response and is parsed by the caller.
+	if [ -n "$_token" ]; then
+		echo "Found a token in the environment, so the request is authenticated." >&2
+	else
+		echo "No GITHUB_TOKEN or GH_TOKEN set, so the request is anonymous." >&2
+	fi
 	if check_cmd curl; then
 		if [ -n "$_token" ]; then
 			curl -fsSL -H "Authorization: Bearer $_token" "$1"

--- a/install-guard.sh
+++ b/install-guard.sh
@@ -79,7 +79,7 @@ get_version() {
 }
 
 get_latest_release() {
-	download https://api.github.com/repos/aws-cloudformation/cloudformation-guard/releases/latest |
+	download_from_api https://api.github.com/repos/aws-cloudformation/cloudformation-guard/releases/latest |
 		awk -F '"' '/tag_name/ { print $4 }'
 }
 
@@ -107,6 +107,29 @@ download() {
 		if ! (wget -qO- "$1"); then
 			err "error attempting to download from the github repository"
 		fi
+	fi
+}
+
+# The GitHub API rate limits anonymous requests per source IP. CI runners share
+# their IPs, so that quota is often already spent, and the request fails.
+# Authenticate when the environment offers a token. With no token the request
+# goes out anonymously, exactly as it always has. This is kept separate from
+# download() so the token only ever reaches the API host, never the storage
+# host a release asset redirects to.
+download_from_api() {
+	_token="${GITHUB_TOKEN:-${GH_TOKEN:-}}"
+	if check_cmd curl; then
+		if [ -n "$_token" ]; then
+			curl -fsSL -H "Authorization: Bearer $_token" "$1"
+		else
+			curl -fsSL "$1"
+		fi || err "error attempting to download from the github repository"
+	else
+		if [ -n "$_token" ]; then
+			wget -qO- --header="Authorization: Bearer $_token" "$1"
+		else
+			wget -qO- "$1"
+		fi || err "error attempting to download from the github repository"
 	fi
 }
 


### PR DESCRIPTION
## Problem

`Testing Windows Install Script (install-guard.ps1)` fails on `main` itself, not
just on pull requests. Run
[34151842199](https://github.com/aws-cloudformation/cloudformation-guard/actions/runs/34151842199)
at `814bd00a4e6d761e8b5c9f615dd510b1a2a7c374` has exactly one failing job, this
one, and it fails about 15 seconds in:

```
Invoke-RestMethod: install-guard.ps1:56
{ "message": "API rate limit exceeded for 48.217.34.224. (But here's the good news:
Authenticated requests get a higher rate limit. ...)" }
```

Both install scripts ask the GitHub API for the latest release without
credentials, and the anonymous API is rate limited per source IP. Hosted runners
share those IPs, so the quota is frequently already spent by the time the job
runs and the request returns the rate-limit error instead of a tag name. Nothing
in a pull request can influence this — the scripts install the last published
release and never build the crate — which is why the job fails on `main` too.

## Change

Send an `Authorization: Bearer` header on the releases-API request when
`GITHUB_TOKEN` or `GH_TOKEN` is set, and pass the workflow token into both
install-script steps. The anonymous limit is 60 requests per hour against 5000
for an authenticated one. `permissions: contents: read` already covers reading
releases, so it is unchanged.

`install-guard.sh` had the same unauthenticated call and gets the same fix; the
two jobs are siblings and fixing only one would leave the shell job flaking. The
`.sh` jobs pass today only because they have not yet lost the same coin flip.

Each script also logs which path it took, because a green job is not on its own
evidence that a token was found — the anonymous quota fluctuates, so a job can
pass simply because that runner's IP had budget left. The token value is never
logged, only whether one was present.

## Behavior with no token

Unchanged, and that is deliberate — end users run these scripts outside Actions,
so requiring a token would be a worse regression than the flake. With neither
variable set, `install-guard.ps1` passes no `-Headers` argument at all and
`install-guard.sh` invokes `curl -fsSL <url>`, exactly as today.

In the shell script the header lives on a separate function rather than on
`download()`, which is shared with the release-asset download. That keeps the
token scoped to `api.github.com` and stops it following a redirect to the
storage host that serves release assets.

## Verification

The token is populated on a pull request from a fork, so this is demonstrable
here rather than only on `main`. From this PR's own run, which is
`event=pull_request` with `fork=true`:

```
##[group]GITHUB_TOKEN Permissions
Contents: read
Metadata: read
##[endgroup]
  GITHUB_TOKEN: ***
Getting the latest release version online
Found a token in the environment, so the request is authenticated.
Latest release is 3.2.1
```

The same line appears in the `install-guard.sh` job. `Contents: read` is what the
declared `permissions:` block yields and is sufficient to read public releases.

Also checked:

- `shellcheck install-guard.sh` clean, matching the `shellcheck` job's invocation.
- The request was exercised in every token state with a stubbed `curl`/`wget` to
  capture argv — no token, `GITHUB_TOKEN`, `GH_TOKEN` fallback, empty-string
  tokens — plus the `wget` branch. The release-asset download carries no
  `Authorization` header even when a token is set.
- `Get-Versions` and the header helper ran on PowerShell 7.4.2 across the same
  token states. Against the live API the no-token path reports a 60/hour limit
  and the authenticated path 5000/hour, and both resolve the current release.
- No explicit `User-Agent` is set, and none is needed: the API rejects a request
  with no UA, but `curl`, `wget` and `Invoke-RestMethod` all send one by default,
  so there is nothing latent here. Verified by stripping the header, which does
  produce `Request forbidden by administrative rules`.
- The Windows-only parts of the script (architecture detection, the symlink, the
  `PATH` update) were not run locally; the change does not touch them, and CI
  covers them.
