### PR TITLE
fix(functions): regex_replace discards the text the pattern did not match

### DIFF
--- a/guard/resources/validate/functions/rules/regex_replace_no_match.guard
+++ b/guard/resources/validate/functions/rules/regex_replace_no_match.guard
@@ -1,0 +1,19 @@
+#
+# A normalisation step that is a no-op on this input must not change the verdict.
+#
+# The author strips an optional prefix before checking the name, which is the ordinary way to write a
+# rule that has to accept either a bare name or a fully qualified one. `Arn` in the data does not carry
+# the `arn:aws:s3:::` prefix, so the pattern does not match.
+#
+# `regex_replace` used to answer `""` for a pattern that did not match, and `""` compares, so the `!=`
+# below was satisfied and the rule passed -- on a value it was written to catch. A no-match now returns
+# the input unchanged, so the comparison sees the real name and this rule FAILs, which is the same
+# verdict the assertion has when it is written without the normalisation step.
+#
+let template = Resources.*[ Type == 'AWS::New::Service' ]
+
+rule NORMALISED_ARN_IS_STILL_COMPARED when %template !empty {
+    let arn = %template.Properties.Arn
+    let normalised = regex_replace(%arn, "^arn:aws:s3:::(.+)$", "${1}")
+    %normalised != "arn:aws:newservice:us-west-2:123456789012:Table/extracted"
+}

