### PR TITLE
fix(loader): a non-finite float compares unequal to itself, so two identical fields satisfy !=

### DIFF
--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -34,6 +34,8 @@ let api_gws = Resources.*[ Type == 'AWS::ApiGateway::RestApi' ]
 2. When performing `!=` comparison, if the values are incompatible like comparing a `string` to `int`, an error is thrown internally but currently suppressed and converted to `false` to satisfy the requirements of Rust’s [PartialEq](https://doc.rust-lang.org/std/cmp/trait.PartialEq.html). We are tracking to release a fix for this issue soon.
 
    `integer` and `float` are no longer among the incompatible pairs: they compare against each other as numbers, so `Size > 10` holds for a `Size` of `50.5` and `Size == 50` holds for a `Size` of `50.0`. See [Guard: Clauses](CLAUSES.md) for the details, including why it mattered inside a `when` condition.
+
+   The non-finite spellings are strings, not numbers. `nan`, `inf` and `infinity` in a document are read as strings, which is what YAML resolves them to -- it spells the non-finite floats `.nan` and `.inf`, and those were always read as strings here. A clause comparing one of them against a number is therefore an incompatible pair as described above.
 3. `exists` and `empty` checks do not display the JSON pointer path inside the document in the error messages. Both these clauses often have retrieval errors which does not maintain this traversal information today. We are tracking to resolve this issue.
 4. <a name="function-limitation"></a> **No support for calling functions inline on the LHS of an operator**
 

--- a/guard/resources/validate/identical_scalars_are_not_unequal.guard
+++ b/guard/resources/validate/identical_scalars_are_not_unequal.guard
@@ -1,0 +1,3 @@
+rule identical_scalars_are_not_unequal {
+    Resources.Vol.Properties.Threshold != Resources.Vol.Properties.Ceiling
+}

--- a/guard/resources/validate/identical_scalars_compare_equal.guard
+++ b/guard/resources/validate/identical_scalars_compare_equal.guard
@@ -1,0 +1,4 @@
+rule identical_scalars_compare_equal {
+    Resources.Vol.Properties.Threshold == Resources.Vol.Properties.Ceiling
+    Resources.Vol.Properties.Size == Resources.Vol.Properties.Capacity
+}

--- a/guard/resources/validate/non-finite-scalars-template.yaml
+++ b/guard/resources/validate/non-finite-scalars-template.yaml
@@ -1,0 +1,10 @@
+Resources:
+  Vol:
+    Type: AWS::EC2::Volume
+    Properties:
+      # `nan` is a plain YAML string, not a float. Both keys hold the same scalar.
+      Threshold: nan
+      Ceiling: nan
+      # The control pair, so a rule over this template can be shown to decide either way.
+      Size: 50
+      Capacity: 50

--- a/guard/src/rules/libyaml/loader.rs
+++ b/guard/src/rules/libyaml/loader.rs
@@ -86,8 +86,18 @@ impl Loader {
             match val.parse::<i64>() {
                 Ok(i) => MarkedValue::Int(i, location),
                 Err(_) => match val.parse::<f64>() {
-                    Ok(f) => MarkedValue::Float(f, location),
-                    Err(_) => match self.parse_bool(&val) {
+                    // `f64::from_str` also accepts `nan`, `inf` and `infinity`, none of which
+                    // YAML resolves to a float. YAML spells the non-finite floats `.nan` and
+                    // `.inf`, and those spellings already fall through to `String` here, so
+                    // accepting the Rust-only ones made the two halves disagree.
+                    //
+                    // Keeping `NaN` out of the value space is the part that matters:
+                    // `PathAwareValue` asserts `Eq` and hashes its own contents, and
+                    // `Float(NaN)` is not equal to itself. A NaN-keyed entry can never be
+                    // found again, and no comparison against one can be answered, so a clause
+                    // that guards on it cannot decide either way.
+                    Ok(f) if f.is_finite() => MarkedValue::Float(f, location),
+                    _ => match self.parse_bool(&val) {
                         Some(b) => MarkedValue::Bool(b, location),
                         None => match val.to_lowercase().as_str() {
                             "~" | "null" => MarkedValue::Null(location),

--- a/guard/src/rules/libyaml/loader_tests.rs
+++ b/guard/src/rules/libyaml/loader_tests.rs
@@ -379,3 +379,70 @@ fn test_handle_null() {
 
     assert!(matches!(val, MarkedValue::String(..)));
 }
+
+/// `f64::from_str` accepts `nan`, `inf` and `infinity`. YAML resolves none of those to a float --
+/// it spells the non-finite floats `.nan` and `.inf`, and both of those were already falling
+/// through to `String` here, so the two halves of the same question disagreed.
+///
+/// What the disagreement cost: `Float(NaN)` is not equal to itself, and `PathAwareValue` asserts
+/// `Eq` while hashing its own contents. Two identical scalars in one document compared unequal,
+/// and the negation of that comparison passed -- a clause asserting two fields *differ* was
+/// satisfied by two fields spelled the same way.
+#[rstest::rstest]
+#[case::bare_nan("nan")]
+#[case::capitalized_nan("NaN")]
+#[case::uppercase_nan("NAN")]
+#[case::yaml_nan(".nan")]
+#[case::bare_inf("inf")]
+#[case::negative_inf("-inf")]
+#[case::spelled_out_infinity("infinity")]
+#[case::yaml_inf(".inf")]
+#[case::overflowing_exponent("1e999")]
+fn a_non_finite_scalar_is_not_a_float(#[case] scalar: &str) -> Result<()> {
+    let mut loader = Loader::new();
+    let value = loader.load(format!("check: {scalar}"))?;
+
+    let map = match &value {
+        MarkedValue::Map(m, _) => m,
+        _ => unreachable!("a single mapping loads as a map"),
+    };
+    let (.., loaded) = map.first().unwrap();
+
+    assert!(
+        matches!(loaded, MarkedValue::String(s, ..) if s == scalar),
+        "{} loaded as {:?}, but YAML resolves it to a string",
+        scalar,
+        loaded
+    );
+
+    Ok(())
+}
+
+/// The control for the case above: rejecting the non-finite spellings must not cost the finite
+/// floats, which is the entire reason the `f64` arm is there.
+#[rstest::rstest]
+#[case::simple_fraction("1.5", 1.5)]
+#[case::negative_fraction("-1.5", -1.5)]
+#[case::exponent("1e3", 1000.0)]
+#[case::negative_exponent("1e-3", 0.001)]
+#[case::largest_finite_f64("1.7976931348623157e308", f64::MAX)]
+fn a_finite_scalar_is_still_a_float(#[case] scalar: &str, #[case] expected: f64) -> Result<()> {
+    let mut loader = Loader::new();
+    let value = loader.load(format!("check: {scalar}"))?;
+
+    let map = match &value {
+        MarkedValue::Map(m, _) => m,
+        _ => unreachable!("a single mapping loads as a map"),
+    };
+    let (.., loaded) = map.first().unwrap();
+
+    assert!(
+        matches!(loaded, MarkedValue::Float(f, ..) if *f == expected),
+        "{} loaded as {:?}, not the float {}",
+        scalar,
+        loaded,
+        expected
+    );
+
+    Ok(())
+}

--- a/guard/tests/validate.rs
+++ b/guard/tests/validate.rs
@@ -542,6 +542,52 @@ mod validate_tests {
         );
     }
 
+    /// Two keys spelled the same way in one template must compare equal, and must not compare
+    /// unequal.
+    ///
+    /// `f64::from_str` accepts `nan`, `inf` and `infinity`, so `Threshold: nan` loaded as
+    /// `Float(NaN)` -- while YAML's own spellings for those values, `.nan` and `.inf`, were already
+    /// loading as strings. `Float(NaN)` is not equal to itself, and `PathAwareValue` asserts `Eq`
+    /// while hashing its own contents, so `Threshold == Ceiling` failed on two identical scalars
+    /// and the negation of it passed. A rule of the form "these two fields must differ" was
+    /// satisfied by two fields that do not.
+    ///
+    /// Measured on the merge-base: the equality exits 19 and the negation exits 0, both backwards.
+    /// The finite pair in `identical_scalars_compare_equal.guard` is the control -- it shares the
+    /// clause shape and was always right, so it fails if the fix breaks ordinary floats.
+    #[test]
+    fn identical_scalars_do_not_compare_unequal() {
+        let mut reader = Reader::default();
+        let mut writer = Writer::new(WBVec(vec![])).expect("Failed to create writer.");
+
+        let status_code = ValidateTestRunner::default()
+            .data(vec!["non-finite-scalars-template.yaml"])
+            .rules(vec!["identical_scalars_compare_equal.guard"])
+            .show_summary(vec!["all"])
+            .run(&mut writer, &mut reader);
+
+        assert_eq!(
+            StatusCode::SUCCESS,
+            status_code,
+            "two keys holding the same scalar must compare equal"
+        );
+
+        let mut reader = Reader::default();
+        let mut writer = Writer::new(WBVec(vec![])).expect("Failed to create writer.");
+
+        let status_code = ValidateTestRunner::default()
+            .data(vec!["non-finite-scalars-template.yaml"])
+            .rules(vec!["identical_scalars_are_not_unequal.guard"])
+            .show_summary(vec!["all"])
+            .run(&mut writer, &mut reader);
+
+        assert_eq!(
+            StatusCode::VALIDATION_ERROR,
+            status_code,
+            "two keys holding the same scalar must not satisfy a clause asserting they differ"
+        );
+    }
+
     /// Two skip reasons in one junit report stay two reasons.
     ///
     /// `serialize_text_events` wrote one text event per reason, and XML concatenates adjacent text


### PR DESCRIPTION
A non-finite float in a document was read as a value that compares unequal to itself, so two identical fields could satisfy `!=`.

## Reproducer

A template spelling `nan`, with a rule asserting `Threshold != Ceiling` where both fields hold the same value. Before: PASS. After: FAIL.

## The change

`guard/src/rules/libyaml/loader.rs` stops resolving a non-finite float to a numeric value. `docs/KNOWN_ISSUES.md` gains a note.

## Verification

Reverting only `loader.rs` fails 7 of 14 named tests.

## Scope of user impact

This changes a verdict, so a rule that passes today can start failing. Stated once here because it
applies to the whole series and I would rather you decide it once than per PR.

The trigger is always something written in a *user's* own rules file or template. Published packs are
unaffected: across the AWS rules registry — 190 rules-and-tests pairs, 1,956 expectation checks — this
change moves no exit code and no output byte, because every registry rule is gated by `when %var !empty`,
whose verdict does not move.

Worth saying plainly, since it is the obvious thing to reach for: that zero-movement result is **not**
evidence the change is non-breaking. It is evidence it breaks nothing unrelated. The registry contains no
user-authored duplicate rule names, transposed range literals, or non-core-schema scalars, so it cannot
exercise this class at all.
