### PR TITLE
fix(operators): a range inside a list literal is compared, not evaluated, so a denylist admits every value

### DIFF
--- a/guard/src/rules/eval/operators.rs
+++ b/guard/src/rules/eval/operators.rs
@@ -315,7 +315,23 @@ fn contained_in(lhs_value: Rc<PathAwareValue>, rhs_value: Rc<PathAwareValue>) ->
 
         rest => match &*rhs_value {
             PathAwareValue::List((_, rhsl)) => {
-                if rhsl.contains(rest) {
+                // `Vec::contains` decides membership with `PartialEq`, which answers
+                // `element == rest` -- the direction that has no range arm and must not get one,
+                // because `eq` has to stay symmetric while membership does not. So a range nested in
+                // a list literal was never treated as a range: for a `Port` of 85,
+                // `Port in [r[80,90]]` failed and `Port not in [r[80,90]]` passed, which is a
+                // denylist of ranges that admits every value. Unwrapped, `Port in r[80,90]` was
+                // always right, because that spelling reaches `compare_eq` below, and `compare_eq`
+                // is where the range table lives.
+                //
+                // `eq` is still consulted first, and not for belt and braces: it is the only one of
+                // the two that relates a range to an equal range, so asking `compare_eq` alone would
+                // lose `%range_literal in [r[80,90]]`. Everything `eq` decides, it decides the same
+                // way as before; `compare_eq` can only add a match, never remove one.
+                if rhsl
+                    .iter()
+                    .any(|elem| elem == rest || compare_eq(rest, elem).unwrap_or(false))
+                {
                     ValueEvalResult::ComparisonResult(ComparisonResult::Success(Compare::ValueIn(
                         LhsRhsPair::new(Rc::new(rest.clone()), Rc::clone(&rhs_value)),
                     )))

--- a/guard/src/rules/eval_tests.rs
+++ b/guard/src/rules/eval_tests.rs
@@ -7302,50 +7302,56 @@ fn every_operator_and_operand_shape_agrees_with_a_stated_oracle() -> Result<()> 
     Ok(())
 }
 
-#[test]
-fn probe_vacuous_pass_record_shape() -> Result<()> {
-    fn dump(r: &EventRecord<'_>, depth: usize) {
-        let kind = match &r.container {
-            Some(RecordType::FileCheck(n)) => format!("FileCheck {:?}", n.status),
-            Some(RecordType::RuleCheck(n)) => format!("RuleCheck {:?}", n.status),
-            Some(RecordType::GuardClauseBlockCheck(b)) => {
-                format!("GuardClauseBlockCheck {:?}", b.status)
+/// A range inside a list literal is a range.
+///
+/// `contained_in` decided list membership with `Vec::contains`, which compares by `PartialEq`, and
+/// `PartialEq` is asked `element == value` -- the direction that has no range arm, and must not get
+/// one, because `eq` has to stay symmetric while membership does not. So a range nested in a list
+/// literal matched nothing, in either polarity. For a `Port` of 85, `Port in [r[80,90]]` failed and
+/// `Port not in [r[80,90]]` passed: a denylist of port ranges that admits every port.
+///
+/// Unwrapped, the same question was always answered correctly, because `Port in r[80,90]` reaches
+/// `compare_eq`, which is where the range table lives. Both spellings are asserted here, since the
+/// two agreeing is the actual property.
+///
+/// Every cell has its opposite, so a fix that made membership always true, or always false, fails
+/// rather than passing half the table.
+#[rstest::rstest]
+#[case::covering_range_wrapped("in [r[80,90]]", Status::PASS)]
+#[case::covering_range_unwrapped("in r[80,90]", Status::PASS)]
+#[case::covering_range_wrapped_negated("not in [r[80,90]]", Status::FAIL)]
+#[case::covering_range_unwrapped_negated("not in r[80,90]", Status::FAIL)]
+#[case::excluding_range_wrapped("in [r[10,20]]", Status::FAIL)]
+#[case::excluding_range_wrapped_negated("not in [r[10,20]]", Status::PASS)]
+#[case::range_beside_a_matching_value("in [r[10,20], 85]", Status::PASS)]
+#[case::range_beside_a_non_matching_value("in [r[10,20], 99]", Status::FAIL)]
+#[case::two_ranges_one_covering("in [r[10,20], r[80,90]]", Status::PASS)]
+#[case::two_ranges_neither_covering("in [r[10,20], r[30,40]]", Status::FAIL)]
+fn a_range_inside_a_list_literal_is_a_range(
+    #[case] clause: &str,
+    #[case] expected: Status,
+) -> Result<()> {
+    const INPUT: &str = r#"
+    {
+        Resources: {
+            Vol: {
+                Type: 'AWS::EC2::Volume',
+                Properties: { Port: 85 }
             }
-            Some(RecordType::ClauseValueCheck(ClauseCheck::Success)) => {
-                "ClauseValueCheck Success".to_string()
-            }
-            Some(RecordType::ClauseValueCheck(_)) => "ClauseValueCheck other".to_string(),
-            Some(other) => format!("{:?}", std::mem::discriminant(other)),
-            None => "none".to_string(),
-        };
-        println!(
-            "PROBE {}{} children={}",
-            "  ".repeat(depth),
-            kind,
-            r.children.len()
-        );
-        for c in &r.children {
-            dump(c, depth + 1);
         }
     }
-    for (label, data) in [
-        (
-            "empty list  Size: []",
-            r#"{ "Resources": { "V": { "Type": "AWS::EC2::Volume", "Properties": { "Size": [] } } } }"#,
-        ),
-        (
-            "normal pass Size: 50",
-            r#"{ "Resources": { "V": { "Type": "AWS::EC2::Volume", "Properties": { "Size": 50 } } } }"#,
-        ),
-    ] {
-        let rules =
-            "rule r {\n    Resources.*[ Type == 'AWS::EC2::Volume' ].Properties.Size == 50\n}\n";
-        let rules_file = RulesFile::try_from(rules)?;
-        let values = PathAwareValue::try_from(data)?;
-        let mut root = root_scope(&rules_file, Rc::new(values));
-        let status = eval_rules_file(&rules_file, &mut root, None)?;
-        println!("PROBE === {} -> {:?}", label, status);
-        dump(&root.reset_recorder().extract(), 0);
-    }
+    "#;
+
+    // A plain template rather than `format!`, following the convention above: the rule is mostly
+    // braces and the escaping reads worse than the rule it describes.
+    let rules = "rule ranged { Resources.Vol.Properties.Port CLAUSE }".replace("CLAUSE", clause);
+
+    assert_eq!(
+        expected,
+        rule_status_in(&rules, INPUT, "ranged")?,
+        "clause: Port {}",
+        clause
+    );
+
     Ok(())
 }

--- a/guard/src/rules/path_value.rs
+++ b/guard/src/rules/path_value.rs
@@ -330,9 +330,15 @@ impl PartialEq for PathAwareValue {
 ///
 /// Range membership used to be answered here too, which broke symmetry outright:
 /// `Int(50) == RangeInt(5..100)` held while the reverse did not, there being no reverse arm. Those
-/// arms were unreachable and were removed rather than mirrored. Nothing is lost, because every
-/// clause is decided by `compare_eq`, which keeps its own range table and recurses through itself
-/// for lists and maps, so a range nested in a list literal never arrives here either.
+/// arms were removed rather than mirrored, because membership is `compare_eq`'s job and it keeps its
+/// own range table.
+///
+/// A range nested in a list literal does still arrive here, through `Vec::contains` in
+/// `contained_in`, and that is what the removed arms were not reaching: `contains` asks
+/// `element == value`, so it needed the reverse arm, the one that never existed. Membership through a
+/// list was therefore answered `false` for every range, in both polarities, until `contained_in`
+/// started asking `compare_eq` as well. The arms stay out; the caller asks the function that has the
+/// table.
 ///
 /// Numeric widening does stay, reached through `compare_values`. Unlike the other two it is an
 /// equivalence relation on the values it relates, and `Hash` agrees with it.


### PR DESCRIPTION
A range inside a list literal was compared as a value rather than evaluated as a range, so a denylist built that way admitted everything it was meant to exclude.

## Reproducer

```yaml
Resources: { SG: { Properties: { Port: 85 } } }
```

| rule | before | after |
| --- | --- | --- |
| `Port not in [r[80,90]]` — denylist | **exit 0, PASS** | exit 19, FAIL |
| `Port in [r[80,90]]` — allowlist | exit 19, FAIL | exit 0, PASS |
| `Port not in r[80,90]` — unwrapped, control | exit 19, FAIL | exit 19, FAIL |
| `Port not in [r[10,20]]` — outside the range, control | exit 0, PASS | exit 0, PASS |

On `origin/release/3.2.1` the first row prints:

```
tmpl.yaml Status = PASS
PASS rules
deny.guard/port_must_not_be_in_the_reserved_range    PASS
```

The rule is named in the PASS list, so the operator is affirmatively told the denylist held while the forbidden port went through. Both controls hold before and after, so this is not "make everything fail."

## The change

One hunk in `guard/src/rules/eval/operators.rs`: `rhsl.contains(rest)` becomes `rhsl.iter().any(|elem| elem == rest || compare_eq(rest, elem).unwrap_or(false))`. `contains` uses `PartialEq`, which never asks a range whether it covers a value. The `path_value.rs` edit in this commit is doc-comment only.

## Verification

`a_range_inside_a_list_literal_is_a_range`, 10 cases. Reverting only the `operators.rs` hunk fails 3 of 10; the other 7 are the controls and stay green.

## Scope of user impact

This changes a verdict, so a rule that passes today can start failing. Stated once here because it
applies to the whole series and I would rather you decide it once than per PR.

The trigger is always something written in a *user's* own rules file or template. Published packs are
unaffected: across the AWS rules registry — 190 rules-and-tests pairs, 1,956 expectation checks — this
change moves no exit code and no output byte, because every registry rule is gated by `when %var !empty`,
whose verdict does not move.

Worth saying plainly, since it is the obvious thing to reach for: that zero-movement result is **not**
evidence the change is non-breaking. It is evidence it breaks nothing unrelated. The registry contains no
user-authored duplicate rule names, transposed range literals, or non-core-schema scalars, so it cannot
exercise this class at all.