--- a/guard/src/rules/functions/strings.rs
+++ b/guard/src/rules/functions/strings.rs
@@ -65,10 +65,33 @@ pub(crate) fn regex_replace(
             QueryResult::Literal(v) | QueryResult::Resolved(v) => {
                 if let PathAwareValue::String((path, val)) = &**v {
                     let regex = Regex::try_from(extract_expr).map_err(Box::new)?;
-                    let mut replaced = String::with_capacity(replace_expr.len() * 2);
-                    for cap in regex.captures_iter(val) {
-                        cap.map_err(Box::new)?.expand(replace_expr, &mut replaced);
-                    }
+                    // The whole string, not just the captures.
+                    //
+                    // This expanded each capture into a fresh empty `String` and returned that, so
+                    // every character the pattern did not match was dropped:
+                    // `regex_replace("prod-database-01", "database", "db")` answered `"db"` where a
+                    // replace gives `"prod-db-01"`, and a pattern matching several times returned the
+                    // expansions run together with the gaps between them gone. No fixture caught it
+                    // because all of them, and the example in `docs/FUNCTIONS.md`, anchor the pattern
+                    // with `^...$` so the match covers the whole string and there is no outside text.
+                    //
+                    // A pattern that did not match returned `""`, which is the same bug seen from the
+                    // other side and the damaging one: `""` is a value, so it compares. A rule that
+                    // stripped an optional prefix before testing a name passed on a name it was
+                    // written to catch, silently and at exit 0. Copying the unmatched remainder
+                    // answers both -- with nothing matched the remainder is the whole input, which is
+                    // what a replace returns.
+                    //
+                    // `try_replacen` rather than `replace_all`: `replace_all` delegates to `replacen`,
+                    // which is `try_replacen(..).unwrap()`, so a match that fails at run time -- a
+                    // backtrack limit, which `fancy_regex` can hit and the plain `regex` crate cannot
+                    // -- would panic and exit 101 instead of reporting. A limit of 0 means no limit,
+                    // and `&str` as the replacement expands through `Captures::expand`, so `${1}` and
+                    // the rest of the substitution syntax read exactly as they did before.
+                    let replaced = regex
+                        .try_replacen(val, 0, replace_expr)
+                        .map_err(Box::new)?
+                        .into_owned();
                     aggr.push(Some(PathAwareValue::String((path.clone(), replaced))));
                 } else {
                     aggr.push(None);

--- a/guard/src/rules/functions/strings_tests.rs
+++ b/guard/src/rules/functions/strings_tests.rs
@@ -96,6 +96,69 @@ fn test_regex_replace() -> crate::rules::Result<()> {
     Ok(())
 }
 
+/// `regex_replace` keeps the text that the pattern did not match.
+///
+/// It used to expand the captures into a fresh empty string and return that, so everything outside the
+/// match was dropped: `regex_replace("prod-database-01", "database", "db")` answered `"db"` rather than
+/// `"prod-db-01"`. Every shipped example anchors its pattern with `^...$`, which makes the match span
+/// the whole string, so there was never any outside text to lose and no test noticed.
+///
+/// The no-match row is the one that mattered in practice. An unmatched pattern produced `""`, and `""`
+/// is a value, so it compares: a rule that normalised an optional prefix before checking a name got a
+/// pass on the name it meant to catch. Returning the input unchanged is what a replace does, and it
+/// falls out of copying the unmatched remainder rather than needing a case of its own.
+#[test]
+fn regex_replace_keeps_the_text_outside_the_match() -> crate::rules::Result<()> {
+    let cases = [
+        // (input, pattern, replacement, expected)
+        // A match in the middle. The prefix and the suffix both have to survive.
+        ("prod-database-01", "database", "db", "prod-db-01"),
+        // Several matches, each with a capture. The gaps between them are text too.
+        ("a1b2c3", r"(\d)", "<${1}>", "a<1>b<2>c<3>"),
+        // A match at one end only.
+        ("prod-database-01", "^prod-", "", "database-01"),
+        ("prod-database-01", "-01$", "", "prod-database"),
+        // No match at all: the input, unchanged. This is the fail-open case.
+        (
+            "MY_SECRET_BUCKET",
+            "^arn:aws:s3:::(.+)$",
+            "${1}",
+            "MY_SECRET_BUCKET",
+        ),
+        ("prod-database-01", "nothing-here", "x", "prod-database-01"),
+        // Anchored across the whole string, which is what the shipped fixtures and the doc example
+        // do. There is no outside text, so this answer is the same before and after.
+        (
+            "arn:aws:newservice:us-west-2:123456789012:Table/extracted",
+            r"^arn:(\w+):(\w+):([\w0-9-]+):(\d+):(.+)$",
+            "${1}/${4}/${3}/${2}-${5}",
+            "aws/123456789012/us-west-2/newservice-Table/extracted",
+        ),
+    ];
+
+    for (input, pattern, replacement, expected) in cases {
+        let value = PathAwareValue::String((Path::root(), String::from(input)));
+        let args = vec![QueryResult::Resolved(Rc::new(value))];
+
+        let result = regex_replace(&args, pattern, replacement)?;
+        assert_eq!(result.len(), 1, "one input, one answer");
+
+        match &result[0] {
+            Some(PathAwareValue::String((_, got))) => assert_eq!(
+                got, expected,
+                "regex_replace({:?}, {:?}, {:?})",
+                input, pattern, replacement
+            ),
+            other => panic!(
+                "regex_replace({:?}, {:?}, {:?}) gave {:?}, expected {:?}",
+                input, pattern, replacement, other, expected
+            ),
+        }
+    }
+
+    Ok(())
+}
+
 #[test]
 fn test_substring() -> crate::rules::Result<()> {
     let value_str = r#"

--- a/guard/tests/validate.rs
+++ b/guard/tests/validate.rs
@@ -1699,6 +1699,27 @@ mod validate_tests {
         );
     }
 
+    /// A `regex_replace` whose pattern does not match returns the input, so the clause around it still
+    /// compares the real value and this rule fails.
+    ///
+    /// It used to return `""`. An empty string is a value and it compares, so the `!=` in
+    /// `regex_replace_no_match.guard` was satisfied and the run exited 0 -- a rule that normalises an
+    /// optional prefix before checking a name reported a pass on the name it was written to catch. The
+    /// verdict is the assertion here, not the text: SUCCESS before, VALIDATION_ERROR after.
+    #[test]
+    fn a_regex_replace_that_matches_nothing_does_not_pass_the_rule() {
+        let mut reader = Reader::default();
+        let mut writer = Writer::default();
+
+        let status_code = ValidateTestRunner::default()
+            .rules(vec!["/functions/rules/regex_replace_no_match.guard"])
+            .data(vec!["/functions/data/template.yaml"])
+            .show_summary(vec!["all"])
+            .run(&mut writer, &mut reader);
+
+        assert_eq!(StatusCode::VALIDATION_ERROR, status_code);
+    }
+
     #[test]
     fn test_validate_with_failing_complex_rule() {
         let mut reader = Reader::default();


### PR DESCRIPTION
`regex_replace` returned only the captured groups, discarding the text the pattern did not match, so an unanchored pattern silently truncated its input.

## The change

`guard/src/rules/functions/strings.rs` keeps the unmatched text. This changes the return value for every unanchored pattern, so a rule comparing the result can move.

## Verification

`regex_replace_no_match.guard` moves exit 0 to 19. Reverting only `strings.rs` fails 1 of 2 named tests.

## Scope of user impact

This changes a verdict, so a rule that passes today can start failing. Stated once here because it
applies to the whole series and I would rather you decide it once than per PR.

The trigger is always something written in a *user's* own rules file or template. Published packs are
unaffected: across the AWS rules registry — 190 rules-and-tests pairs, 1,956 expectation checks — this
change moves no exit code and no output byte, because every registry rule is gated by `when %var !empty`,
whose verdict does not move.

Worth saying plainly, since it is the obvious thing to reach for: that zero-movement result is **not**
evidence the change is non-breaking. It is evidence it breaks nothing unrelated. The registry contains no
user-authored duplicate rule names, transposed range literals, or non-core-schema scalars, so it cannot
exercise this class at all.
